### PR TITLE
docs: update timestamp in docs-check prompt

### DIFF
--- a/.github/prompts/docs-check.prompt.md
+++ b/.github/prompts/docs-check.prompt.md
@@ -18,7 +18,7 @@ The source code is the source of truth. Specifically verify:
 Fix any inconsistencies you find by editing the documentation files directly.
 Do not modify any Rust source code — only update documentation (README.md files, doc comments, and example scripts).
 
-Update this line with the last time you ran: Mon Jun 22 19:19:56 UTC 2026.
+Update this line with the last time you ran: Mon Jun 29 19:16:15 UTC 2026.
 If everything is already consistent, make no changes apart from this file.
 There might not be any changes to make since you have run on previous events.
 You should focus on the commits made since the last time you ran.


### PR DESCRIPTION
Updated the timestamp in `.github/prompts/docs-check.prompt.md`.

Verified that:
- Default values in README match actual defaults in `src/cli.rs`.
- Keybindings in `tutorial.rs` and `README.md` are consistent with code.
- Command-line flag names and descriptions in the `README.md` are consistent with `src/cli.rs`.
- Example scripts in `examples/` are accurate.
- `flyline mouse --mode disabled` is valid and correct.

---
*PR created automatically by Jules for task [11341510630759137024](https://jules.google.com/task/11341510630759137024) started by @HalFrgrd*