### PR TITLE
Improve flycomp integration, demo tape fixes etc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "flycomp"
 version = "1.0.0"
-source = "git+https://github.com/HalFrgrd/flycomp.git?rev=0508922a06b71d3e1e57e1a08074d7b2ab31c54d#0508922a06b71d3e1e57e1a08074d7b2ab31c54d"
+source = "git+https://github.com/HalFrgrd/flycomp.git?rev=cc92b88dd768aef89ffdd257685f1994595c91dc#cc92b88dd768aef89ffdd257685f1994595c91dc"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "flycomp"
 version = "1.0.0"
-source = "git+https://github.com/HalFrgrd/flycomp.git?rev=79abf0d733ae5072b2ba2dd1e58b5feab0f9401f#79abf0d733ae5072b2ba2dd1e58b5feab0f9401f"
+source = "git+https://github.com/HalFrgrd/flycomp.git?rev=0508922a06b71d3e1e57e1a08074d7b2ab31c54d#0508922a06b71d3e1e57e1a08074d7b2ab31c54d"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "flycomp"
 version = "1.0.0"
-source = "git+https://github.com/HalFrgrd/flycomp.git?rev=2dba32bde08c6e2a65754623c66384572f02605a#2dba32bde08c6e2a65754623c66384572f02605a"
+source = "git+https://github.com/HalFrgrd/flycomp.git?rev=79abf0d733ae5072b2ba2dd1e58b5feab0f9401f#79abf0d733ae5072b2ba2dd1e58b5feab0f9401f"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ parse-style = { version = "0.4.0" }
 easing-function = "0.1.1"
 strum = { version = "0.28.0", features = ["derive"] }
 ctor = "0.10.0"
-flycomp = { git = "https://github.com/HalFrgrd/flycomp.git", rev = "0508922a06b71d3e1e57e1a08074d7b2ab31c54d" }
+flycomp = { git = "https://github.com/HalFrgrd/flycomp.git", rev = "cc92b88dd768aef89ffdd257685f1994595c91dc" }
 
 [features]
 pre_bash_4_4 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ parse-style = { version = "0.4.0" }
 easing-function = "0.1.1"
 strum = { version = "0.28.0", features = ["derive"] }
 ctor = "0.10.0"
-flycomp = { git = "https://github.com/HalFrgrd/flycomp.git", rev = "2dba32bde08c6e2a65754623c66384572f02605a" }
+flycomp = { git = "https://github.com/HalFrgrd/flycomp.git", rev = "79abf0d733ae5072b2ba2dd1e58b5feab0f9401f" }
 
 [features]
 pre_bash_4_4 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ parse-style = { version = "0.4.0" }
 easing-function = "0.1.1"
 strum = { version = "0.28.0", features = ["derive"] }
 ctor = "0.10.0"
-flycomp = { git = "https://github.com/HalFrgrd/flycomp.git", rev = "79abf0d733ae5072b2ba2dd1e58b5feab0f9401f" }
+flycomp = { git = "https://github.com/HalFrgrd/flycomp.git", rev = "0508922a06b71d3e1e57e1a08074d7b2ab31c54d" }
 
 [features]
 pre_bash_4_4 = []

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -1958,14 +1958,14 @@ static DEFAULT_BINDINGS: LazyLock<[Binding; 90]> = LazyLock::new(|| {
             Action::FuzzyHistoryAcceptEntry,
         ),
         Binding::new(
-            &expand_variations![KC::Enter.into()],
-            ContextVar::TabCompletionEntrySelected.into(),
-            Action::TabCompletionAcceptEntry,
-        ),
-        Binding::new(
             &expand_variations![M::CONTROL + KC::Enter.into(), M::SUPER + KC::Enter.into()],
             ContextVar::TabCompletionAvailable.into(),
             Action::TabCompletionAcceptAll,
+        ),
+        Binding::new(
+            &expand_variations![KC::Enter.into()],
+            ContextVar::TabCompletionEntrySelected.into(),
+            Action::TabCompletionAcceptEntry,
         ),
         Binding::new(
             &expand_variations![KC::Enter.into()],

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -71,6 +71,12 @@ enum ContextVar {
     BufferHasAgentModePrefix,
     #[strum(message = "The content mode is normal editing (no overlay is active)")]
     EditingBufferMode,
+    #[strum(message = "Prompting the user whether they want to run flycomp")]
+    TabCompletionAskForFlycomp,
+    #[strum(message = "Flycomp completion synthesis is currently running in the background")]
+    TabCompletionRunningFlycomp,
+    #[strum(message = "Flycomp completion synthesis finished and has a result or error")]
+    TabCompletionFlycompResult,
 }
 
 impl ContextVar {
@@ -149,6 +155,24 @@ impl ContextVar {
                 app.buffer_starts_with_agent_command_prefix().is_some()
             }
             ContextVar::EditingBufferMode => matches!(app.content_mode, ContentMode::Normal),
+            ContextVar::TabCompletionAskForFlycomp => {
+                matches!(
+                    app.content_mode,
+                    ContentMode::TabCompletionAskForFlycomp { .. }
+                )
+            }
+            ContextVar::TabCompletionRunningFlycomp => {
+                matches!(
+                    app.content_mode,
+                    ContentMode::TabCompletionRunningFlycomp { .. }
+                )
+            }
+            ContextVar::TabCompletionFlycompResult => {
+                matches!(
+                    app.content_mode,
+                    ContentMode::TabCompletionFlycompResult { .. }
+                )
+            }
         }
     }
 }
