### PR TITLE
Remove visual selection maintenance on entry changes

### DIFF
--- a/src/active_suggestions.rs
+++ b/src/active_suggestions.rs
@@ -1596,23 +1596,10 @@ impl ActiveSuggestions {
         self.filtered_suggestions
             .sort_by(|a, b| b.score.cmp(&a.score));
 
-        // Reset selected position if needed
+        // Reset selected position
         if self.filtered_suggestions.is_empty() {
             self.selected_coord = None;
-            return;
-        }
-
-        if self.current_1d_index().is_none() {
-            if !self.auto_started {
-                self.selected_coord = Some((0, 0));
-            }
-            return;
-        }
-
-        if self
-            .current_1d_index()
-            .is_some_and(|idx| idx >= self.filtered_suggestions.len())
-        {
+        } else {
             self.selected_coord = if self.auto_started {
                 None
             } else {

--- a/src/history.rs
+++ b/src/history.rs
@@ -606,14 +606,10 @@ impl FuzzyHistorySearch {
         max_visible: usize,
     ) -> (&[HistoryEntryFormatted], usize, usize, usize) {
         // when the command changes, reset the cache
-        // but keep the current visual row if possible
-        let mut desired_visual_row = None;
-
         if Some(current_cmd.to_string()) != self.cache_command {
             self.cache_command = Some(current_cmd.to_string());
             self.cache = vec![];
             self.global_index = 0;
-            desired_visual_row = Some(self.window.visual_index_of_interest());
             self.cache_index = 0;
             self.window = StatefulSlidingWindow::new(0, Self::VISIBLE_CACHE_SIZE, 0, None);
         }
@@ -624,9 +620,6 @@ impl FuzzyHistorySearch {
 
         self.window.update_max_index(cache_len);
         self.window.update_window_size(max_visible);
-        if let Some(desired) = desired_visual_row {
-            self.window.set_visual_index_of_interest(desired);
-        }
         self.window.move_index_to(self.cache_index);
 
         let entries_to_show = &mut self.cache[self.window.get_window_range()];

--- a/src/stateful_sliding_window.rs
+++ b/src/stateful_sliding_window.rs
@@ -80,14 +80,6 @@ impl StatefulSlidingWindow {
         self.start_index..((self.start_index + self.window_size).min(self.max_index))
     }
 
-    pub fn visual_index_of_interest(&self) -> usize {
-        self.index_of_interest - self.start_index
-    }
-
-    pub fn set_visual_index_of_interest(&mut self, visual_index: usize) {
-        self.index_of_interest = self.start_index + visual_index;
-        self.fix_window();
-    }
 
     pub fn force_window_and_index(&mut self, new_start: usize, new_index: usize) {
         self.start_index = new_start;


### PR DESCRIPTION
Removed code that attempts to maintain visual selection position in suggestions and history search. Verified with tests and manual inspection.

---
*PR created automatically by Jules for task [3385042072864788753](https://jules.google.com/task/3385042072864788753) started by @HalFrgrd*