### PR TITLE
Fix bracket coloring for flow control keywords

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1218,14 +1218,10 @@ impl<'a> App<'a> {
             match handle.receiver.try_recv() {
                 Ok(Some((builder, elapsed))) => {
                     // Take ownership of wuc_substring from the waiting state.
-                    let wuc =
-                        match std::mem::replace(&mut self.content_mode, ContentMode::Normal) {
-                            ContentMode::TabCompletionWaiting {
-                                wuc_substring,
-                                ..
-                            } => wuc_substring,
-                            _ => unreachable!(),
-                        };
+                    let wuc = match std::mem::replace(&mut self.content_mode, ContentMode::Normal) {
+                        ContentMode::TabCompletionWaiting { wuc_substring, .. } => wuc_substring,
+                        _ => unreachable!(),
+                    };
                     self.finish_tab_complete(builder, wuc, elapsed);
                     self.on_possible_buffer_change();
                     return true;

--- a/src/app/tab_completion.rs
+++ b/src/app/tab_completion.rs
@@ -1006,7 +1006,8 @@ impl App<'_> {
 
         let wuc_substring = completion_context.word_under_cursor.clone();
 
-        let (tx, rx) = std::sync::mpsc::channel::<Option<(ActiveSuggestionsBuilder, std::time::Duration)>>();
+        let (tx, rx) =
+            std::sync::mpsc::channel::<Option<(ActiveSuggestionsBuilder, std::time::Duration)>>();
 
         let completion_context_owned = completion_context.into_owned();
 

--- a/src/dparser.rs
+++ b/src/dparser.rs
@@ -480,7 +480,19 @@ impl DParser {
                 {
                     let depth = nestings.len();
                     self.tokens[idx].annotations.opening = Some(OpeningState::Unmatched);
-                    self.tokens[idx].annotations.bracket_depth = Some(depth);
+
+                    if matches!(
+                        token.kind,
+                        TokenKind::If
+                            | TokenKind::Case
+                            | TokenKind::For
+                            | TokenKind::While
+                            | TokenKind::Until
+                    ) {
+                        // Do not color keywords like bracket tokens
+                    } else {
+                        self.tokens[idx].annotations.bracket_depth = Some(depth);
+                    }
 
                     if self.current_command_range.is_none() {
                         self.current_command_range = Some(idx..=idx);
@@ -515,7 +527,15 @@ impl DParser {
                         opening_idx,
                         is_auto_inserted: false,
                     });
-                    self.tokens[idx].annotations.bracket_depth = Some(depth);
+
+                    if matches!(
+                        token.kind,
+                        TokenKind::Fi | TokenKind::Done | TokenKind::Esac
+                    ) {
+                        // Do not color keywords like bracket tokens
+                    } else {
+                        self.tokens[idx].annotations.bracket_depth = Some(depth);
+                    }
 
                     let current_command_range_contains_cursor =
                         cursor_byte_pos.is_some_and(|pos| {
@@ -2423,6 +2443,25 @@ mod tests {
         parser.walk_to_end();
         for token in parser.tokens() {
             assert_eq!(token.annotations.bracket_depth, None);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_keyword_bracket_color {
+    use super::*;
+
+    #[test]
+    fn test_keywords_have_no_bracket_depth() {
+        let mut parser = DParser::from("if true; then echo hi; while true; do echo; done; fi");
+        parser.walk_to_end();
+        for token in parser.tokens() {
+            if matches!(
+                token.token.kind,
+                TokenKind::If | TokenKind::Fi | TokenKind::While | TokenKind::Done
+            ) {
+                assert_eq!(token.annotations.bracket_depth, None);
+            }
         }
     }
 }


### PR DESCRIPTION
Exclude flow control keywords like `if`, `while`, `until`, `for`, `case` and their closing counterparts `fi`, `done`, `esac` from being assigned a bracket depth, which means they won't get rainbow coloring that is intended for real brackets.

---
*PR created automatically by Jules for task [1692456607942179532](https://jules.google.com/task/1692456607942179532) started by @HalFrgrd*