### PR TITLE
Fix flycomp cargo completions and improve robustness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "is_executable",
  "log",
  "regex",
  "serde",

--- a/flycomp/Cargo.toml
+++ b/flycomp/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.102"
+is_executable = "1.0.5"
 clap = { version = "4.6.1", features = ["derive", "string"] }
 clap_complete = { version = "4.6.3", features = ["unstable-dynamic"] }
 log = "0.4"

--- a/flycomp/src/lib.rs
+++ b/flycomp/src/lib.rs
@@ -470,6 +470,19 @@ pub fn run_help(
     sandbox: bool,
     timeout_ms: u64,
 ) -> anyhow::Result<String> {
+    let mut actual_command = command_path.to_string();
+
+    // If command_path is a simple name (no path separators), check CWD.
+    if !command_path.contains(std::path::MAIN_SEPARATOR) {
+        let cwd_path = std::env::current_dir()?.join(command_path);
+        if cwd_path.exists() {
+            use is_executable::IsExecutable;
+            if cwd_path.is_executable() {
+                actual_command = format!(".{}{}", std::path::MAIN_SEPARATOR, command_path);
+            }
+        }
+    }
+
     let use_sandbox = sandbox && {
         // Test if bwrap exists in PATH by trying to spawn it with --version
         match std::process::Command::new("bwrap")
@@ -504,11 +517,11 @@ pub fn run_help(
             "/proc",
             "--unshare-all",
             "--",
-            command_path,
+            &actual_command,
         ]);
         cmd
     } else {
-        std::process::Command::new(command_path)
+        std::process::Command::new(&actual_command)
     };
 
     let mut child = child
@@ -523,7 +536,13 @@ pub fn run_help(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
-        .map_err(|e| anyhow::anyhow!("failed to spawn '{}': {}", command_path, e))?;
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                anyhow::anyhow!("command '{}' not found in PATH or CWD", actual_command)
+            } else {
+                anyhow::anyhow!("failed to spawn '{}': {}", actual_command, e)
+            }
+        })?;
 
     let mut stdout_handle = child
         .stdout
@@ -907,6 +926,39 @@ Options:
 
         // Cleanup
         let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_run_help_in_cwd() {
+        use std::io::Write;
+        let temp_dir = std::env::current_dir().unwrap().join("target").join("test_run_help_cwd");
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let cmd_path = temp_dir.join("dummy_cmd");
+
+        let script = "#!/bin/sh\necho \"Usage: dummy_cmd [OPTIONS]\n\nOptions:\n  --foo  bar\"";
+        {
+            let mut f = std::fs::File::create(&cmd_path).unwrap();
+            f.write_all(script.as_bytes()).unwrap();
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&cmd_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&cmd_path, perms).unwrap();
+        }
+
+        let old_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&temp_dir).unwrap();
+
+        let res = run_help("dummy_cmd", &[], false, 5000);
+
+        std::env::set_current_dir(old_cwd).unwrap();
+        let _ = std::fs::remove_dir_all(&temp_dir);
+
+        let output = res.expect("run_help should succeed");
+        assert!(output.contains("--foo"));
     }
 
     #[test]

--- a/flycomp/src/main.rs
+++ b/flycomp/src/main.rs
@@ -77,14 +77,20 @@ fn main() -> anyhow::Result<()> {
     }
 
     let command_str = args.command.as_deref().unwrap_or("");
-    let output = flycomp::generate_completion_output(
+    match flycomp::generate_completion_output(
         command_str,
         args.output,
         args.strategy,
         !args.no_sandbox,
         args.timeout_ms,
-    )?;
-    print!("{}", output);
-
-    Ok(())
+    ) {
+        Ok(output) => {
+            print!("{}", output);
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("Error: {:#}", e);
+            std::process::exit(1);
+        }
+    }
 }

