### PR TITLE
Enhance Tab Completion Mouse and Keyboard Support

### DIFF
--- a/src/active_suggestions.rs
+++ b/src/active_suggestions.rs
@@ -1171,6 +1171,51 @@ impl ActiveSuggestions {
         }
     }
 
+    pub fn on_page_up(&mut self) {
+        if self.auto_started {
+            // Move selection up by one page
+            let n = self.filtered_suggestions.len();
+            if n == 0 {
+                return;
+            }
+            let current_idx = self.current_1d_index().unwrap_or(0);
+            let page_size = self.row_window_to_show.window_size();
+            let next_idx = current_idx.saturating_sub(page_size);
+            self.set_selected_by_idx(next_idx);
+        } else {
+            // Move selection one column to the left
+            self.on_left_arrow();
+        }
+    }
+
+    pub fn on_page_down(&mut self) {
+        if self.auto_started {
+            // Move selection down by one page
+            let n = self.filtered_suggestions.len();
+            if n == 0 {
+                return;
+            }
+            let current_idx = self.current_1d_index().unwrap_or(0);
+            let page_size = self.row_window_to_show.window_size();
+            let next_idx = (current_idx + page_size).min(n.saturating_sub(1));
+            self.set_selected_by_idx(next_idx);
+        } else {
+            // Move selection one column to the right
+            self.on_right_arrow();
+        }
+    }
+
+    pub fn set_selected_by_scrollbar_pos(&mut self, relative_pos: f64) {
+        let n = self.filtered_suggestions.len();
+        if n == 0 {
+            return;
+        }
+
+        let target_idx = (relative_pos * (n as f64)).floor() as usize;
+        let target_idx = target_idx.min(n.saturating_sub(1));
+        self.set_selected_by_idx(target_idx);
+    }
+
     /// Return the portion of the suggestions grid that fits within the given
     /// terminal width, starting from column `col_offset`.
     pub fn into_grid(

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -402,6 +402,10 @@ pub enum Action {
     TabCompletionMoveLeft,
     #[strum(message = "Move right in tab completion suggestions")]
     TabCompletionMoveRight,
+    #[strum(message = "Move one page up / one column left in tab completion suggestions")]
+    TabCompletionMovePageUp,
+    #[strum(message = "Move one page down / one column right in tab completion suggestions")]
+    TabCompletionMovePageDown,
     #[strum(message = "Accept the currently selected suggestion")]
     TabCompletionAcceptEntry,
     #[strum(message = "Move to the previous tab completion suggestion")]
@@ -611,6 +615,16 @@ impl Action {
             Action::TabCompletionMoveRight => {
                 if let ContentMode::TabCompletion(active_suggestions) = &mut app.content_mode {
                     active_suggestions.on_right_arrow();
+                }
+            }
+            Action::TabCompletionMovePageUp => {
+                if let ContentMode::TabCompletion(active_suggestions) = &mut app.content_mode {
+                    active_suggestions.on_page_up();
+                }
+            }
+            Action::TabCompletionMovePageDown => {
+                if let ContentMode::TabCompletion(active_suggestions) = &mut app.content_mode {
+                    active_suggestions.on_page_down();
                 }
             }
             Action::TabCompletionAcceptEntry => {
@@ -1843,7 +1857,7 @@ fn capitalize_first(s: &str) -> String {
 /// useful for backward compatibility with old applications. The "Esc+" option is recommended for most users"
 /// In text_buffer.rs, I check if either of them are set for maximal compatibility.
 /// From highest priority to lowest
-static DEFAULT_BINDINGS: LazyLock<[Binding; 87]> = LazyLock::new(|| {
+static DEFAULT_BINDINGS: LazyLock<[Binding; 89]> = LazyLock::new(|| {
     use KeyCode as KC;
     use KeyModifiers as M;
     [
@@ -1881,6 +1895,16 @@ static DEFAULT_BINDINGS: LazyLock<[Binding; 87]> = LazyLock::new(|| {
             &[KC::Right.into()],
             ContextVar::TabCompletionMultiColAvailable.into(),
             Action::TabCompletionMoveRight,
+        ),
+        Binding::new(
+            &[KC::PageUp.into()],
+            ContextVar::TabCompletionAvailable.into(),
+            Action::TabCompletionMovePageUp,
+        ),
+        Binding::new(
+            &[KC::PageDown.into()],
+            ContextVar::TabCompletionAvailable.into(),
+            Action::TabCompletionMovePageDown,
         ),
         Binding::new(
             &[KC::Up.into()],

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -811,8 +811,18 @@ impl<'a> App<'a> {
             Some((tag @ Tag::Ps1PromptCwdWidget(_), _)) => {
                 self.last_mouse_over_cell = Some(tag);
             }
+            Some((tag @ Tag::TabCompletionSource, true)) => {
+                self.last_mouse_over_cell = Some(tag);
+                if let ContentMode::TabCompletion(ref active_suggestions) = self.content_mode {
+                    self.tooltip = Some(active_suggestions.comp_type.description().into_owned());
+                }
+            }
+            Some((tag @ Tag::TabCompletionScrollBar { .. }, true)) => {
+                self.last_mouse_over_cell = Some(tag);
+            }
             _ => {
                 self.last_mouse_over_cell = None;
+                self.tooltip = None;
             }
         }
 
@@ -1009,6 +1019,20 @@ impl<'a> App<'a> {
                     }
                 }
             }
+            Some(Tag::TabCompletionScrollBar { start_y, height }) => {
+                if matches!(
+                    mouse.kind,
+                    MouseEventKind::Down(event::MouseButton::Left) | MouseEventKind::Drag(_)
+                ) {
+                    if let ContentMode::TabCompletion(active_suggestions) = &mut self.content_mode {
+                        let relative_y = mouse.row as f64 - start_y as f64;
+                        let relative_pos =
+                            (relative_y / (height.saturating_sub(1)).max(1) as f64).clamp(0.0, 1.0);
+                        active_suggestions.set_selected_by_scrollbar_pos(relative_pos);
+                        update_buffer = true;
+                    }
+                }
+            }
             _ => {}
         }
 
@@ -1016,7 +1040,8 @@ impl<'a> App<'a> {
             self.on_possible_buffer_change();
             true
         } else {
-            false
+            // Return true for move events to ensure redraw for tooltips and highlights
+            matches!(mouse.kind, MouseEventKind::Moved)
         }
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -714,6 +714,10 @@ impl<'a> App<'a> {
     fn on_mouse(&mut self, mouse: MouseEvent) -> bool {
         log::trace!("Mouse event: {:?}", mouse);
 
+        let old_mouse_button_down = self.mouse_state.is_left_button_down();
+        let old_mouse_over_cell = self.last_mouse_over_cell;
+        let old_tooltip = self.tooltip.clone();
+
         // Track whether the left mouse button is currently being held down so
         // interactive cells (clipboard cells, buttons) can render a "depressed"
         // state while the user is pressing on them.
@@ -1036,12 +1040,15 @@ impl<'a> App<'a> {
             _ => {}
         }
 
+        let something_changed = self.last_mouse_over_cell != old_mouse_over_cell
+            || self.tooltip != old_tooltip
+            || self.mouse_state.is_left_button_down() != old_mouse_button_down;
+
         if update_buffer {
             self.on_possible_buffer_change();
             true
         } else {
-            // Return true for move events to ensure redraw for tooltips and highlights
-            matches!(mouse.kind, MouseEventKind::Moved)
+            something_changed
         }
     }
 

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -65,6 +65,8 @@ impl DrawnContent {
                     | Tag::PromptCopyBufferWidget
                     | Tag::Clipboard(_)
                     | Tag::Ps1PromptCwdWidget(_)
+                    | Tag::TabCompletionSource
+                    | Tag::TabCompletionScrollBar { .. }
             )
         }) {
             return direct_contact.map(|cell| (cell.tag, true));
@@ -1080,16 +1082,26 @@ impl<'a> App<'a> {
         content.write_tagged_span(&TaggedSpan::new(
             Span::styled(
                 format!(
-                    "# Pos: {}; Filtered: {}/{}; {} ({:.1}ms)",
+                    "# Pos: {}; Filtered: {}/{}; ",
                     pos_string,
                     active_suggestions.filtered_suggestions_len(),
                     active_suggestions.all_suggestions_len(),
+                ),
+                settings.colour_palette.secondary_text(),
+            ),
+            Tag::TabSuggestion,
+        ));
+
+        content.write_tagged_span(&TaggedSpan::new(
+            Span::styled(
+                format!(
+                    "{} ({:.1}ms)",
                     active_suggestions.comp_type.display_name(),
                     active_suggestions.load_time.as_secs_f32() * 1000.0,
                 ),
                 settings.colour_palette.secondary_text(),
             ),
-            Tag::TabSuggestion,
+            Tag::TabCompletionSource,
         ));
     }
 
@@ -1193,10 +1205,14 @@ impl<'a> App<'a> {
             .map(|idx| idx.to_string())
             .unwrap_or_else(|| "-".to_string());
 
-        let status_str = format!(
-            " Pos: {}/{}; {} ({:.1}ms) ",
+        let status_prefix = format!(
+            " Pos: {}/{}; ",
             pos_string,
             active_suggestions.filtered_suggestions_len(),
+        );
+
+        let source_str = format!(
+            "{} ({:.1}ms) ",
             active_suggestions.comp_type.display_name(),
             active_suggestions.load_time.as_secs_f32() * 1000.0,
         );
@@ -1207,8 +1223,19 @@ impl<'a> App<'a> {
             settings.colour_palette.secondary_text(),
             false,
             cursor_pos_maybe,
-            Some(&status_str),
+            None,
         );
+
+        let status_y = box_area.bottom() - 1;
+        content.move_cursor_to(status_y, x + 2);
+        content.write_tagged_span(&TaggedSpan::new(
+            Span::styled(status_prefix, settings.colour_palette.secondary_text()),
+            Tag::TabSuggestion,
+        ));
+        content.write_tagged_span(&TaggedSpan::new(
+            Span::styled(source_str, settings.colour_palette.secondary_text()),
+            Tag::TabCompletionSource,
+        ));
 
         let selected_1d = active_suggestions.current_1d_index();
         let window_range = active_suggestions.row_window_to_show.get_window_range();
@@ -1238,7 +1265,10 @@ impl<'a> App<'a> {
             num_rows_visible,
             window_range.start,
             settings.colour_palette.secondary_text(),
-            Tag::TabSuggestion,
+            Tag::TabCompletionScrollBar {
+                start_y: y + 1,
+                height: num_rows_visible as u16,
+            },
         );
 
         if let Some(sel_row) = selected_grid_row {

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -1217,25 +1217,25 @@ impl<'a> App<'a> {
             active_suggestions.load_time.as_secs_f32() * 1000.0,
         );
 
+        let status_line = TaggedLine::from(vec![
+            TaggedSpan::new(
+                Span::styled(status_prefix, settings.colour_palette.secondary_text()),
+                Tag::TabSuggestion,
+            ),
+            TaggedSpan::new(
+                Span::styled(source_str, settings.colour_palette.secondary_text()),
+                Tag::TabCompletionSource,
+            ),
+        ]);
+
         content.render_border(
             box_area,
             Tag::TabSuggestion,
             settings.colour_palette.secondary_text(),
             false,
             cursor_pos_maybe,
-            None,
+            Some(status_line),
         );
-
-        let status_y = box_area.bottom() - 1;
-        content.move_cursor_to(status_y, x + 2);
-        content.write_tagged_span(&TaggedSpan::new(
-            Span::styled(status_prefix, settings.colour_palette.secondary_text()),
-            Tag::TabSuggestion,
-        ));
-        content.write_tagged_span(&TaggedSpan::new(
-            Span::styled(source_str, settings.colour_palette.secondary_text()),
-            Tag::TabCompletionSource,
-        ));
 
         let selected_1d = active_suggestions.current_1d_index();
         let window_range = active_suggestions.row_window_to_show.get_window_range();

--- a/src/content_builder.rs
+++ b/src/content_builder.rs
@@ -827,7 +827,7 @@ impl Contents {
         style: ratatui::style::Style,
         is_selected: bool,
         connector_from: Option<Coord>,
-        status_str: Option<&str>,
+        status_line: Option<TaggedLine>,
     ) {
         if area.width < 2 || area.height < 2 {
             return;
@@ -863,7 +863,7 @@ impl Contents {
             }
         }
 
-        if let Some(status) = status_str {
+        if let Some(status) = status_line {
             let max_status_width = area.width.saturating_sub(2) as usize;
             let rect_for_status = Rect {
                 x: area.left() + 2,
@@ -875,11 +875,7 @@ impl Contents {
                 col: rect_for_status.x,
                 row: rect_for_status.y,
             };
-            self.write_span_internal(
-                &TaggedSpan::new(Span::styled(status, style), tag),
-                true,
-                Some(rect_for_status),
-            );
+            self.write_tagged_line_area(&status, rect_for_status);
         }
 
         if let Some(cursor_pos) = connector_from

--- a/src/content_builder.rs
+++ b/src/content_builder.rs
@@ -184,6 +184,8 @@ pub enum Tag {
     HistoryResult(usize),
     Tooltip,
     AiResult(usize),
+    TabCompletionSource,
+    TabCompletionScrollBar { start_y: u16, height: u16 },
     TutorialPrev,
     TutorialNext,
     Tutorial,

--- a/src/stateful_sliding_window.rs
+++ b/src/stateful_sliding_window.rs
@@ -72,6 +72,10 @@ impl StatefulSlidingWindow {
         self.fix_window();
     }
 
+    pub fn window_size(&self) -> usize {
+        self.window_size
+    }
+
     pub fn get_window_range(&self) -> std::ops::Range<usize> {
         self.start_index..((self.start_index + self.window_size).min(self.max_index))
     }

--- a/src/tab_completion_context.rs
+++ b/src/tab_completion_context.rs
@@ -51,6 +51,26 @@ impl CompType {
             CompType::FuzzyFilenameExpansion => "FuzzyFilenameExpansion",
         }
     }
+
+    pub fn description(&self) -> Cow<'static, str> {
+        match self {
+            CompType::None => Cow::Borrowed("No completion available."),
+            CompType::FirstWord => Cow::Borrowed("Completing the command name (executables in PATH, aliases, or shell builtins)."),
+            CompType::FuzzyFirstWord => Cow::Borrowed("Fuzzy-matching the command name against available executables and aliases."),
+            CompType::CommandComp { command_word } => {
+                Cow::Owned(format!("Programmable completion for the '{}' command.", command_word))
+            }
+            CompType::FuzzyCommandComp { command_word } => {
+                Cow::Owned(format!("Fuzzy programmable completion for the '{}' command.", command_word))
+            }
+            CompType::EnvVariable => Cow::Borrowed("Completing an environment variable name."),
+            CompType::TildeExpansion => Cow::Borrowed("Expanding '~username' to the user's home directory."),
+            CompType::HostnameExpansion => Cow::Borrowed("Completing a hostname (usually from /etc/hosts)."),
+            CompType::GlobExpansion => Cow::Borrowed("Expanding a shell glob pattern (e.g., *.rs)."),
+            CompType::FilenameExpansion => Cow::Borrowed("Completing a file or directory path."),
+            CompType::FuzzyFilenameExpansion => Cow::Borrowed("Fuzzy-matching a file or directory path in the current directory."),
+        }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq)]


### PR DESCRIPTION
Enhanced the tab completion system with improved mouse and keyboard support.

Key changes:
1. Mouse Dragging: Users can now click and drag on the vertical scrollbar in the tab completion popup to scroll through results and change the selection.
2. Source Tooltips: Hovering over the completion source indicator (like "FirstWord", "CommandComp") now shows a descriptive tooltip explaining what that completion source is doing.
3. Page Navigation:
   - PageUp and PageDown now navigate through completion results.
   - In the multi-column grid view, they jump one column to the left or right.
   - In the single-column list view (auto-complete), they scroll by one full page of results.
4. Internal Fixes: Fixed a memory leak in dynamic description generation and improved scrollbar scaling accuracy. Redraws are now correctly triggered on mouse movement to support smooth tooltip updates.

---
*PR created automatically by Jules for task [17313715602626089708](https://jules.google.com/task/17313715602626089708) started by @HalFrgrd*