### PR TITLE
feat: add hostname tab completions

### DIFF
--- a/src/app/tab_completion.rs
+++ b/src/app/tab_completion.rs
@@ -373,6 +373,24 @@ fn gen_completions_uncomitted(
                     );
                 }
             }
+            CompType::HostnameExpansion => {
+                log::debug!(
+                    "CompType::HostnameExpansion for {}",
+                    word_under_cursor.as_ref()
+                );
+                let completions = tab_complete_hostname_expansion(word_under_cursor.as_ref());
+                log::debug!(
+                    "CompType::HostnameExpansion found {} completions for pattern: {}",
+                    completions.len(),
+                    word_under_cursor.as_ref()
+                );
+                if !completions.is_empty() {
+                    return Some(
+                        ActiveSuggestionsBuilder::from_processed(completions)
+                            .with_comp_type(comp_type.clone()),
+                    );
+                }
+            }
             CompType::TildeExpansion => {
                 log::debug!(
                     "CompType::TildeExpansion for {}",
@@ -868,6 +886,33 @@ fn fuzzy_glob_recursive(
     out
 }
 
+fn tab_complete_hostname_expansion(pattern: &str) -> Vec<ProcessedSuggestion> {
+    let at_idx = if let Some(idx) = pattern.rfind('@') {
+        idx
+    } else {
+        return vec![];
+    };
+
+    let user_pattern = &pattern[at_idx + 1..];
+    let prefix = &pattern[..=at_idx];
+
+    let mut suggestions = Vec::new();
+
+    for hostname in crate::hostnames::get_all_hostnames() {
+        if hostname.starts_with(user_pattern) {
+            suggestions.push(ProcessedSuggestion::new(
+                format!("{}{}", prefix, hostname),
+                "",
+                "",
+            ));
+        }
+    }
+
+    suggestions.sort_by(|a, b| a.s.cmp(&b.s));
+    suggestions.dedup_by(|a, b| a.s == b.s);
+    suggestions
+}
+
 fn tab_complete_tilde_expansion(pattern: &str) -> Vec<ProcessedSuggestion> {
     let user_pattern = if let Some(stripped) = pattern.strip_prefix('~') {
         stripped
@@ -1208,6 +1253,13 @@ mod tab_completion_tests {
 
     rusty_fork_test! {
         // ------- dummy git completion (clap-based, no bash symbols) -------
+
+        #[test]
+        fn hostname_completion() {
+            let actual = run_completion("ssh us@localho");
+            let names: Vec<&str> = actual.iter().map(|s| s.s.as_str()).collect();
+            assert_eq!(names, vec!["us@localhost"]);
+        }
 
         #[test]
         fn git_top_level_subcommand_a_completes_to_add() {

--- a/src/hostnames.rs
+++ b/src/hostnames.rs
@@ -1,0 +1,86 @@
+use std::sync::LazyLock;
+
+static ALL_HOSTNAMES: LazyLock<Vec<String>> = LazyLock::new(|| {
+    let mut hostnames: Vec<String> = Vec::new();
+    let mut seen_hostnames: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    let mut add_hostname = |hostname: String| {
+        if !hostname.is_empty() && seen_hostnames.insert(hostname.clone()) {
+            hostnames.push(hostname);
+        }
+    };
+
+    if cfg!(test) {
+        add_hostname("localhost".to_string());
+        add_hostname("server1.example.com".to_string());
+        add_hostname("web-prod-01".to_string());
+        return hostnames;
+    }
+
+    // Parse /etc/hosts
+    if let Ok(contents) = std::fs::read_to_string("/etc/hosts") {
+        for line in contents.lines() {
+            let line = line.split('#').next().unwrap_or("").trim();
+            if line.is_empty() {
+                continue;
+            }
+            let mut fields = line.split_whitespace();
+            // Skip the IP address
+            fields.next();
+            for hostname in fields {
+                add_hostname(hostname.to_string());
+            }
+        }
+    }
+
+    // Parse ~/.ssh/config
+    let ssh_config_path = std::env::var("HOME")
+        .map(|home| format!("{}/.ssh/config", home))
+        .unwrap_or_default();
+    if !ssh_config_path.is_empty() {
+        if let Ok(contents) = std::fs::read_to_string(ssh_config_path) {
+            for line in contents.lines() {
+                let line = line.trim();
+                if line.starts_with("Host ") {
+                    let mut fields = line.split_whitespace();
+                    fields.next(); // Skip "Host"
+                    for hostname in fields {
+                        if hostname != "*" && !hostname.contains('?') && !hostname.contains('*') {
+                            add_hostname(hostname.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Parse ~/.ssh/known_hosts
+    let known_hosts_path = std::env::var("HOME")
+        .map(|home| format!("{}/.ssh/known_hosts", home))
+        .unwrap_or_default();
+    if !known_hosts_path.is_empty() {
+        if let Ok(contents) = std::fs::read_to_string(known_hosts_path) {
+            for line in contents.lines() {
+                let line = line.trim();
+                if line.is_empty() || line.starts_with('#') {
+                    continue;
+                }
+                let mut fields = line.split_whitespace();
+                if let Some(host_field) = fields.next() {
+                    for hostname in host_field.split(',') {
+                        if !hostname.is_empty() && !hostname.starts_with('|') { // skip hashed hosts
+                            add_hostname(hostname.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    hostnames.sort();
+    hostnames
+});
+
+pub fn get_all_hostnames() -> &'static [String] {
+    &ALL_HOSTNAMES
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ mod shell_integration;
 mod snake_animation;
 mod stateful_sliding_window;
 mod tab_completion_context;
+pub mod hostnames;
 mod table;
 mod text_buffer;
 mod tutorial;

--- a/src/tab_completion_context.rs
+++ b/src/tab_completion_context.rs
@@ -25,6 +25,7 @@ pub enum CompType {
     },
     EnvVariable,            // the env variable under the cursor, with the leading $
     TildeExpansion,         // the tilde under the cursor, e.g. "~us|erna"
+    HostnameExpansion,      // the hostname under the cursor, e.g. "user@ho|st"
     GlobExpansion,          // the glob pattern under the cursor, e.g. "*.rs|t"
     FilenameExpansion,      // the filename under the cursor, e.g. "fi|le.txt"
     FuzzyFilenameExpansion, // fuzzy-match files in the parent directory when FilenameExpansion finds nothing
@@ -44,6 +45,7 @@ impl CompType {
             CompType::FuzzyCommandComp { .. } => "FuzzyCommandComp",
             CompType::EnvVariable => "EnvVariable",
             CompType::TildeExpansion => "TildeExpansion",
+            CompType::HostnameExpansion => "HostnameExpansion",
             CompType::GlobExpansion => "GlobExpansion",
             CompType::FilenameExpansion => "FilenameExpansion",
             CompType::FuzzyFilenameExpansion => "FuzzyFilenameExpansion",
@@ -149,6 +151,8 @@ impl<'a> CompletionContext<'a> {
             comp_types.push(CompType::EnvVariable);
         } else if wuc.starts_with('~') && !wuc.contains("/") {
             comp_types.push(CompType::TildeExpansion);
+        } else if wuc.contains('@') && !wuc.contains("/") {
+            comp_types.push(CompType::HostnameExpansion);
         } else if CompType::is_glob_pattern(wuc) {
             comp_types.push(CompType::GlobExpansion);
         } else {
@@ -1548,6 +1552,22 @@ mod tests {
                     command_word: "cd".to_string()
                 },
                 CompType::FuzzyFilenameExpansion
+            ]
+        );
+    }
+
+    #[test]
+    fn test_hostname_completion() {
+        let ctx = run_inline("ssh user@hostn█");
+
+        assert_eq!(ctx.word_under_cursor.as_ref(), "user@hostn");
+        assert_eq!(
+            ctx.comp_types,
+            vec![
+                CompType::CommandComp {
+                    command_word: "ssh".to_string()
+                },
+                CompType::HostnameExpansion
             ]
         );
     }


### PR DESCRIPTION
Adds hostname completion, such as resolving `ssh user@hostn` to `ssh user@hostname`.
This parses the `/etc/hosts` file and `~/.ssh/config` and `~/.ssh/known_hosts` to dynamically list available hostnames, with a hardcoded mock list to facilitate tests.

---
*PR created automatically by Jules for task [5087678360294214060](https://jules.google.com/task/5087678360294214060) started by @HalFrgrd*