--- a/flycomp/src/parse_help.rs
+++ b/flycomp/src/parse_help.rs
@@ -71,10 +71,14 @@ pub(crate) fn parse_flag_tokens(token: &str) -> (Option<String>, Option<String>,
         if piece.starts_with("--") {
             // May be "--flag" or "--flag=<VAL>"
             if let Some((flag, val)) = piece.split_once('=') {
-                long = Some(flag.trim_end_matches(',').to_string());
+                long = Some(flag.trim_end_matches(',').trim_end_matches('.').to_string());
                 value_type = Some(val.trim_matches(|c| c == '<' || c == '>').to_string());
             } else {
-                long = Some(piece.trim_end_matches(',').to_string());
+                let mut l = piece.trim_end_matches(',').to_string();
+                while l.ends_with('.') {
+                    l.pop();
+                }
+                long = Some(l);
             }
         } else if let Some(short_candidate) = piece.strip_prefix('-') {
             let short_candidate = short_candidate.trim_end_matches(',');
@@ -227,12 +231,14 @@ pub fn parse_help_clap(help: &str) -> Command {
                         if !first_name.is_empty() {
                             let aliases: Vec<String> =
                                 name_iter.filter(|s| !s.is_empty()).collect();
-                            cmd.subcommands.push(Command {
-                                name: Some(first_name),
-                                aliases,
-                                description: sub_desc,
-                                ..Command::default()
-                            });
+                            if first_name != "..." {
+                                cmd.subcommands.push(Command {
+                                    name: Some(first_name),
+                                    aliases,
+                                    description: sub_desc,
+                                    ..Command::default()
+                                });
+                            }
                         }
                     }
                 }
@@ -1927,5 +1933,39 @@ Options:
             args.iter()
                 .any(|a| a.long.as_deref() == Some("--nonocolor"))
         );
+    }
+
+    #[test]
+    fn test_cargo_help_with_ellipsis() {
+        const HELP: &str = r#"Rust's package manager
+
+Usage: cargo [+toolchain] [OPTIONS] [COMMAND]
+
+Options:
+  -v, --verbose...               Use verbose output
+  -h, --help                     Print help
+
+Commands:
+    build, b    Compile the current package
+    check, c    Analyze the current package
+    ...         See all commands with --list
+"#;
+        let cmd = parse_help(HELP);
+        assert_eq!(cmd.name.as_deref(), Some("cargo"));
+
+        // Check flags: --verbose... should become --verbose
+        let verbose = cmd
+            .args
+            .iter()
+            .find(|a| a.short.as_deref() == Some("-v"))
+            .expect("verbose flag found");
+        assert_eq!(verbose.long.as_deref(), Some("--verbose"));
+
+        // Check subcommands: ... should be skipped
+        let subs = subcommand_names(&cmd);
+        assert!(subs.contains(&"build"));
+        assert!(subs.contains(&"check"));
+        assert!(!subs.contains(&"..."));
+        assert_eq!(subs.len(), 2);
     }
 }


### PR DESCRIPTION
This PR fixes the issue where `flycomp cargo` would yield a completion with no subcommands and improves the overall robustness of `flycomp`.

Key changes:
1. **Robust Command Resolution**: `flycomp` now checks the current working directory for an executable if a simple command name (no path separators) is provided.
2. **Improved Error Handling**: If a command is not found or fails to run, `flycomp` now prints a clear error message to stderr and exits with a non-zero exit code.
3. **Cargo Parsing Fixes**:
   - The help parser now correctly ignores the `...` placeholder in subcommand lists.
   - Trailing dots (ellipses) are stripped from flag names (e.g., `--verbose...` becomes `--verbose`).
4. **Enhanced Testing**: Added new test cases in `flycomp/src/lib.rs` and `flycomp/src/parse_help.rs` to verify the new command resolution logic and the Cargo-specific parsing fixes.

These changes ensure that `cargo` and similar tools generate accurate completion scripts and that the tool behaves predictably when commands are missing.

---
*PR created automatically by Jules for task [15855265190880494078](https://jules.google.com/task/15855265190880494078) started by @HalFrgrd*