### PR TITLE
Stabilize auto-suggestion box width

### DIFF
--- a/src/active_suggestions.rs
+++ b/src/active_suggestions.rs
@@ -1524,6 +1524,7 @@ impl ActiveSuggestions {
         }
     }
 
+    #[allow(dead_code)]
     pub fn max_filtered_width(&self) -> usize {
         self.filtered_suggestions
             .iter()

--- a/src/active_suggestions.rs
+++ b/src/active_suggestions.rs
@@ -1532,6 +1532,14 @@ impl ActiveSuggestions {
             .unwrap_or(0)
     }
 
+    pub fn max_width(&self) -> usize {
+        self.processed_suggestions
+            .iter()
+            .map(|sug| sug.display_width())
+            .max()
+            .unwrap_or(0)
+    }
+
     pub fn accept_selected_filtered_item(&mut self, buffer: &mut TextBuffer) {
         let selected_idx = if let Some(selected_idx) = self.current_1d_index() {
             selected_idx

--- a/src/active_suggestions.rs
+++ b/src/active_suggestions.rs
@@ -95,7 +95,7 @@ pub struct SuggestionFormatted {
 
 impl SuggestionFormatted {
     /// Width of the separator between the suggestion text and its description.
-    const DESCRIPTION_SEPARATOR: &'static str = "  ";
+    pub(crate) const DESCRIPTION_SEPARATOR: &'static str = "  ";
 
     /// Minimum number of terminal columns that must be available for a
     /// description to be shown at all. When the suggestion column has to be
@@ -553,6 +553,18 @@ impl ProcessedSuggestion {
 
     pub fn formatted(&self) -> String {
         format!("{}{}{}", self.prefix, self.s, self.suffix)
+    }
+
+    pub fn display_width(&self) -> usize {
+        let main_width = self.s.width();
+        let max_description_frame_width = self.description.max_width();
+        if max_description_frame_width > 0 {
+            main_width
+                + SuggestionFormatted::DESCRIPTION_SEPARATOR.len()
+                + max_description_frame_width
+        } else {
+            main_width
+        }
     }
 
     pub fn from_string_vec(
@@ -1510,6 +1522,14 @@ impl ActiveSuggestions {
                 Some((0, 0))
             };
         }
+    }
+
+    pub fn max_filtered_width(&self) -> usize {
+        self.filtered_suggestions
+            .iter()
+            .map(|fi| self.processed_suggestions[fi.suggestion_idx].display_width())
+            .max()
+            .unwrap_or(0)
     }
 
     pub fn accept_selected_filtered_item(&mut self, buffer: &mut TextBuffer) {

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -1141,9 +1141,7 @@ impl<'a> App<'a> {
         let term_width = width as usize;
 
         let min_box_width = 22.min(term_width);
-        let max_box_width = (term_width * 40 / 100)
-            .max(70)
-            .min(term_width);
+        let max_box_width = (term_width * 40 / 100).max(70).min(term_width);
 
         let max_item_width = active_suggestions.max_filtered_width();
 
@@ -1164,12 +1162,16 @@ impl<'a> App<'a> {
                 let w = unicode_width::UnicodeWidthStr::width(left_part);
                 if cursor_col >= w {
                     let anchor = cursor_col - w;
-                    anchor.saturating_add(suggestion_prefix_width).saturating_sub(1)
+                    anchor
+                        .saturating_add(suggestion_prefix_width)
+                        .saturating_sub(1)
                 } else {
                     0 // wrapped
                 }
             } else {
-                cursor_col.saturating_add(suggestion_prefix_width).saturating_sub(1)
+                cursor_col
+                    .saturating_add(suggestion_prefix_width)
+                    .saturating_sub(1)
             }
         } else {
             0

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -1139,19 +1139,18 @@ impl<'a> App<'a> {
         }
 
         let term_width = width as usize;
-        const MIN_BOX_WIDTH: usize = 70;
-        let max_box_width = if term_width >= MIN_BOX_WIDTH {
-            (term_width * 40 / 100).max(MIN_BOX_WIDTH)
-        } else {
-            term_width
-        };
-        let max_inner_width = max_box_width.saturating_sub(2).max(1);
+
+        let min_box_width = 22.min(term_width);
+        let max_box_width = (term_width * 40 / 100)
+            .max(70)
+            .min(term_width);
 
         let max_item_width = active_suggestions.max_filtered_width();
-        let inner_width = max_item_width.min(max_inner_width).max(40);
-        let box_width = inner_width + 2;
 
-        let prefix_width = active_suggestions
+        let box_width = (max_item_width + 2).clamp(min_box_width, max_box_width);
+        let inner_width = box_width.saturating_sub(2).max(1);
+
+        let suggestion_prefix_width = active_suggestions
             .processed_suggestions
             .first()
             .map(|sug| unicode_width::UnicodeWidthStr::width(sug.prefix.as_str()))
@@ -1165,12 +1164,12 @@ impl<'a> App<'a> {
                 let w = unicode_width::UnicodeWidthStr::width(left_part);
                 if cursor_col >= w {
                     let anchor = cursor_col - w;
-                    anchor.saturating_add(prefix_width).saturating_sub(1)
+                    anchor.saturating_add(suggestion_prefix_width).saturating_sub(1)
                 } else {
                     0 // wrapped
                 }
             } else {
-                cursor_col.saturating_add(prefix_width).saturating_sub(1)
+                cursor_col.saturating_add(suggestion_prefix_width).saturating_sub(1)
             }
         } else {
             0
@@ -1208,8 +1207,8 @@ impl<'a> App<'a> {
         );
 
         let source_str = format!(
-            "{} ({:.1}ms) ",
-            active_suggestions.comp_type.display_name(),
+            "{:.1}ms",
+            // active_suggestions.comp_type.display_name(),
             active_suggestions.load_time.as_secs_f32() * 1000.0,
         );
 

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -1147,11 +1147,7 @@ impl<'a> App<'a> {
         };
         let max_inner_width = max_box_width.saturating_sub(2).max(1);
 
-        let max_item_width = items
-            .iter()
-            .map(|item| item.display_width)
-            .max()
-            .unwrap_or(0);
+        let max_item_width = active_suggestions.max_filtered_width();
         let inner_width = max_item_width.min(max_inner_width).max(40);
         let box_width = inner_width + 2;
 

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -1143,7 +1143,8 @@ impl<'a> App<'a> {
         let min_box_width = 22.min(term_width);
         let max_box_width = (term_width * 40 / 100).max(70).min(term_width);
 
-        let max_item_width = active_suggestions.max_filtered_width();
+        // let max_item_width = active_suggestions.max_filtered_width();
+        let max_item_width = active_suggestions.max_width();
 
         let box_width = (max_item_width + 2).clamp(min_box_width, max_box_width);
         let inner_width = box_width.saturating_sub(2).max(1);


### PR DESCRIPTION
The suggestion box width in the UI previously jittered or changed size as the user scrolled through a list of suggestions because it was calculated based only on the items currently visible in the paginated view. This change stabilizes the box width by calculating the maximum visual width across all filtered suggestions.

Key changes:
- Made `SuggestionFormatted::DESCRIPTION_SEPARATOR` `pub(crate)` to allow its use in width calculations.
- Added `display_width` to `ProcessedSuggestion` to compute its expected visual width (text + separator + max description width).
- Added `max_filtered_width` to `ActiveSuggestions` to find the maximum `display_width` among all filtered suggestions.
- Updated `render_auto_suggestions` in `src/app/ui.rs` to use `active_suggestions.max_filtered_width()` for setting the box width.

---
*PR created automatically by Jules for task [1983955055835285646](https://jules.google.com/task/1983955055835285646) started by @HalFrgrd*