### PR TITLE
fix: cache and dynamically update LS_COLORS for file styling

### DIFF
--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -1283,8 +1283,35 @@ impl ExecutablesOnPath {
 static EXECUTABLES_ON_PATH: LazyLock<Mutex<ExecutablesOnPath>> =
     LazyLock::new(|| Mutex::new(ExecutablesOnPath::new()));
 
-pub(crate) static LS_COLORS: LazyLock<Option<LsColors>> =
-    LazyLock::new(|| get_envvar_value("LS_COLORS").map(|s| LsColors::from_string(&s)));
+pub(crate) struct LsColorsCache {
+    raw_string: Option<String>,
+    parsed: Option<LsColors>,
+}
+
+impl LsColorsCache {
+    fn new() -> Self {
+        Self {
+            raw_string: None,
+            parsed: None,
+        }
+    }
+
+    fn get(&mut self) -> Option<&LsColors> {
+        let current_raw = get_envvar_value("LS_COLORS");
+        if self.raw_string != current_raw {
+            self.raw_string = current_raw.clone();
+            self.parsed = current_raw.map(|s| LsColors::from_string(&s));
+        }
+        self.parsed.as_ref()
+    }
+}
+
+pub(crate) static LS_COLORS: LazyLock<Mutex<LsColorsCache>> =
+    LazyLock::new(|| Mutex::new(LsColorsCache::new()));
+
+pub(crate) fn style_for_path(path: &Path) -> Option<lscolors::Style> {
+    LS_COLORS.lock().unwrap().get().and_then(|ls| ls.style_for_path(path).cloned())
+}
 
 /// Get all potential first word completions (aliases, reserved words, functions, builtins, executables)
 #[cfg(not(test))]

--- a/src/content_utils.rs
+++ b/src/content_utils.rs
@@ -749,8 +749,8 @@ pub fn fuzzy_indices_with_threshold(
 }
 
 pub fn style_for_path(path: &Path) -> Option<Style> {
-    let lscolors_style = bash_funcs::LS_COLORS.as_ref()?.style_for_path(path)?;
-    Some(lscolors_style_to_ratatui(lscolors_style))
+    let lscolors_style = bash_funcs::style_for_path(path)?;
+    Some(lscolors_style_to_ratatui(&lscolors_style))
 }
 
 /// Convert an `lscolors::Color` to a `ratatui::style::Color`.


### PR DESCRIPTION
The LS_COLORS environment variable was previously loaded with a `LazyLock<Option<LsColors>>` meaning if the environment variable provider populated it after it was first evaluated, the colorings wouldn't show up. This patch converts it to a dynamic cache that tracks the raw string of the environment variable.

---
*PR created automatically by Jules for task [16920253790482354644](https://jules.google.com/task/16920253790482354644) started by @HalFrgrd*