@@ -382,6 +406,10 @@ impl TryFrom<&str> for ContextExpr {
 )]
 #[strum(serialize_all = "camelCase")]
 pub enum Action {
+    #[strum(message = "Toggle Yes/No choice in the flycomp prompt")]
+    FlycompAskToggleChoice,
+    #[strum(message = "Accept the current Yes/No choice in the flycomp prompt")]
+    FlycompAskAcceptChoice,
     #[strum(message = "Accept inline history suggestion")]
     InlineSuggestionAccept,
     #[strum(message = "Temporarily dismiss the inline history suggestion")]
@@ -597,6 +625,29 @@ impl Action {
             Action::AgentOutputNextSuggestion => {
                 if let ContentMode::AgentOutputSelection(selection) = &mut app.content_mode {
                     selection.move_down(); // TODO: cycle through
+                }
+            }
+            Action::FlycompAskToggleChoice => {
+                if let ContentMode::TabCompletionAskForFlycomp {
+                    ref mut selected_yes,
+                    ..
+                } = app.content_mode
+                {
+                    *selected_yes = !*selected_yes;
+                }
+            }
+            Action::FlycompAskAcceptChoice => {
+                let mode = std::mem::replace(&mut app.content_mode, ContentMode::Normal);
+                if let ContentMode::TabCompletionAskForFlycomp {
+                    command_word,
+                    word_under_cursor,
+                    selected_yes,
+                    ..
+                } = mode
+                {
+                    if selected_yes {
+                        app.run_flycomp(command_word, word_under_cursor);
+                    }
                 }
             }
             Action::TabCompletionMoveUp => {
@@ -1865,10 +1916,90 @@ fn capitalize_first(s: &str) -> String {
 /// useful for backward compatibility with old applications. The "Esc+" option is recommended for most users"
 /// In text_buffer.rs, I check if either of them are set for maximal compatibility.
 /// From highest priority to lowest
-static DEFAULT_BINDINGS: LazyLock<[Binding; 90]> = LazyLock::new(|| {
+static DEFAULT_BINDINGS: LazyLock<Vec<Binding>> = LazyLock::new(|| {
     use KeyCode as KC;
     use KeyModifiers as M;
-    [
+    vec![
+        // --- TabCompletionAskForFlycomp bindings ---
+        Binding::new(
+            &expand_variations![
+                KC::Left.into(),
+                KC::Right.into(),
+                KC::Up.into(),
+                KC::Down.into()
+            ],
+            ContextVar::TabCompletionAskForFlycomp.into(),
+            Action::FlycompAskToggleChoice,
+        ),
+        Binding::new(
+            &[KC::Tab.into()],
+            ContextVar::TabCompletionAskForFlycomp.into(),
+            Action::FlycompAskToggleChoice,
+        ),
+        Binding::new(
+            &[KC::Enter.into()],
+            ContextVar::TabCompletionAskForFlycomp.into(),
+            Action::FlycompAskAcceptChoice,
+        ),
+        Binding::new(
+            &[KC::Esc.into()],
+            ContextVar::TabCompletionAskForFlycomp.into(),
+            Action::EscapeToNormalMode,
+        ),
+        Binding::new(
+            &[
+                M::CONTROL + KC::Char('c').into(),
+                M::META + KC::Char('c').into(),
+                M::SUPER + KC::Char('c').into(),
+            ],
+            ContextVar::TabCompletionAskForFlycomp.into(),
+            Action::EscapeToNormalMode,
+        ),
+        // --- TabCompletionRunningFlycomp bindings ---
+        Binding::new(
+            &[KC::Esc.into()],
+            ContextVar::TabCompletionRunningFlycomp.into(),
+            Action::EscapeToNormalMode,
+        ),
+        Binding::new(
+            &[
+                M::CONTROL + KC::Char('c').into(),
+                M::META + KC::Char('c').into(),
+                M::SUPER + KC::Char('c').into(),
+            ],
+            ContextVar::TabCompletionRunningFlycomp.into(),
+            Action::EscapeToNormalMode,
+        ),
+        // --- TabCompletionFlycompResult bindings ---
+        Binding::new(
+            &[KC::Esc.into(), KC::Enter.into(), KC::Backspace.into()],
+            ContextVar::TabCompletionFlycompResult.into(),
+            Action::EscapeToNormalMode,
+        ),
+        Binding::new(
+            &expand_variations![
+                KC::Left.into(),
+                KC::Right.into(),
+                KC::Up.into(),
+                KC::Down.into()
+            ],
+            ContextVar::TabCompletionFlycompResult.into(),
+            Action::EscapeToNormalMode,
+        ),
+        Binding::new(
+            &[
+                M::CONTROL + KC::Char('c').into(),
+                M::META + KC::Char('c').into(),
+                M::SUPER + KC::Char('c').into(),
+            ],
+            ContextVar::TabCompletionFlycompResult.into(),
+            Action::EscapeToNormalMode,
+        ),
+        Binding::new(
+            &[KeyEventMatch::AnyCharAndMods(M::empty())],
+            ContextVar::TabCompletionFlycompResult.into(),
+            Action::EscapeToNormalMode,
+        ),
         Binding::new(
             &[KC::Down.into()],
             ContextVar::AgentOutputSelection.into(),
@@ -2844,48 +2975,6 @@ impl<'a> App<'a> {
 
         let key = apply_remappings(key, &self.settings.key_remappings);
         log::trace!("Key event after remapping: {:?}", key);
-
-        // Intercept keys for flycomp modes
-        match &mut self.content_mode {
-            ContentMode::TabCompletionAskForFlycomp {
-                command_word,
-                word_under_cursor,
-                selected_yes,
-            } => {
-                match key.code {
-                    KeyCode::Tab | KeyCode::Left | KeyCode::Right | KeyCode::Up | KeyCode::Down => {
-                        *selected_yes = !*selected_yes;
-                    }
-                    KeyCode::Esc => {
-                        self.content_mode = ContentMode::Normal;
-                    }
-                    KeyCode::Enter => {
-                        if *selected_yes {
-                            let cmd = command_word.clone();
-                            let wuc = word_under_cursor.clone();
-                            self.run_flycomp(cmd, wuc);
-                        } else {
-                            self.content_mode = ContentMode::Normal;
-                        }
-                    }
-                    _ => {}
-                }
-                return;
-            }
-            ContentMode::TabCompletionRunningFlycomp { .. } => {
-                if key.code == KeyCode::Esc {
-                    // Cancel by returning to normal mode
-                    self.content_mode = ContentMode::Normal;
-                }
-                return;
-            }
-            ContentMode::TabCompletionFlycompResult { .. } => {
-                // Any key exits back to normal editing
-                self.content_mode = ContentMode::Normal;
-                return;
-            }
-            _ => {}
-        }
 
         // Evaluate every context variable once up front, so each variable's
         // condition runs at most once per key press regardless of how many

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1404,6 +1404,9 @@ impl<'a> App<'a> {
         let cmd_word = alias_expanded_command_word;
         let start_time = std::time::Instant::now();
         let thread_handle = std::thread::spawn(move || {
+            unsafe {
+                libc::signal(libc::SIGCHLD, libc::SIG_DFL);
+            }
             flycomp::generate_completion_output(
                 &cmd_word,
                 flycomp::OutputFormat::Bash,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1332,18 +1332,30 @@ impl<'a> App<'a> {
                                     "Failed to evaluate synthesized completion script: {:?}",
                                     e
                                 );
+                                let error_message = format!(
+                                    "Failed to load script:\n  - {}",
+                                    e.chain()
+                                        .map(|c| c.to_string())
+                                        .collect::<Vec<_>>()
+                                        .join("\n  - ")
+                                );
                                 self.content_mode = ContentMode::TabCompletionFlycompResult {
                                     command_word,
-                                    error_message: format!("Failed to load script: {}", e),
+                                    error_message,
                                 };
                             }
                         }
                     }
                     Ok(Err(e)) => {
                         log::warn!("flycomp failed for command '{}': {:?}", command_word, e);
+                        let error_message = e
+                            .chain()
+                            .map(|c| c.to_string())
+                            .collect::<Vec<_>>()
+                            .join("\n  - ");
                         self.content_mode = ContentMode::TabCompletionFlycompResult {
                             command_word,
-                            error_message: e.to_string(),
+                            error_message,
                         };
                     }
                     Err(join_err) => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1319,6 +1319,23 @@ impl<'a> App<'a> {
                 match thread_handle.join() {
                     Ok(Ok(script)) => {
                         log::info!("flycomp succeeded for command '{}'", command_word);
+                        let output_dir = self.settings.flycomp_output.as_deref();
+                        match crate::bash_funcs::resolve_and_write_completion_script(
+                            &command_word,
+                            &script,
+                            output_dir,
+                        ) {
+                            Ok(write_path) => {
+                                log::info!(
+                                    "Wrote synthesized completion script to '{}'",
+                                    write_path.display()
+                                );
+                            }
+                            Err(e) => {
+                                log::error!("Failed to write completion script: {}", e);
+                            }
+                        }
+
                         match crate::bash_funcs::evaluate_shell_string(&script) {
                             Ok(_) => {
                                 log::info!(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -326,6 +326,8 @@ pub(crate) enum ContentMode {
         command_word: String,
         word_under_cursor: String,
         selected_yes: bool,
+        sandbox: bool,
+        dump_path: String,
     },
     TabCompletionRunningFlycomp {
         command_word: String,

--- a/src/app/tab_completion.rs
+++ b/src/app/tab_completion.rs
@@ -1099,10 +1099,19 @@ impl App<'_> {
                 .unwrap_or("")
                 .to_string();
 
+            let output_dir = self.settings.flycomp_output.as_deref();
+            let dump_path =
+                crate::bash_funcs::resolve_completion_script_path(&command_word, output_dir)
+                    .to_string_lossy()
+                    .into_owned();
+            let sandbox = crate::bash_funcs::is_bwrap_available();
+
             self.content_mode = ContentMode::TabCompletionAskForFlycomp {
                 command_word,
                 word_under_cursor: wuc_substring.s.clone(),
                 selected_yes: true,
+                sandbox,
+                dump_path,
             };
             return;
         }

--- a/src/app/tab_completion.rs
+++ b/src/app/tab_completion.rs
@@ -498,7 +498,9 @@ fn gen_completions_uncomitted(
             }
             CompType::FilenameExpansion => {
                 if auto_started && word_under_cursor.as_ref().trim().is_empty() {
-                    log::debug!("Skipping FilenameExpansion because auto_started is true and word_under_cursor is empty");
+                    log::debug!(
+                        "Skipping FilenameExpansion because auto_started is true and word_under_cursor is empty"
+                    );
                     continue;
                 }
                 log::debug!(
@@ -529,7 +531,9 @@ fn gen_completions_uncomitted(
             }
             CompType::FuzzyFilenameExpansion => {
                 if auto_started && word_under_cursor.as_ref().trim().is_empty() {
-                    log::debug!("Skipping FuzzyFilenameExpansion because auto_started is true and word_under_cursor is empty");
+                    log::debug!(
+                        "Skipping FuzzyFilenameExpansion because auto_started is true and word_under_cursor is empty"
+                    );
                     continue;
                 }
                 log::debug!(
@@ -1104,7 +1108,7 @@ impl App<'_> {
                 crate::bash_funcs::resolve_completion_script_path(&command_word, output_dir)
                     .to_string_lossy()
                     .into_owned();
-            let sandbox = crate::bash_funcs::is_bwrap_available();
+            let sandbox = flycomp::is_sandboxing_available();
 
             self.content_mode = ContentMode::TabCompletionAskForFlycomp {
                 command_word,

--- a/src/app/tab_completion.rs
+++ b/src/app/tab_completion.rs
@@ -1199,6 +1199,18 @@ impl App<'_> {
             // Child process
             unsafe {
                 libc::setsid();
+                // Reset common signals to default so the child process terminates cleanly and instantly on signals.
+                for sig in &[
+                    libc::SIGINT,
+                    libc::SIGTERM,
+                    libc::SIGHUP,
+                    libc::SIGQUIT,
+                    libc::SIGTSTP,
+                    libc::SIGTTIN,
+                    libc::SIGTTOU,
+                ] {
+                    libc::signal(*sig, libc::SIG_DFL);
+                }
                 libc::close(read_fd);
                 let dev_null =
                     libc::open(b"/dev/null\0".as_ptr() as *const libc::c_char, libc::O_RDWR);

--- a/src/app/tab_completion.rs
+++ b/src/app/tab_completion.rs
@@ -497,8 +497,8 @@ fn gen_completions_uncomitted(
                 }
             }
             CompType::FilenameExpansion => {
-                if auto_started {
-                    log::debug!("Skipping FilenameExpansion because auto_started is true");
+                if auto_started && word_under_cursor.as_ref().trim().is_empty() {
+                    log::debug!("Skipping FilenameExpansion because auto_started is true and word_under_cursor is empty");
                     continue;
                 }
                 log::debug!(
@@ -528,8 +528,8 @@ fn gen_completions_uncomitted(
                 }
             }
             CompType::FuzzyFilenameExpansion => {
-                if auto_started {
-                    log::debug!("Skipping FuzzyFilenameExpansion because auto_started is true");
+                if auto_started && word_under_cursor.as_ref().trim().is_empty() {
+                    log::debug!("Skipping FuzzyFilenameExpansion because auto_started is true and word_under_cursor is empty");
                     continue;
                 }
                 log::debug!(

--- a/src/app/tab_completion.rs
+++ b/src/app/tab_completion.rs
@@ -1198,6 +1198,7 @@ impl App<'_> {
         if pid == 0 {
             // Child process
             unsafe {
+                libc::setsid();
                 libc::close(read_fd);
                 let dev_null =
                     libc::open(b"/dev/null\0".as_ptr() as *const libc::c_char, libc::O_RDWR);

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -806,17 +806,50 @@ impl<'a> App<'a> {
             ContentMode::TabCompletionAskForFlycomp {
                 command_word,
                 selected_yes,
+                sandbox,
+                dump_path,
                 ..
             } if self.mode.is_running() => {
                 content.newline();
+                let sandbox_str = if *sandbox { "sandboxed" } else { "unsandboxed" };
                 content.write_tagged_span(&TaggedSpan::new(
                     Span::styled(
                         format!(
-                            "No completion script found for '{}'. Run flycomp to synthesize one? ",
-                            command_word
+                            "No completion script found for '{}'. Run flycomp ({}) to synthesize one?",
+                            command_word, sandbox_str
                         ),
-                        Style::default().fg(Color::Yellow),
+                        self.settings.colour_palette.normal_text(),
                     ),
+                    Tag::Normal,
+                ));
+                content.newline();
+                content.write_tagged_span(&TaggedSpan::new(
+                    Span::styled(
+                        "  Would dump to: ",
+                        self.settings.colour_palette.normal_text(),
+                    ),
+                    Tag::Normal,
+                ));
+                content.write_tagged_span(&TaggedSpan::new(
+                    Span::styled(
+                        dump_path.to_string(),
+                        self.settings.colour_palette.key_sequence_style(),
+                    ),
+                    Tag::Normal,
+                ));
+                content.newline();
+                content.write_tagged_span(&TaggedSpan::new(
+                    Span::styled(
+                        ">",
+                        self.settings
+                            .colour_palette
+                            .normal_text()
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Tag::Normal,
+                ));
+                content.write_tagged_span(&TaggedSpan::new(
+                    Span::styled("  Proceed? ", self.settings.colour_palette.normal_text()),
                     Tag::Normal,
                 ));
 

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -871,15 +871,18 @@ impl<'a> App<'a> {
                 content.newline();
                 content.write_tagged_span(&TaggedSpan::new(
                     Span::styled(
-                        format!("flycomp was not successful for '{}': ", command_word),
+                        format!("flycomp was not successful for '{}':", command_word),
                         Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                     ),
                     Tag::Normal,
                 ));
-                content.write_tagged_span(&TaggedSpan::new(
-                    Span::styled(error_message.clone(), Style::default().fg(Color::LightRed)),
-                    Tag::Normal,
-                ));
+                for line in error_message.lines() {
+                    content.newline();
+                    content.write_tagged_span(&TaggedSpan::new(
+                        Span::styled(line.to_string(), Style::default().fg(Color::LightRed)),
+                        Tag::Normal,
+                    ));
+                }
                 content.newline();
                 content.write_tagged_span(&TaggedSpan::new(
                     Span::styled(

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -130,7 +130,8 @@ impl CommandWordInfo {
                     format!("builtin: {}", command)
                 }
             }
-            CommandWordInfo::File { path, .. } => format!("file: {}", path),
+            // Most of them are files so this cleans things up
+            CommandWordInfo::File { path, .. } => path.clone(),
             CommandWordInfo::Function {
                 source_file, line, ..
             } => match (source_file, line) {

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -884,10 +884,16 @@ pub fn evaluate_shell_string(script: &str) -> Result<()> {
         let script_cstr = std::ffi::CString::new(script)?;
         let allocated_ptr = bash_symbols::xmalloc_cstr(&script_cstr);
         let from_file_cstr = std::ffi::CString::new("flycomp")?;
+
         #[cfg(not(feature = "pre_bash_4_4"))]
-        bash_symbols::evalstring(allocated_ptr, from_file_cstr.as_ptr(), 0);
+        let flags = bash_symbols::SEVAL_NOHIST | bash_symbols::SEVAL_NOOPTIMIZE;
         #[cfg(feature = "pre_bash_4_4")]
-        bash_symbols::parse_and_execute(allocated_ptr, from_file_cstr.as_ptr(), 0);
+        let flags = bash_symbols::SEVAL_NOHIST;
+
+        #[cfg(not(feature = "pre_bash_4_4"))]
+        bash_symbols::evalstring(allocated_ptr, from_file_cstr.as_ptr(), flags);
+        #[cfg(feature = "pre_bash_4_4")]
+        bash_symbols::parse_and_execute(allocated_ptr, from_file_cstr.as_ptr(), flags);
         Ok(())
     }
 }

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -830,7 +830,18 @@ pub fn useful_compspec_ran(command_word: &str) -> bool {
             Ok(cstr) => cstr,
             Err(_) => return false,
         };
-        let compspec_ptr = bash_symbols::progcomp_search(command_word_cstr.as_ptr());
+        let mut compspec_ptr = bash_symbols::progcomp_search(command_word_cstr.as_ptr());
+        if compspec_ptr.is_null() {
+            // Basename fallback search (matches bash's own logic in pcomplete.c)
+            if let Some(pos) = command_word.rfind('/') {
+                let basename = &command_word[pos + 1..];
+                if !basename.is_empty() {
+                    if let Ok(basename_cstr) = std::ffi::CString::new(basename) {
+                        compspec_ptr = bash_symbols::progcomp_search(basename_cstr.as_ptr());
+                    }
+                }
+            }
+        }
         if compspec_ptr.is_null() {
             log::info!(
                 "useful_compspec_ran: no registered compspec found for '{}' (default/fallback)",
@@ -1307,14 +1318,26 @@ pub fn resolve_and_write_completion_script(
     let output_dir = flycomp_output.unwrap_or("~/.local/share/bash-completion/completions/");
     let expanded_dir = fully_expand_path(output_dir);
 
-    // Find non-conflicting filename by appending _v2, _v3, etc.
-    let mut final_name = file_name.to_string();
+    // Sanitize the command name
+    let sanitized_name: String = file_name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    // Find non-conflicting filename by appending .v2, .v3, etc.
+    let mut final_name = format!("{}.flycomp.bash", sanitized_name);
     let mut suffix_counter = 2;
     while std::path::Path::new(&expanded_dir)
         .join(&final_name)
         .exists()
     {
-        final_name = format!("{}_v{}", file_name, suffix_counter);
+        final_name = format!("{}.v{}.flycomp.bash", sanitized_name, suffix_counter);
         suffix_counter += 1;
     }
     let write_path = std::path::Path::new(&expanded_dir).join(&final_name);
@@ -2028,7 +2051,10 @@ mod tests {
             resolve_and_write_completion_script("git", script_content, Some(flycomp_output_str))
                 .unwrap();
         assert!(path1.exists());
-        assert_eq!(path1.file_name().unwrap().to_str().unwrap(), "git");
+        assert_eq!(
+            path1.file_name().unwrap().to_str().unwrap(),
+            "git.flycomp.bash"
+        );
         let content1 = std::fs::read_to_string(&path1).unwrap();
         assert_eq!(content1, script_content);
 
@@ -2038,18 +2064,24 @@ mod tests {
             resolve_and_write_completion_script("git", script_content_2, Some(flycomp_output_str))
                 .unwrap();
         assert!(path2.exists());
-        assert_eq!(path2.file_name().unwrap().to_str().unwrap(), "git_v2");
+        assert_eq!(
+            path2.file_name().unwrap().to_str().unwrap(),
+            "git.v2.flycomp.bash"
+        );
         let content2 = std::fs::read_to_string(&path2).unwrap();
         assert_eq!(content2, script_content_2);
 
         // Test path expansion (e.g. command_word is alias and expansion is longer)
         // Note: "gst" -> "git status" -> cmd_word is "git".
-        // Since "git" and "git_v2" already exist, this should resolve to "git_v3".
+        // Since "git.flycomp.bash" and "git.v2.flycomp.bash" already exist, this should resolve to "git.v3.flycomp.bash".
         let path3 =
             resolve_and_write_completion_script("gst", "echo 'gst'", Some(flycomp_output_str))
                 .unwrap();
         assert!(path3.exists());
-        assert_eq!(path3.file_name().unwrap().to_str().unwrap(), "git_v3");
+        assert_eq!(
+            path3.file_name().unwrap().to_str().unwrap(),
+            "git.v3.flycomp.bash"
+        );
         let content3 = std::fs::read_to_string(&path3).unwrap();
         assert_eq!(content3, "echo 'gst'");
 
@@ -2061,7 +2093,10 @@ mod tests {
         )
         .unwrap();
         assert!(path4.exists());
-        assert_eq!(path4.file_name().unwrap().to_str().unwrap(), "my_command");
+        assert_eq!(
+            path4.file_name().unwrap().to_str().unwrap(),
+            "my_command.flycomp.bash"
+        );
 
         // Clean up
         let _ = std::fs::remove_dir_all(&flycomp_output_dir);

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -1291,11 +1291,25 @@ pub fn fully_expand_path(p: &str) -> String {
     }
 }
 
-pub fn resolve_and_write_completion_script(
+pub fn is_bwrap_available() -> bool {
+    match std::process::Command::new("bwrap")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    {
+        Ok(mut child) => {
+            let _ = child.wait();
+            true
+        }
+        _ => false,
+    }
+}
+
+pub fn resolve_completion_script_path(
     command_word: &str,
-    script: &str,
     flycomp_output: Option<&str>,
-) -> Result<std::path::PathBuf, std::io::Error> {
+) -> std::path::PathBuf {
     // Resolve the alias-expanded target command name
     let poss_alias = find_alias(command_word);
     let alias_def = poss_alias
@@ -1340,12 +1354,19 @@ pub fn resolve_and_write_completion_script(
         final_name = format!("{}.v{}.flycomp.bash", sanitized_name, suffix_counter);
         suffix_counter += 1;
     }
-    let write_path = std::path::Path::new(&expanded_dir).join(&final_name);
+    std::path::Path::new(&expanded_dir).join(&final_name)
+}
 
-    // Create directories recursively and write the file
-    std::fs::create_dir_all(&expanded_dir)?;
+pub fn resolve_and_write_completion_script(
+    command_word: &str,
+    script: &str,
+    flycomp_output: Option<&str>,
+) -> Result<std::path::PathBuf, std::io::Error> {
+    let write_path = resolve_completion_script_path(command_word, flycomp_output);
+    if let Some(parent) = write_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     std::fs::write(&write_path, script)?;
-
     Ok(write_path)
 }
 
@@ -2097,6 +2118,42 @@ mod tests {
             path4.file_name().unwrap().to_str().unwrap(),
             "my_command.flycomp.bash"
         );
+
+        // Clean up
+        let _ = std::fs::remove_dir_all(&flycomp_output_dir);
+    }
+
+    #[test]
+    fn test_resolve_completion_script_path() {
+        let unique_dir_name = format!(
+            "flyline_test_resolve_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let flycomp_output_dir = std::env::temp_dir().join(unique_dir_name);
+        let flycomp_output_str = flycomp_output_dir.to_str().unwrap();
+
+        // 1. Path resolution without existing file
+        let path1 = resolve_completion_script_path("git", Some(flycomp_output_str));
+        assert_eq!(
+            path1.file_name().unwrap().to_str().unwrap(),
+            "git.flycomp.bash"
+        );
+        assert!(!path1.exists()); // should not create file
+
+        // Create the directory and write a file to simulate collision
+        std::fs::create_dir_all(&flycomp_output_dir).unwrap();
+        std::fs::write(&path1, "test").unwrap();
+
+        // 2. Collision avoidance check
+        let path2 = resolve_completion_script_path("git", Some(flycomp_output_str));
+        assert_eq!(
+            path2.file_name().unwrap().to_str().unwrap(),
+            "git.v2.flycomp.bash"
+        );
+        assert!(!path2.exists());
 
         // Clean up
         let _ = std::fs::remove_dir_all(&flycomp_output_dir);

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -1274,6 +1274,52 @@ pub fn fully_expand_path(p: &str) -> String {
     }
 }
 
+pub fn resolve_and_write_completion_script(
+    command_word: &str,
+    script: &str,
+    flycomp_output: Option<&str>,
+) -> Result<std::path::PathBuf, std::io::Error> {
+    // Resolve the alias-expanded target command name
+    let poss_alias = find_alias(command_word);
+    let alias_def = poss_alias
+        .as_deref()
+        .filter(|alias| !alias.is_empty())
+        .unwrap_or(command_word);
+    let cmd_word = alias_def
+        .split_whitespace()
+        .next()
+        .unwrap_or(alias_def)
+        .to_string();
+
+    // Get the base command filename
+    let file_name = std::path::Path::new(&cmd_word)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or(&cmd_word);
+
+    // Resolve output completions directory
+    let output_dir = flycomp_output.unwrap_or("~/.local/share/bash-completion/completions/");
+    let expanded_dir = fully_expand_path(output_dir);
+
+    // Find non-conflicting filename by appending _v2, _v3, etc.
+    let mut final_name = file_name.to_string();
+    let mut suffix_counter = 2;
+    while std::path::Path::new(&expanded_dir)
+        .join(&final_name)
+        .exists()
+    {
+        final_name = format!("{}_v{}", file_name, suffix_counter);
+        suffix_counter += 1;
+    }
+    let write_path = std::path::Path::new(&expanded_dir).join(&final_name);
+
+    // Create directories recursively and write the file
+    std::fs::create_dir_all(&expanded_dir)?;
+    std::fs::write(&write_path, script)?;
+
+    Ok(write_path)
+}
+
 // QuoteType can be  in the middle  of a word (i.e.  backslash)
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
 pub enum QuoteType {
@@ -1956,6 +2002,63 @@ mod tests {
         detect_and_convert_inline_descriptions(&mut comps, &flags);
         assert_eq!(comps[0], "port\tList port mappings");
         assert_eq!(comps[1], "ps\tList containers");
+    }
+
+    #[test]
+    fn test_resolve_and_write_completion_script() {
+        let unique_dir_name = format!(
+            "flyline_test_completions_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let flycomp_output_dir = std::env::temp_dir().join(unique_dir_name);
+        let flycomp_output_str = flycomp_output_dir.to_str().unwrap();
+
+        // Test normal writing
+        let script_content = "echo 'hello'";
+        let path1 =
+            resolve_and_write_completion_script("git", script_content, Some(flycomp_output_str))
+                .unwrap();
+        assert!(path1.exists());
+        assert_eq!(path1.file_name().unwrap().to_str().unwrap(), "git");
+        let content1 = std::fs::read_to_string(&path1).unwrap();
+        assert_eq!(content1, script_content);
+
+        // Test collision avoidance
+        let script_content_2 = "echo 'world'";
+        let path2 =
+            resolve_and_write_completion_script("git", script_content_2, Some(flycomp_output_str))
+                .unwrap();
+        assert!(path2.exists());
+        assert_eq!(path2.file_name().unwrap().to_str().unwrap(), "git_v2");
+        let content2 = std::fs::read_to_string(&path2).unwrap();
+        assert_eq!(content2, script_content_2);
+
+        // Test path expansion (e.g. command_word is alias and expansion is longer)
+        // Note: "gst" -> "git status" -> cmd_word is "git".
+        // Since "git" and "git_v2" already exist, this should resolve to "git_v3".
+        let path3 =
+            resolve_and_write_completion_script("gst", "echo 'gst'", Some(flycomp_output_str))
+                .unwrap();
+        assert!(path3.exists());
+        assert_eq!(path3.file_name().unwrap().to_str().unwrap(), "git_v3");
+        let content3 = std::fs::read_to_string(&path3).unwrap();
+        assert_eq!(content3, "echo 'gst'");
+
+        // Test command word with path
+        let path4 = resolve_and_write_completion_script(
+            "/usr/bin/my_command",
+            "echo 'my_command'",
+            Some(flycomp_output_str),
+        )
+        .unwrap();
+        assert!(path4.exists());
+        assert_eq!(path4.file_name().unwrap().to_str().unwrap(), "my_command");
+
+        // Clean up
+        let _ = std::fs::remove_dir_all(&flycomp_output_dir);
     }
 }
 

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -1291,21 +1291,6 @@ pub fn fully_expand_path(p: &str) -> String {
     }
 }
 
-pub fn is_bwrap_available() -> bool {
-    match std::process::Command::new("bwrap")
-        .arg("--version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-    {
-        Ok(mut child) => {
-            let _ = child.wait();
-            true
-        }
-        _ => false,
-    }
-}
-
 pub fn resolve_completion_script_path(
     command_word: &str,
     flycomp_output: Option<&str>,

--- a/src/bash_symbols.rs
+++ b/src/bash_symbols.rs
@@ -5,6 +5,9 @@ pub const EOF: c_int = -1;
 
 pub const BUILTIN_ENABLED: c_int = 0x01;
 
+pub const SEVAL_NOHIST: c_int = 0x004;
+pub const SEVAL_NOOPTIMIZE: c_int = 0x400;
+
 /* A structure which represents a word. */
 // typedef struct word_desc {
 //   char *word;		/* Zero terminated string. */

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -512,6 +512,7 @@ enum Commands {
         #[arg(long = "num-suggestion-rows", value_name = "NUM")]
         num_suggestion_rows: Option<u16>,
         /// Directory where flycomp output should be saved.
+        /// You should source the completions from this directory in your bashrc so flyline can use them next time.
         #[arg(long = "flycomp-output", value_name = "DIR")]
         flycomp_output: Option<String>,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -511,6 +511,9 @@ enum Commands {
         /// Maximum number of suggestion rows to render for tab-completion lists.
         #[arg(long = "num-suggestion-rows", value_name = "NUM")]
         num_suggestion_rows: Option<u16>,
+        /// Directory where flycomp output should be saved.
+        #[arg(long = "flycomp-output", value_name = "DIR")]
+        flycomp_output: Option<String>,
     },
     /// Configure mouse options and debugging.
     #[command(name = "mouse", verbatim_doc_comment)]
@@ -1194,6 +1197,7 @@ impl Flyline {
                         use_flycomp,
                         sort_order,
                         num_suggestion_rows,
+                        flycomp_output,
                     }) => {
                         if let Some(enabled) = auto_suggest {
                             log::info!("Auto tab-completion suggestions set to {}", enabled);
@@ -1215,6 +1219,10 @@ impl Flyline {
                             }
                             log::info!("Suggestion row limit set to {}", num);
                             self.settings.num_suggestion_rows = num;
+                        }
+                        if let Some(path) = flycomp_output {
+                            log::info!("Flycomp output directory set to '{}'", path);
+                            self.settings.flycomp_output = Some(path);
                         }
                     }
                     Some(Commands::Time { format }) => {

--- a/src/mouse_state.rs
+++ b/src/mouse_state.rs
@@ -13,7 +13,7 @@ pub enum ClickCount {
 pub enum PointerShape {
     Default,
     Text,
-    Grab,
+    Pointer,
     Grabbing,
 }
 
@@ -22,7 +22,7 @@ impl PointerShape {
         match self {
             PointerShape::Default => "default",
             PointerShape::Text => "text",
-            PointerShape::Grab => "grab",
+            PointerShape::Pointer => "pointer",
             PointerShape::Grabbing => "grabbing",
         }
     }
@@ -220,7 +220,7 @@ impl MouseState {
                     | Tag::TabCompletionScrollBar { .. }
             )
         }) {
-            PointerShape::Grab
+            PointerShape::Pointer
         } else {
             PointerShape::Default
         };

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -191,6 +191,9 @@ pub struct Settings {
     pub auto_suggest: bool,
     /// Whether to use flycomp to synthesize completions.
     pub use_flycomp: bool,
+    /// Optional path to the directory where flycomp output is saved.
+    /// When `None`, defaults to `~/.local/share/bash-completion/completions/`.
+    pub flycomp_output: Option<String>,
     /// How to sort suggestions when fuzzy scores are tied.
     pub suggestion_sort_order: SuggestionSortOrder,
     /// Maximum number of suggestion rows to render for tab-completion lists.
@@ -258,6 +261,7 @@ impl Default for Settings {
             show_animations: true,
             auto_suggest: true,
             use_flycomp: true,
+            flycomp_output: None,
             suggestion_sort_order: SuggestionSortOrder::default(),
             num_suggestion_rows: 15,
             show_inline_history: true,

--- a/tapes/demo_auto_tab_completion.tape
+++ b/tapes/demo_auto_tab_completion.tape
@@ -8,7 +8,7 @@ Set Width 1800
 Source demo_setup.tape
 
 Hide
-Type@5ms " flyline suggestions --auto-suggest true && clear"
+Type@15ms " flyline suggestions --auto-suggest true && clear"
 Enter
 Show
 

--- a/tapes/demo_overview.tape
+++ b/tapes/demo_overview.tape
@@ -9,7 +9,7 @@ Require claude
 
 Hide
 Sleep 50ms
-Type@5ms ` export PATH="/home/john/bin/:$PATH" && flyline suggestions --auto-suggest true && flyline suggestions --num-suggestion-rows 10  && clear`
+Type@15ms ` export PATH="/home/john/bin/:$PATH" && flyline suggestions --auto-suggest true && flyline suggestions --num-suggestion-rows 10  && clear`
 Enter
 Show
 
@@ -19,7 +19,7 @@ Show
 Hide
 Type " clear"
 Enter
-Type@5ms ` clear && echo "flyline is a Bash plugin that brings many improvements. For instance, Intellisense style suggestions:" && echo ""`
+Type@15ms ` clear && echo "flyline is a Bash plugin that brings many improvements. For instance, Intellisense style suggestions:" && echo ""`
 Enter
 Sleep 100ms
 Show
@@ -50,7 +50,7 @@ Sleep 800ms
 
 Hide
 Ctrl+C
-Type@5ms ` flyline suggestions --auto-suggest false && clear`
+Type@15ms ` flyline suggestions --auto-suggest false && clear`
 Enter
 Show
 
@@ -62,10 +62,10 @@ Show
 Hide
 Sleep 100ms
 Ctrl+C
-Type@5ms ` cd ~/foo/bar/baz`
+Type@15ms ` cd ~/foo/bar/baz`
 Enter
 Sleep 100ms
-Type@5ms ` clear && echo "Navigate using your prompt:" && echo ""`
+Type@15ms ` clear && echo "Navigate using your prompt:" && echo ""`
 Enter
 Show
 
@@ -82,7 +82,7 @@ Enter
 Sleep 1000ms
 
 Hide
-Type@5ms ` cd ~/`
+Type@15ms ` cd ~/`
 Enter
 Show
 
@@ -94,7 +94,7 @@ Show
 Hide
 Sleep 100ms
 Ctrl+C
-Type@5ms ` clear`
+Type@15ms ` clear`
 Enter
 Type `# Fuzzy history search`
 Show
@@ -126,7 +126,7 @@ Sleep 800ms
 Hide
 Sleep 100ms
 Ctrl+C
-Type@5ms ` clear && echo "flyline can interface with your AI agent to help you write commands:" && echo ""`
+Type@15ms ` clear && echo "flyline can interface with your AI agent to help you write commands:" && echo ""`
 Enter
 Show
 
@@ -152,7 +152,7 @@ Enter
 Hide
 Sleep 100ms
 Ctrl+C
-Type@5ms ` clear && echo "flyline's deep Bash integration allows tooltips as you type:" && echo ""`
+Type@15ms ` clear && echo "flyline's deep Bash integration allows tooltips as you type:" && echo ""`
 Enter
 Show
 
@@ -171,9 +171,9 @@ Sleep 2000ms
 
 Hide
 Ctrl+C
-Type@5ms ` flyline editor --auto-close-chars true `
+Type@15ms ` flyline editor --auto-close-chars true `
 Enter
-Type@5ms ` clear && echo "flyline can intelligently close opening quotes and brackets:" && echo ""`
+Type@15ms ` clear && echo "flyline can intelligently close opening quotes and brackets:" && echo ""`
 Enter
 Show
 
@@ -192,7 +192,7 @@ Sleep 800ms
 
 Hide
 Ctrl+C
-Type@5ms ` flyline editor --auto-close-chars false `
+Type@15ms ` flyline editor --auto-close-chars false `
 Enter
 Show
 
@@ -203,7 +203,7 @@ Show
 
 Hide
 Ctrl+C
-Type@5ms ` clear && echo "flyline supports code editor-like text selection" && echo "This has nothing to do with the terminal emulator, it's all inside of Bash!" && echo ""`
+Type@15ms ` clear && echo "flyline supports code editor-like text selection" && echo "This has nothing to do with the terminal emulator, it's all inside of Bash!" && echo ""`
 Enter
 Show
 
@@ -231,7 +231,7 @@ Sleep 800ms
 
 Hide
 Ctrl+C
-Type@5ms ` clear && echo "Check out the rest of this README to learn about flyline's other features! Like dynamic prompts:" && echo ""`
+Type@15ms ` clear && echo "Check out the rest of this README to learn about flyline's other features! Like dynamic prompts:" && echo ""`
 Enter
 Show
 


### PR DESCRIPTION
Add a configurable flycomp_output setting/CLI flag and write synthesized completion scripts to disk on success.

Improve flycomp error rendering (multi-line) and adjust shell-script evaluation flags; add basename fallback when detecting registered compspecs.

Minor UX/maintenance tweaks: tab-completion child signal/session setup, mouse pointer-shape rename, demo tape timing updates, and bump flycomp git revision.