### PR TITLE
Revert auto color detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,21 +477,6 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
-source = "git+https://github.com/nornagon/crossterm?rev=87db8bfa6dc99427fd3b071681b07fc31c6ce995#87db8bfa6dc99427fd3b071681b07fc31c6ce995"
-dependencies = [
- "bitflags 2.10.0",
- "crossterm_winapi",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -505,7 +490,7 @@ dependencies = [
  "libc",
  "mio",
  "parking_lot",
- "rustix 1.1.3",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -822,7 +807,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "color-eyre",
- "crossterm 0.28.1",
+ "crossterm",
  "flash",
  "futures",
  "glob",
@@ -1234,12 +1219,6 @@ checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
 dependencies = [
  "bitflags 2.10.0",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1852,7 +1831,7 @@ name = "ratatui-crossterm"
 version = "0.1.0-beta.0"
 source = "git+https://github.com/Marlinski/ratatui.git?rev=fd8e0f024847af467129e0a166390d7e291c1b2e#fd8e0f024847af467129e0a166390d7e291c1b2e"
 dependencies = [
- "crossterm 0.29.0",
+ "crossterm",
  "instability",
  "ratatui-core 0.1.0-beta.0",
 ]
@@ -1864,7 +1843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
 dependencies = [
  "cfg-if",
- "crossterm 0.29.0",
+ "crossterm",
  "instability",
  "ratatui-core 0.1.0",
 ]
@@ -2054,19 +2033,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.10.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -2074,7 +2040,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -2260,7 +2226,7 @@ dependencies = [
  "assert_enum_variants",
  "clap_complete_nushell",
  "color-eyre",
- "crossterm 0.29.0",
+ "crossterm",
  "derive_builder",
  "derive_more",
  "frizbee",
@@ -2377,7 +2343,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -2951,7 +2917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix 1.1.3",
+ "rustix",
  "winsafe",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,7 @@ crate-type = ["cdylib"]
 clap = { version = "4.5.49", features = ["derive"] }
 clap_complete = "4.5.66"
 ratatui = { git = "https://github.com/Marlinski/ratatui.git", rev = "fd8e0f024847af467129e0a166390d7e291c1b2e", features = ["default"] }
-# Fork of crossterm that adds query_background_color() / query_foreground_color() (OSC 10/11).
-# Track upstream PR: https://github.com/crossterm-rs/crossterm/compare/master...nornagon:crossterm:nornagon/color-query
-crossterm = { git = "https://github.com/nornagon/crossterm", rev = "87db8bfa6dc99427fd3b071681b07fc31c6ce995" }
+crossterm ="0.29.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3.31"
 log = "0.4"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,9 +12,9 @@ use crate::dparser::{AnnotatedToken, ToInclusiveRange};
 use crate::history::{HistoryEntry, HistoryEntryFormatted, HistoryManager};
 use crate::iter_first_last::FirstLast;
 use crate::mouse_state::MouseState;
-use crate::palette::{DefaultMode, Palette};
+use crate::palette::Palette;
 use crate::prompt_manager::PromptManager;
-use crate::settings::{self, ColorTheme, MouseMode, Settings};
+use crate::settings::{self, MouseMode, Settings};
 use crate::text_buffer::{SubString, TextBuffer};
 use crate::{bash_funcs, dparser};
 use crate::{bash_symbols, command_acceptance};
@@ -63,45 +63,6 @@ fn set_panic_hook() {
     }));
 }
 
-/// Standard sRGB luminance coefficients (ITU-R BT.709).
-const SRGB_RED_COEFF: f32 = 0.2126;
-const SRGB_GREEN_COEFF: f32 = 0.7152;
-const SRGB_BLUE_COEFF: f32 = 0.0722;
-/// Backgrounds with perceived luminance above this threshold are treated as light.
-const LUMINANCE_LIGHT_THRESHOLD: f32 = 0.5;
-
-/// Query the terminal background colour and decide whether to use the dark or
-/// light palette preset.  Falls back to `Dark` if the query fails or the
-/// terminal does not respond.
-fn detect_background_mode() -> DefaultMode {
-    match crossterm::style::query_background_color() {
-        Ok(Some(crossterm::style::Color::Rgb { r, g, b })) => {
-            // Perceived luminance using the standard sRGB coefficients.
-            let luminance = SRGB_RED_COEFF * (r as f32 / 255.0)
-                + SRGB_GREEN_COEFF * (g as f32 / 255.0)
-                + SRGB_BLUE_COEFF * (b as f32 / 255.0);
-            if luminance > LUMINANCE_LIGHT_THRESHOLD {
-                log::debug!("Background RGB({r},{g},{b}) luminance={luminance:.3} → light mode");
-                DefaultMode::Light
-            } else {
-                log::debug!("Background RGB({r},{g},{b}) luminance={luminance:.3} → dark mode");
-                DefaultMode::Dark
-            }
-        }
-        Ok(color) => {
-            log::debug!(
-                "Background color {:?} not an RGB value, defaulting to dark mode",
-                color
-            );
-            DefaultMode::Dark
-        }
-        Err(e) => {
-            log::debug!("Could not query background color: {e}, defaulting to dark mode");
-            DefaultMode::Dark
-        }
-    }
-}
-
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum ExitState {
     WithCommand(String),
@@ -132,15 +93,6 @@ pub fn get_command(settings: &mut Settings) -> ExitState {
     let mut stdout = std::io::stdout();
     std::io::Write::flush(&mut stdout).unwrap();
     crossterm::terminal::enable_raw_mode().unwrap();
-
-    // Resolve the colour palette before starting the TUI. When the theme is
-    // `Auto`, query the terminal background colour and apply the appropriate
-    // preset defaults; user-specified overrides inside the palette are preserved.
-    if settings.color_theme == ColorTheme::Auto {
-        let mode = detect_background_mode();
-        settings.color_palette.apply_theme(mode);
-        log::info!("Auto theme resolved to {:?}", mode);
-    }
 
     let backend = ratatui::backend::CrosstermBackend::new(std::io::stdout());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,17 +126,6 @@ struct FlylineArgs {
     command: Option<Commands>,
 }
 
-#[derive(ValueEnum, Clone, Debug)]
-enum ColorDefault {
-    /// Dark-terminal colour preset (the original flyline palette).
-    Dark,
-    /// Light-terminal colour preset.
-    Light,
-    /// Automatically detect dark or light mode by querying the terminal background
-    /// colour at startup.
-    Auto,
-}
-
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// Configure AI agent mode.
@@ -215,7 +204,7 @@ enum Commands {
         /// Apply a built-in colour preset for dark or light terminals, or `auto` to detect
         /// the terminal background colour at startup and choose automatically.
         #[arg(long = "default-theme", value_name = "MODE")]
-        default_theme: Option<ColorDefault>,
+        default_theme: Option<settings::ColorTheme>,
         /// Style for recognised (valid) commands (e.g. "green").
         #[arg(long = "recognised-command", value_name = "STYLE")]
         recognised_command: Option<String>,
@@ -546,21 +535,7 @@ impl Flyline {
                         markdown_code,
                     }) => {
                         if let Some(preset) = default_theme {
-                            self.settings.color_theme = match preset {
-                                ColorDefault::Dark => settings::ColorTheme::Dark,
-                                ColorDefault::Light => settings::ColorTheme::Light,
-                                ColorDefault::Auto => settings::ColorTheme::Auto,
-                            };
-                            // Apply the theme defaults immediately (leaving overrides intact)
-                            // unless the theme is Auto (resolved at app startup).
-                            if self.settings.color_theme != settings::ColorTheme::Auto {
-                                let mode = match self.settings.color_theme {
-                                    settings::ColorTheme::Dark => palette::DefaultMode::Dark,
-                                    settings::ColorTheme::Light => palette::DefaultMode::Light,
-                                    settings::ColorTheme::Auto => unreachable!(),
-                                };
-                                self.settings.color_palette.apply_theme(mode);
-                            }
+                            self.settings.color_palette.apply_theme(preset);
                             log::info!("Color theme set to {:?}", self.settings.color_theme);
                         }
 

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -2,6 +2,8 @@ use itertools::Itertools;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
+use crate::settings::ColorTheme;
+
 /// Parse a rich-style string (e.g. `"bold red"`) into a `ratatui::style::Style`.
 /// Returns an error message if the string cannot be parsed.
 pub fn parse_str_to_style(s: &str) -> Result<ratatui::style::Style, String> {
@@ -46,14 +48,6 @@ fn parse_color_to_ratatui(c: parse_style::Color) -> ratatui::style::Color {
     }
 }
 
-/// Which built-in colour preset is active.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum DefaultMode {
-    #[default]
-    Dark,
-    Light,
-}
-
 /// The colour palette. Holds theme-default styles and per-field user overrides.
 ///
 /// Each style is stored as a default (`field: Style`, from the active theme preset)
@@ -66,9 +60,6 @@ pub enum DefaultMode {
 /// user override.
 #[derive(Debug, Clone)]
 pub struct Palette {
-    /// Which built-in preset is active.
-    pub default_mode: DefaultMode,
-
     recognised_command: Style,
     pub recognised_command_override: Option<Style>,
 
@@ -199,7 +190,6 @@ impl Palette {
     /// Dark-terminal defaults (the original flyline palette).
     pub fn dark() -> Self {
         Palette {
-            default_mode: DefaultMode::Dark,
             recognised_command: Style::default().fg(Color::Green),
             recognised_command_override: None,
             unrecognised_command: Style::default().fg(Color::Red),
@@ -253,7 +243,6 @@ impl Palette {
     /// Light-terminal defaults.
     pub fn light() -> Self {
         Palette {
-            default_mode: DefaultMode::Light,
             recognised_command: Style::default().fg(Color::DarkGray),
             recognised_command_override: None,
             unrecognised_command: Style::default().fg(Color::Red),
@@ -306,12 +295,11 @@ impl Palette {
 
     /// Apply a new theme preset to the default style values, leaving any
     /// user-specified overrides intact.
-    pub fn apply_theme(&mut self, mode: DefaultMode) {
+    pub fn apply_theme(&mut self, mode: ColorTheme) {
         let template = match mode {
-            DefaultMode::Dark => Self::dark(),
-            DefaultMode::Light => Self::light(),
+            ColorTheme::Dark => Self::dark(),
+            ColorTheme::Light => Self::light(),
         };
-        self.default_mode = template.default_mode;
         self.recognised_command = template.recognised_command;
         self.unrecognised_command = template.unrecognised_command;
         self.single_quoted_text = template.single_quoted_text;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,18 +2,16 @@ use std::collections::HashMap;
 
 use crate::app::actions;
 use crate::palette::Palette;
+use clap::ValueEnum;
 
 /// Which theme the user has configured for the colour palette.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
 pub enum ColorTheme {
     /// Dark-terminal preset (the original flyline palette). This is the default.
     #[default]
     Dark,
     /// Light-terminal preset.
     Light,
-    /// Automatically detect dark or light mode by querying the terminal background
-    /// colour at startup.
-    Auto,
 }
 
 /// A single custom prompt animation registered with `flyline create-anim`.
@@ -87,7 +85,7 @@ pub struct Settings {
     pub send_shell_integration_codes: bool,
     /// Configurable colour palette for UI elements.
     pub color_palette: Palette,
-    /// Which colour theme the user has selected (dark, light, or auto).
+    /// Which colour theme the user has selected (dark or light).
     pub color_theme: ColorTheme,
     /// User defined keybindings
     pub keybindings: Vec<actions::Binding>,


### PR DESCRIPTION
I was experiencing some problems using this branch of crossterm.
Stdin was being emptied at start of app.
So if you type, sleep 1, enter, asdf, the asdf was forgotten about.

What was strange is that I tried using the 36d95b26a26e64b0f8c12edfe11f410a6d56a812 commit from the crossterm repo by specifying it in my cargo.toml and I was still getting the problem. This commit is meant to be the same code as the 0.29.0 version from crates.io so it was odd to see differences in behaviour.

 https://github.com/nornagon/crossterm/compare/36d95b26a26e64b0f8c12edfe11f410a6d56a812...87db8bfa6dc99427fd3b071681b07fc31c6ce995

When https://github.com/crossterm-rs/crossterm/issues/1037 is merged and stable, I will use it.