### PR TITLE
Improve tab completion description processing

### DIFF
--- a/src/active_suggestions.rs
+++ b/src/active_suggestions.rs
@@ -295,41 +295,6 @@ mod description_tests {
     }
 
     #[test]
-    fn test_split_completion_description_strips_parentheses() {
-        // Single frame with parentheses
-        let (text, frames) = UnprocessedSuggestion::split_completion_description("cmd\t(desc)");
-        assert_eq!(text, "cmd");
-        assert_eq!(frames, vec!["desc".to_string()]);
-
-        // Multiple frames with parentheses
-        let (text, frames) =
-            UnprocessedSuggestion::split_completion_description("cmd\t(frame1)\t(frame2)");
-        assert_eq!(text, "cmd");
-        assert_eq!(frames, vec!["frame1".to_string(), "frame2".to_string()]);
-
-        // Frame without parentheses
-        let (text, frames) = UnprocessedSuggestion::split_completion_description("cmd\tno parens");
-        assert_eq!(text, "cmd");
-        assert_eq!(frames, vec!["no parens".to_string()]);
-
-        // Frame with only leading parenthesis
-        let (text, frames) = UnprocessedSuggestion::split_completion_description("cmd\t(no end");
-        assert_eq!(text, "cmd");
-        assert_eq!(frames, vec!["(no end".to_string()]);
-
-        // Frame with only trailing parenthesis
-        let (text, frames) = UnprocessedSuggestion::split_completion_description("cmd\tno start)");
-        assert_eq!(text, "cmd");
-        assert_eq!(frames, vec!["no start)".to_string()]);
-
-        // Parentheses inside the frame
-        let (text, frames) =
-            UnprocessedSuggestion::split_completion_description("cmd\t(frame (inside))");
-        assert_eq!(text, "cmd");
-        assert_eq!(frames, vec!["frame (inside)".to_string()]);
-    }
-
-    #[test]
     fn raw_match_text_no_tab_unchanged() {
         let item = UnprocessedSuggestion {
             raw_text: "git-commit".to_string(),
@@ -648,17 +613,7 @@ impl UnprocessedSuggestion {
         match raw.split_once('\t') {
             None => (raw, vec![]),
             Some((text, rest)) => {
-                let frames: Vec<String> = rest
-                    .split('\t')
-                    .map(|s| {
-                        if let Some(stripped) = s.strip_prefix('(').and_then(|s| s.strip_suffix(')'))
-                        {
-                            stripped.to_owned()
-                        } else {
-                            s.to_owned()
-                        }
-                    })
-                    .collect();
+                let frames: Vec<String> = rest.split('\t').map(|s| s.to_owned()).collect();
                 (text, frames)
             }
         }

--- a/src/active_suggestions.rs
+++ b/src/active_suggestions.rs
@@ -295,6 +295,41 @@ mod description_tests {
     }
 
     #[test]
+    fn test_split_completion_description_strips_parentheses() {
+        // Single frame with parentheses
+        let (text, frames) = UnprocessedSuggestion::split_completion_description("cmd\t(desc)");
+        assert_eq!(text, "cmd");
+        assert_eq!(frames, vec!["desc".to_string()]);
+
+        // Multiple frames with parentheses
+        let (text, frames) =
+            UnprocessedSuggestion::split_completion_description("cmd\t(frame1)\t(frame2)");
+        assert_eq!(text, "cmd");
+        assert_eq!(frames, vec!["frame1".to_string(), "frame2".to_string()]);
+
+        // Frame without parentheses
+        let (text, frames) = UnprocessedSuggestion::split_completion_description("cmd\tno parens");
+        assert_eq!(text, "cmd");
+        assert_eq!(frames, vec!["no parens".to_string()]);
+
+        // Frame with only leading parenthesis
+        let (text, frames) = UnprocessedSuggestion::split_completion_description("cmd\t(no end");
+        assert_eq!(text, "cmd");
+        assert_eq!(frames, vec!["(no end".to_string()]);
+
+        // Frame with only trailing parenthesis
+        let (text, frames) = UnprocessedSuggestion::split_completion_description("cmd\tno start)");
+        assert_eq!(text, "cmd");
+        assert_eq!(frames, vec!["no start)".to_string()]);
+
+        // Parentheses inside the frame
+        let (text, frames) =
+            UnprocessedSuggestion::split_completion_description("cmd\t(frame (inside))");
+        assert_eq!(text, "cmd");
+        assert_eq!(frames, vec!["frame (inside)".to_string()]);
+    }
+
+    #[test]
     fn raw_match_text_no_tab_unchanged() {
         let item = UnprocessedSuggestion {
             raw_text: "git-commit".to_string(),
@@ -613,7 +648,17 @@ impl UnprocessedSuggestion {
         match raw.split_once('\t') {
             None => (raw, vec![]),
             Some((text, rest)) => {
-                let frames: Vec<String> = rest.split('\t').map(|s| s.to_owned()).collect();
+                let frames: Vec<String> = rest
+                    .split('\t')
+                    .map(|s| {
+                        if let Some(stripped) = s.strip_prefix('(').and_then(|s| s.strip_suffix(')'))
+                        {
+                            stripped.to_owned()
+                        } else {
+                            s.to_owned()
+                        }
+                    })
+                    .collect();
                 (text, frames)
             }
         }

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -600,7 +600,7 @@ fn analyze_candidate(s: &str) -> Option<(&str, &str, usize)> {
 /// So here I convert those to the format "suggestion<TAB>description" so that
 /// flyline can show the description in a separate column.
 fn detect_and_convert_inline_descriptions(completions: &mut Vec<String>, flags: &CompletionFlags) {
-    if flags.filename_completion_desired {
+    if flags.filename_completion_desired || completions.iter().any(|s| s.contains('\t')) {
         return;
     }
 
@@ -1635,6 +1635,16 @@ mod tests {
         let mut comps = vec!["my file      description".to_string()];
         detect_and_convert_inline_descriptions(&mut comps, &flags);
         assert_eq!(comps[0], "my file      description");
+
+        // 9. One completion already contains a tab character.
+        // Should NOT convert any of them.
+        let mut comps = vec![
+            "port\tList port mappings".to_string(),
+            "ps      List containers".to_string(),
+        ];
+        detect_and_convert_inline_descriptions(&mut comps, &flags);
+        assert_eq!(comps[0], "port\tList port mappings");
+        assert_eq!(comps[1], "ps      List containers");
     }
 }
 

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -631,6 +631,12 @@ fn detect_and_convert_inline_descriptions(completions: &mut Vec<String>, flags: 
     if detected {
         for s in completions.iter_mut() {
             if let Some((value, description, _)) = analyze_candidate(s) {
+                let description =
+                    if let Some(stripped) = description.strip_prefix('(').and_then(|s| s.strip_suffix(')')) {
+                        stripped
+                    } else {
+                        description
+                    };
                 *s = format!("{}\t{}", value, description);
             }
         }
@@ -1645,6 +1651,15 @@ mod tests {
         detect_and_convert_inline_descriptions(&mut comps, &flags);
         assert_eq!(comps[0], "port\tList port mappings");
         assert_eq!(comps[1], "ps      List containers");
+
+        // 10. Descriptions wrapped in parentheses should be stripped.
+        let mut comps = vec![
+            "port      (List port mappings)".to_string(),
+            "ps        (List containers)".to_string(),
+        ];
+        detect_and_convert_inline_descriptions(&mut comps, &flags);
+        assert_eq!(comps[0], "port\tList port mappings");
+        assert_eq!(comps[1], "ps\tList containers");
     }
 }
 


### PR DESCRIPTION
This change improves how flyline handles descriptions from programmable completions.

1. It prevents the heuristic splitting of completions by double spaces if the completion source has already provided tab-separated descriptions. This is done by checking if any candidate completion contains a tab character before applying the double-space heuristic.
2. It strips surrounding parentheses from description frames (e.g., `(desc)` becomes `desc`), which is common in some completion scripts.

Unit tests have been added to `src/bash_funcs.rs` and `src/active_suggestions.rs` to verify these behaviors and ensure no regressions.

---
*PR created automatically by Jules for task [15645752431727733653](https://jules.google.com/task/15645752431727733653) started by @HalFrgrd*