### PR TITLE
docs: update docs-check.prompt.md timestamp

### DIFF
--- a/.github/prompts/docs-check.prompt.md
+++ b/.github/prompts/docs-check.prompt.md
@@ -18,7 +18,7 @@ The source code is the source of truth. Specifically verify:
 Fix any inconsistencies you find by editing the documentation files directly.
 Do not modify any Rust source code — only update documentation (README.md files, doc comments, and example scripts).
 
-Update this line with the last time you ran: never.
+Update this line with the last time you ran: Mon Jun 22 19:19:56 UTC 2026.
 If everything is already consistent, make no changes apart from this file.
 There might not be any changes to make since you have run on previous events.
 You should focus on the commits made since the last time you ran.


### PR DESCRIPTION
I ran the checks defined in `.github/prompts/docs-check.prompt.md` and verified that defaults, keyboard shortcuts, flags, and feature descriptions in the documentation are consistent with the source code (`src/cli.rs`, `src/settings.rs`, etc.). No inconsistencies or typos were found in the examples, tutorial, or README. Thus, the only change made was updating the `last time you ran` timestamp to the current date/time in the prompt file itself, as requested by the instructions.

---
*PR created automatically by Jules for task [17638162366119790230](https://jules.google.com/task/17638162366119790230) started by @HalFrgrd*