### PR TITLE
Bash FFI lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,7 @@ dependencies = [
  "libc",
  "log",
  "lscolors",
+ "parking_lot",
  "parse-style",
  "pulldown-cmark",
  "rand 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ crossterm = { git = "https://github.com/HalFrgrd/crossterm.git", rev = "78def955
 chrono = { version = "0.4" }
 serde = { version = "1", features = ["derive"] }
 log = "0.4"
+parking_lot = "0.12"
 ansi-to-tui = { git = "https://github.com/HalFrgrd/ansi-to-tui.git", rev = "9101076f8e23010515ff6fe1571bf87a2d0d4abc"}
 libc = "0.2.186"
 anyhow = "1.0.102"

--- a/docs/threads_and_locking.md
+++ b/docs/threads_and_locking.md
@@ -12,14 +12,12 @@ To prevent this, `flyline` enforces a global reentrant lock (`BASH_LOCK`).
 1. **Interactive Session (`get_command`)**:
    - While the user is typing, the main thread **does not** hold the global lock continuously.
    - Background threads (like the cache warming thread `"flyline-warming"`) can run concurrently with input editing.
-   - Both the main thread and background threads must acquire `BASH_LOCK` briefly around individual Bash FFI function calls (e.g., fetching variables, aliases, or running command evaluations).
+   - Both the main thread and background threads must acquire `BASH_LOCK` briefly around individual Bash FFI function calls (e.g., fetching variables, aliases, or running command evaluations) to safely serialize access.
 
 2. **Command Execution**:
-   - When the user presses Enter and Flyline returns control to Bash, the main thread locks `BASH_LOCK` for the entire duration of the command execution.
-   - This blocks background threads from executing Bash FFI functions while Bash is actively running commands.
-   - The lock guard is stored in a thread-local static `COMMAND_LOCK_GUARD` on the main thread.
+   - When the user presses Enter and Flyline returns control to Bash, the background cache warming thread is joined and completed.
+   - Because no background Rust threads remain running or calling Bash FFI functions while Bash is executing command execution C code, the main thread **does not need to hold the lock** during command execution.
 
 3. **Deadlock Prevention**:
    - **Reentrancy**: `BASH_LOCK` is a `parking_lot::ReentrantMutex<()>`, allowing the same thread to acquire it recursively.
-   - **Thread Joining**: The main thread drops the command lock guard *before* joining background threads.
    - **Tab Completion Forking**: The background warming thread is joined and completed *before* calling `fork()` to ensure the child process does not inherit a locked mutex.

--- a/docs/threads_and_locking.md
+++ b/docs/threads_and_locking.md
@@ -1,0 +1,25 @@
+# Threads and Locking
+
+This document briefly explains the threading model and lock lifecycle implemented in `flyline`.
+
+## Concurrency and FFI Safety
+`flyline` runs inside the active host Bash process. Multiple Rust threads (e.g., the background cache warming thread) can potentially access Bash internal APIs or heap structures simultaneously, which causes memory corruption and crashes.
+
+To prevent this, `flyline` enforces a global reentrant lock (`BASH_LOCK`).
+
+## Locking Model
+
+1. **Interactive Session (`get_command`)**:
+   - While the user is typing, the main thread **does not** hold the global lock continuously.
+   - Background threads (like the cache warming thread `"flyline-warming"`) can run concurrently with input editing.
+   - Both the main thread and background threads must acquire `BASH_LOCK` briefly around individual Bash FFI function calls (e.g., fetching variables, aliases, or running command evaluations).
+
+2. **Command Execution**:
+   - When the user presses Enter and Flyline returns control to Bash, the main thread locks `BASH_LOCK` for the entire duration of the command execution.
+   - This blocks background threads from executing Bash FFI functions while Bash is actively running commands.
+   - The lock guard is stored in a thread-local static `COMMAND_LOCK_GUARD` on the main thread.
+
+3. **Deadlock Prevention**:
+   - **Reentrancy**: `BASH_LOCK` is a `parking_lot::ReentrantMutex<()>`, allowing the same thread to acquire it recursively.
+   - **Thread Joining**: The main thread drops the command lock guard *before* joining background threads.
+   - **Tab Completion Forking**: The background warming thread is joined and completed *before* calling `fork()` to ensure the child process does not inherit a locked mutex.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -418,9 +418,13 @@ impl<'a> App<'a> {
         // Join any previous warming thread to prevent multiple active warming threads
         crate::threads::join_threads_by_tag(crate::threads::ThreadTag::Warming);
 
-        let warming_handle = std::thread::spawn(|| {
-            crate::bash_funcs::warm_completion_caches();
-        });
+        let warming_handle = std::thread::Builder::new()
+            .name("flyline-warming".to_string())
+            .spawn(|| {
+                crate::bash_funcs::warm_completion_caches();
+                log::info!("Warming thread finished");
+            })
+            .unwrap();
         crate::threads::register_thread(crate::threads::ThreadTag::Warming, warming_handle);
 
         let mut app = App {
@@ -1251,19 +1255,22 @@ impl<'a> App<'a> {
             }
         }
         let start_time = std::time::Instant::now();
-        let thread_handle = std::thread::spawn(move || {
-            unsafe {
-                libc::signal(libc::SIGCHLD, libc::SIG_DFL);
-            }
-            flycomp::generate_completion_output(
-                &cmd_word,
-                flycomp::OutputFormat::Bash,
-                flycomp::SynthesisStrategy::ManPageOrRunHelp,
-                use_sandbox, // sandbox
-                5000,        // timeout_ms
-                2,           // recurse_limit
-            )
-        });
+        let thread_handle = std::thread::Builder::new()
+            .name("flyline-agent-completion".to_string())
+            .spawn(move || {
+                unsafe {
+                    libc::signal(libc::SIGCHLD, libc::SIG_DFL);
+                }
+                flycomp::generate_completion_output(
+                    &cmd_word,
+                    flycomp::OutputFormat::Bash,
+                    flycomp::SynthesisStrategy::ManPageOrRunHelp,
+                    use_sandbox, // sandbox
+                    5000,        // timeout_ms
+                    2,           // recurse_limit
+                )
+            })
+            .unwrap();
         let shared_handle =
             crate::threads::register_thread(crate::threads::ThreadTag::Flycomp, thread_handle);
         self.content_mode = ContentMode::TabCompletionRunningFlycomp {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -421,8 +421,10 @@ impl<'a> App<'a> {
         let warming_handle = std::thread::Builder::new()
             .name("flyline-warming".to_string())
             .spawn(|| {
+                let _timer = crate::perf::PerfTimer::start("warming_thread");
+                let start = std::time::Instant::now();
                 crate::bash_funcs::warm_completion_caches();
-                log::info!("Warming thread finished");
+                log::info!("Warming thread finished in {:?}", start.elapsed());
             })
             .unwrap();
         crate::threads::register_thread(crate::threads::ThreadTag::Warming, warming_handle);
@@ -863,7 +865,7 @@ impl<'a> App<'a> {
                 if has_executed_non_pointer && !is_pointer_action {
                     continue;
                 }
-                log::debug!("Matched mouse action: {:?}", binding.action);
+                log::trace!("Matched mouse action: {:?}", binding.action);
                 matches.push((binding.context.display(), format!("{:?}", binding.action)));
 
                 let output = binding.action.run(self, mouse);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1256,7 +1256,7 @@ impl<'a> App<'a> {
         }
         let start_time = std::time::Instant::now();
         let thread_handle = std::thread::Builder::new()
-            .name("flyline-agent-completion".to_string())
+            .name("flyline-flycomp".to_string())
             .spawn(move || {
                 unsafe {
                     libc::signal(libc::SIGCHLD, libc::SIG_DFL);

--- a/src/app/tab_completion.rs
+++ b/src/app/tab_completion.rs
@@ -1302,32 +1302,35 @@ impl App<'_> {
             }
 
             // Using a thread here makes it easier to handle polling here and in the main app loop.
-            let thread_handle = std::thread::spawn(move || {
-                let mut file = unsafe { std::fs::File::from_raw_fd(read_fd) };
-                let mut len_buf = [0u8; 8];
-                let res = if std::io::Read::read_exact(&mut file, &mut len_buf).is_err() {
-                    None
-                } else {
-                    let len = u64::from_ne_bytes(len_buf);
-                    let mut data_buf = vec![0u8; len as usize];
-                    if std::io::Read::read_exact(&mut file, &mut data_buf).is_ok() {
-                        serde_json::from_slice(&data_buf).ok().flatten()
-                    } else {
+            let thread_handle = std::thread::Builder::new()
+                .name("flyline-flycomp-reader".to_string())
+                .spawn(move || {
+                    let mut file = unsafe { std::fs::File::from_raw_fd(read_fd) };
+                    let mut len_buf = [0u8; 8];
+                    let res = if std::io::Read::read_exact(&mut file, &mut len_buf).is_err() {
                         None
-                    }
-                };
-                let _ = tx.send(res);
+                    } else {
+                        let len = u64::from_ne_bytes(len_buf);
+                        let mut data_buf = vec![0u8; len as usize];
+                        if std::io::Read::read_exact(&mut file, &mut data_buf).is_ok() {
+                            serde_json::from_slice(&data_buf).ok().flatten()
+                        } else {
+                            None
+                        }
+                    };
+                    let _ = tx.send(res);
 
-                // Reap the child process to prevent zombie processes
-                unsafe {
-                    let mut status = 0;
-                    libc::waitpid(pid, &mut status, 0);
-                    log::info!(
-                        "Tab completion process (pid {}) reaped in reader thread",
-                        pid
-                    );
-                }
-            });
+                    // Reap the child process to prevent zombie processes
+                    unsafe {
+                        let mut status = 0;
+                        libc::waitpid(pid, &mut status, 0);
+                        log::info!(
+                            "Tab completion process (pid {}) reaped in reader thread",
+                            pid
+                        );
+                    }
+                })
+                .unwrap();
 
             crate::threads::register_thread(
                 crate::threads::ThreadTag::TabCompletion,

--- a/src/app/tab_completion.rs
+++ b/src/app/tab_completion.rs
@@ -1303,7 +1303,7 @@ impl App<'_> {
 
             // Using a thread here makes it easier to handle polling here and in the main app loop.
             let thread_handle = std::thread::Builder::new()
-                .name("flyline-flycomp-reader".to_string())
+                .name("flyline-completions".to_string())
                 .spawn(move || {
                     let mut file = unsafe { std::fs::File::from_raw_fd(read_fd) };
                     let mut len_buf = [0u8; 8];

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -146,6 +146,7 @@ impl CommandWordInfo {
 
 #[cfg(not(test))]
 pub fn find_alias(cmd: &str) -> Option<String> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     unsafe {
         let alias_ptr =
             bash_symbols::get_alias_value(std::ffi::CString::new(cmd).unwrap().as_ptr());
@@ -170,6 +171,7 @@ pub fn find_alias(cmd: &str) -> Option<String> {
 
 #[cfg(not(test))]
 fn get_command_info_uncached(cmd: &str) -> CommandWordInfo {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     // If the command word looks like a filename (contains '/' or starts with
     // '~'), expand it first so that tilde and variable expansion are resolved
     // before the lookup.
@@ -323,6 +325,7 @@ pub fn get_command_info(cmd: &str) -> CommandWordInfo {
 
 #[cfg(not(test))]
 pub fn format_shell_var_uncached(name: &str) -> String {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     get_shell_var(name)
         .and_then(|mut var| {
             let (res, output) = with_redirected_stdout(|| unsafe {
@@ -380,6 +383,7 @@ pub fn reset_caches() {
 
 #[cfg(not(test))]
 pub fn get_all_aliases() -> Vec<String> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     // TODO can we extract more info here?
     let mut aliases = Vec::new();
 
@@ -431,6 +435,7 @@ pub fn get_all_reserved_words() -> Vec<String> {
 
 #[cfg(not(test))]
 pub fn get_all_variables_with_prefix(prefix: &str) -> Vec<String> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     let mut variables = Vec::new();
     let prefix_c_str = std::ffi::CString::new(prefix.strip_prefix('$').unwrap_or(prefix)).unwrap();
 
@@ -474,6 +479,7 @@ pub fn get_all_variables_with_prefix(prefix: &str) -> Vec<String> {
 
 #[cfg(not(test))]
 pub fn get_all_shell_functions() -> Vec<String> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     let mut functions = Vec::new();
 
     unsafe {
@@ -510,6 +516,7 @@ pub fn get_all_shell_functions() -> Vec<String> {
 
 #[cfg(not(test))]
 pub fn get_all_shell_builtins() -> Vec<String> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     let mut builtins = Vec::new();
 
     unsafe {
@@ -825,6 +832,7 @@ fn vec_of_strings_from_char_char_ptr(ptr: *mut *mut c_char) -> Vec<String> {
 
 #[cfg(not(test))]
 pub fn useful_compspec_ran(command_word: &str) -> bool {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     unsafe {
         let command_word_cstr = match std::ffi::CString::new(command_word) {
             Ok(cstr) => cstr,
@@ -891,9 +899,10 @@ pub fn useful_compspec_ran(_command_word: &str) -> bool {
 
 #[cfg(not(test))]
 pub fn evaluate_shell_string(script: &str) -> Result<()> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     unsafe {
         let script_cstr = std::ffi::CString::new(script)?;
-        let allocated_ptr = bash_symbols::xmalloc_cstr(&script_cstr);
+        let allocated_ptr = bash_symbols::locked_xmalloc_cstr(&script_cstr);
         let from_file_cstr = std::ffi::CString::new("flycomp")?;
 
         #[cfg(not(feature = "pre_bash_4_4"))]
@@ -922,6 +931,7 @@ pub fn run_programmable_completions(
     cursor_byte_pos: usize,            // 7 since cursor is after "com" in "git com|mi asdf"
     word_under_cursor_byte_end: usize, // 9 since we want the end of "commi"
 ) -> Result<ProgrammableCompleteReturn> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     log::debug!(
         "run_programmable_completions called with\nfull_command='{}'\ncommand_word='{}'\nword_under_cursor='{}'\ncursor_byte_pos={}\nword_under_cursor_byte_end={}",
         full_command,
@@ -946,7 +956,7 @@ pub fn run_programmable_completions(
 
     unsafe {
         let full_command_cstr = std::ffi::CString::new(full_command).unwrap();
-        bash_symbols::rl_line_buffer = bash_symbols::xmalloc_cstr(&full_command_cstr); // git commi asdf
+        bash_symbols::rl_line_buffer = bash_symbols::locked_xmalloc_cstr(&full_command_cstr); // git commi asdf
         bash_symbols::rl_point = cursor_byte_pos as std::ffi::c_int; // 7 ("git com|mi asdf")
         bash_symbols::set_readline_state(bash_symbols::RL_STATE_COMPLETING);
 
@@ -1160,6 +1170,7 @@ pub fn print_copt_flags(flag: c_int) {
 
 #[cfg(not(test))]
 pub fn get_shell_var(var_name: &str) -> Option<ShellVar> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     unsafe {
         let var_cstr = std::ffi::CString::new(var_name).unwrap();
         let value_ptr = bash_symbols::find_variable(var_cstr.as_ptr());
@@ -1201,6 +1212,7 @@ pub fn get_hostname() -> String {
 
 #[cfg(not(test))]
 pub fn get_cwd() -> String {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     unsafe {
         let ptr = bash_symbols::get_working_directory(c"flyline".as_ptr());
         if ptr.is_null() {
@@ -1220,6 +1232,7 @@ pub fn get_cwd() -> String {
 
 #[cfg(not(test))]
 pub fn expand_filename(filename: &str) -> String {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     unsafe {
         let expanded_string = bash_symbols::expand_string_to_string(
             std::ffi::CString::new(filename).unwrap().as_ptr(),
@@ -1408,6 +1421,7 @@ extern "C" fn quoting_function_c(
     _rtype: c_int,
     quote_char: *const c_char,
 ) -> *mut c_char {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     let s_str = unsafe { std::ffi::CStr::from_ptr(s).to_string_lossy().into_owned() };
     let quote_char_str = unsafe { std::ffi::CStr::from_ptr(quote_char).to_string_lossy() };
     let quote_type = quote_char_str
@@ -1417,7 +1431,7 @@ extern "C" fn quoting_function_c(
         .unwrap_or_default();
     let quoted = quoting_function_rust(&s_str, quote_type, true, true);
     let quoted_cstr = std::ffi::CString::new(quoted).unwrap();
-    unsafe { bash_symbols::xmalloc_cstr(&quoted_cstr) }
+    unsafe { bash_symbols::locked_xmalloc_cstr(&quoted_cstr) }
 }
 
 pub fn quoting_function_rust(
@@ -1485,10 +1499,11 @@ within double quotes, and vice versa.  It should be smarter. */
 // static char *bash_dequote_filename (char *text, int quote_char)
 #[cfg(not(test))]
 extern "C" fn dequoting_function_c(s: *const c_char, _quote_char: c_int) -> *mut c_char {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     let s_str = unsafe { std::ffi::CStr::from_ptr(s).to_string_lossy().into_owned() };
     let dequoted = dequoting_function_rust(&s_str);
     let dequoted_cstr = std::ffi::CString::new(dequoted).unwrap();
-    unsafe { bash_symbols::xmalloc_cstr(&dequoted_cstr) }
+    unsafe { bash_symbols::locked_xmalloc_cstr(&dequoted_cstr) }
 }
 
 pub fn dequoting_function_rust(s: &str) -> String {
@@ -1614,6 +1629,7 @@ fn get_cached_reserved_words() -> Vec<CommandWordInfo> {
 
 #[cfg(not(test))]
 fn get_cached_shell_functions() -> Vec<CommandWordInfo> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     let mut guard = DEFINED_SHELL_FUNCTIONS.lock().unwrap();
     guard
         .get_or_insert_with(|| {
@@ -1811,6 +1827,7 @@ pub fn get_possible_command_words() -> impl Iterator<Item = CommandWordInfo> {
 
 #[cfg(not(test))]
 pub fn warm_completion_caches() {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     let _ = get_cached_aliases();
     let _ = get_cached_reserved_words();
     let _ = get_cached_shell_functions();
@@ -1836,6 +1853,7 @@ pub fn read_terminating_signal() -> c_int {
 #[cfg(not(test))]
 #[allow(dead_code)]
 pub fn set_env_var(name: &str, value: &str) -> Result<()> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     unsafe {
         let name_cstr = std::ffi::CString::new(name)?;
         let value_cstr = std::ffi::CString::new(value)?;
@@ -1861,6 +1879,7 @@ pub fn set_env_var(name: &str, value: &str) -> Result<()> {
 
 #[cfg(not(test))]
 pub fn export_env_var(name: &str, value: &str) -> Result<()> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     unsafe {
         let name_cstr = std::ffi::CString::new(name)?;
         let value_cstr = std::ffi::CString::new(value)?;

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -1719,6 +1719,7 @@ impl ExecutablesOnPath {
     /// Update the cache in-place: evict removed PATH dirs, add new ones, and
     /// re-scan any directory whose mtime has changed.
     fn update_cache(&mut self) {
+        let _timer = crate::perf::PerfTimer::start_and_log_on_drop("update_path_cache");
         let current_dirs: Vec<PathBuf> = get_envvar_value("PATH")
             .map(|p| p.split(':').map(PathBuf::from).collect())
             .unwrap_or_default();

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -814,18 +814,26 @@ fn vec_of_strings_from_char_char_ptr(ptr: *mut *mut c_char) -> Vec<String> {
             return strings;
         }
 
-        for i in 0.. {
+        // The char** array and its string elements are allocated via xmalloc in Bash's
+        // gen_progcomp_completions / gen_action_completions (see mirror-bash/pcomplete.c:1667).
+        // Since we invoke programmable_completions out-of-band directly, we must free
+        // both the individual strings and the array container using locked_xfree.
+        let mut i = 0;
+        loop {
             let c_str_ptr = *ptr.add(i);
             if c_str_ptr.is_null() {
                 break;
             }
             let c_str = std::ffi::CStr::from_ptr(c_str_ptr);
-            if let Ok(str_slice) = c_str.to_str()
-                && seen.insert(str_slice)
-            {
-                strings.push(str_slice.to_string());
+            if let Ok(str_slice) = c_str.to_str() {
+                if seen.insert(str_slice) {
+                    strings.push(str_slice.to_string());
+                }
             }
+            bash_symbols::locked_xfree(c_str_ptr as *mut libc::c_void);
+            i += 1;
         }
+        bash_symbols::locked_xfree(ptr as *mut libc::c_void);
     }
     strings
 }
@@ -1214,11 +1222,15 @@ pub fn get_hostname() -> String {
 pub fn get_cwd() -> String {
     let _guard = crate::bash_symbols::BASH_LOCK.lock();
     unsafe {
+        // get_working_directory returns a newly allocated string via savestring (using xmalloc)
+        // (see mirror-bash/builtins/common.c:618). We must free it with locked_xfree.
         let ptr = bash_symbols::get_working_directory(c"flyline".as_ptr());
         if ptr.is_null() {
             String::new()
         } else {
-            std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned()
+            let res = std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned();
+            bash_symbols::locked_xfree(ptr as *mut libc::c_void);
+            res
         }
     }
 }
@@ -1234,6 +1246,8 @@ pub fn get_cwd() -> String {
 pub fn expand_filename(filename: &str) -> String {
     let _guard = crate::bash_symbols::BASH_LOCK.lock();
     unsafe {
+        // expand_string_to_string returns an allocated string via string_list (using xmalloc)
+        // (see mirror-bash/subst.c:3859 / 3869). We must free it with locked_xfree.
         let expanded_string = bash_symbols::expand_string_to_string(
             std::ffi::CString::new(filename).unwrap().as_ptr(),
             0,
@@ -1244,11 +1258,14 @@ pub fn expand_filename(filename: &str) -> String {
         }
 
         let c_str = std::ffi::CStr::from_ptr(expanded_string);
-        c_str
+        let res = c_str
             .to_str()
             .ok()
             .map(|s| s.to_string())
-            .unwrap_or_else(|| filename.to_string())
+            .unwrap_or_else(|| filename.to_string());
+
+        bash_symbols::locked_xfree(expanded_string as *mut libc::c_void);
+        res
     }
 }
 

--- a/src/bash_symbols.rs
+++ b/src/bash_symbols.rs
@@ -688,12 +688,14 @@ pub struct StringList {
 }
 
 pub fn set_readline_state(state: libc::c_ulong) {
+    let _guard = BASH_LOCK.lock();
     unsafe {
         rl_readline_state |= state;
     }
 }
 
 pub fn clear_readline_state(state: libc::c_ulong) {
+    let _guard = BASH_LOCK.lock();
     unsafe {
         rl_readline_state &= !state;
     }

--- a/src/bash_symbols.rs
+++ b/src/bash_symbols.rs
@@ -430,12 +430,26 @@ unsafe extern "C" {
     pub fn show_var_attributes(var: *mut ShellVar, flags: c_int, output_fd: c_int) -> c_int;
 }
 
-/// Allocate a copy of `s` using bash's `xmalloc`.
-///
-/// # Safety
-/// Must be called while bash is loaded. The returned pointer must be freed with
-/// `xfree` or passed to bash (which will free it with `xfree`).
-pub unsafe fn xmalloc_cstr(s: &std::ffi::CStr) -> *mut c_char {
+pub(crate) static BASH_LOCK: parking_lot::ReentrantMutex<()> = parking_lot::ReentrantMutex::new(());
+
+/// Guarded xmalloc
+#[allow(dead_code)]
+pub unsafe fn locked_xmalloc(size: libc::size_t) -> *mut libc::c_void {
+    let _guard = BASH_LOCK.lock();
+    unsafe { xmalloc(size) }
+}
+
+/// Guarded xfree
+pub unsafe fn locked_xfree(ptr: *mut libc::c_void) {
+    if !ptr.is_null() {
+        let _guard = BASH_LOCK.lock();
+        unsafe { xfree(ptr) };
+    }
+}
+
+/// Guarded xmalloc_cstr
+pub unsafe fn locked_xmalloc_cstr(s: &std::ffi::CStr) -> *mut c_char {
+    let _guard = BASH_LOCK.lock();
     let bytes = s.to_bytes_with_nul();
     unsafe {
         let ptr = xmalloc(bytes.len()) as *mut c_char;

--- a/src/bash_symbols.rs
+++ b/src/bash_symbols.rs
@@ -380,9 +380,9 @@ unsafe extern "C" {
     pub fn expand_string_to_string(string: *const c_char, quoted: c_int) -> *mut c_char;
 
     // xmalloc.h
-    pub fn xmalloc(size: libc::size_t) -> *mut libc::c_void;
-    pub fn xrealloc(ptr: *mut libc::c_void, size: libc::size_t) -> *mut libc::c_void;
-    pub fn xfree(ptr: *mut libc::c_void);
+    fn xmalloc(size: libc::size_t) -> *mut libc::c_void;
+    fn xrealloc(ptr: *mut libc::c_void, size: libc::size_t) -> *mut libc::c_void;
+    fn xfree(ptr: *mut libc::c_void);
 
     // Signal handling
     /* Set to the value of any terminating signal received. */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,10 @@ pub(crate) struct Flyline {
     settings: settings::Settings,
 }
 
+thread_local! {
+    static COMMAND_LOCK_GUARD: std::cell::RefCell<Option<parking_lot::ReentrantMutexGuard<'static, ()>>> = const { std::cell::RefCell::new(None) };
+}
+
 impl Flyline {
     fn new() -> Self {
         Self {
@@ -147,6 +151,11 @@ impl Flyline {
     fn get(&mut self) -> c_int {
         // This is meant to mimic yy_readline_get.
         if self.content.is_empty() || self.position >= self.content.len() {
+            // Release the command execution lock so background threads can run while editing.
+            COMMAND_LOCK_GUARD.with(|guard| {
+                *guard.borrow_mut() = None;
+            });
+
             log::info!("---------------------- Starting app ------------------------");
 
             unsafe {
@@ -175,6 +184,14 @@ impl Flyline {
             self.settings.last_app_closed_at = Some(std::time::Instant::now());
 
             unsafe { libc::signal(libc::SIGCHLD, prev_sigchld) };
+
+            // Join the warming thread while BASH_LOCK is free, preventing deadlocks.
+            crate::threads::join_threads_by_tag(crate::threads::ThreadTag::Warming);
+
+            // Lock BASH_LOCK for the entire duration of the command execution.
+            COMMAND_LOCK_GUARD.with(|guard| {
+                *guard.borrow_mut() = Some(bash_symbols::BASH_LOCK.lock());
+            });
 
             // unsafe {
             //     // This doesn't seem to be strictly necessary but yy_readline_get does it here.
@@ -327,14 +344,14 @@ fn flyline_load_common() -> c_int {
         let old_name = unsafe { (*bash_input).name };
         // Bash expects name to be heap allocated so it can free it later
         let name = c"flyline";
-        let name_ptr = unsafe { bash_symbols::xmalloc_cstr(name) };
+        let name_ptr = unsafe { bash_symbols::locked_xmalloc_cstr(name) };
         unsafe {
             (*bash_input).stream_type = bash_symbols::StreamType::Stdin;
             (*bash_input).name = name_ptr;
             (*bash_input).getter = Some(flyline_get_char);
             (*bash_input).ungetter = Some(flyline_unget_char);
             if !old_name.is_null() {
-                bash_symbols::xfree(old_name as *mut libc::c_void);
+                bash_symbols::locked_xfree(old_name as *mut libc::c_void);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,10 +135,6 @@ pub(crate) struct Flyline {
     settings: settings::Settings,
 }
 
-thread_local! {
-    static COMMAND_LOCK_GUARD: std::cell::RefCell<Option<parking_lot::ReentrantMutexGuard<'static, ()>>> = const { std::cell::RefCell::new(None) };
-}
-
 impl Flyline {
     fn new() -> Self {
         Self {
@@ -151,11 +147,6 @@ impl Flyline {
     fn get(&mut self) -> c_int {
         // This is meant to mimic yy_readline_get.
         if self.content.is_empty() || self.position >= self.content.len() {
-            // Release the command execution lock so background threads can run while editing.
-            COMMAND_LOCK_GUARD.with(|guard| {
-                *guard.borrow_mut() = None;
-            });
-
             log::info!("---------------------- Starting app ------------------------");
 
             unsafe {
@@ -185,13 +176,11 @@ impl Flyline {
 
             unsafe { libc::signal(libc::SIGCHLD, prev_sigchld) };
 
-            // Join the warming thread while BASH_LOCK is free, preventing deadlocks.
+            // Join the background cache warming thread before returning control to Bash.
+            // This ensures that no background Rust threads are running or calling Bash FFI
+            // functions while Bash is executing command execution C code (which is single-threaded
+            // and has no locking of its own).
             crate::threads::join_threads_by_tag(crate::threads::ThreadTag::Warming);
-
-            // Lock BASH_LOCK for the entire duration of the command execution.
-            COMMAND_LOCK_GUARD.with(|guard| {
-                *guard.borrow_mut() = Some(bash_symbols::BASH_LOCK.lock());
-            });
 
             // unsafe {
             //     // This doesn't seem to be strictly necessary but yy_readline_get does it here.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ pub static mut flyline_struct: bash_symbols::BashBuiltin = bash_symbols::BashBui
 // On pre-bash-4.4 builds, register a shared-library constructor so that flyline
 // is initialised as soon as the library is loaded via `enable -f`.
 // On newer versions of bash `flyline_builtin_load` is called automatically by bash during enable.
-#[cfg(feature = "pre_bash_4_4")]
+#[cfg(all(feature = "pre_bash_4_4", not(test)))]
 #[ctor(unsafe)]
 fn flyline_builtin_load_ctor() {
     let _ = flyline_load_common();

--- a/src/prompt_manager.rs
+++ b/src/prompt_manager.rs
@@ -227,6 +227,8 @@ fn expand_prompt_through_bash(raw: String) -> Option<Vec<Line<'static>>> {
 
     let c_prompt = std::ffi::CString::new(raw).ok()?;
 
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
+
     let decoded = unsafe {
         #[cfg(not(feature = "pre_bash_4_4"))]
         let decoded_prompt_cstr = bash_symbols::decode_prompt_string(c_prompt.as_ptr(), 1);
@@ -243,7 +245,7 @@ fn expand_prompt_through_bash(raw: String) -> Option<Vec<Line<'static>>> {
             .to_string();
 
         // `decode_prompt_string` returns an allocated buffer.
-        bash_symbols::xfree(decoded_prompt_cstr as *mut std::ffi::c_void);
+        bash_symbols::locked_xfree(decoded_prompt_cstr as *mut std::ffi::c_void);
 
         decoded
     };


### PR DESCRIPTION
Stack trace from reddit user rvc2018:

```
 Module libgcc_s.so.1 from deb gcc-14-14.2.0-4ubuntu2~24.04.1.amd64
 Stack trace of thread 111739:
 #0  0x00007d7768c9eb2c __pthread_kill_implementation (libc.so.6 + 0x9eb2c)
 #1  0x00007d7768c4527e __GI_raise (libc.so.6 + 0x4527e)
 #2  0x00007d7768c2898f __GI_abort (libc.so.6 + 0x2898f)
 #3  0x00007d7768c297b6 __libc_message_impl (libc.so.6 + 0x297b6)
 #4  0x00007d7768ca8ff5 malloc_printerr (libc.so.6 + 0xa8ff5)
 #5  0x00007d7768ca9b7c unlink_chunk (libc.so.6 + 0xa9b7c)
 #6  0x00007d7768cac1d5 _int_malloc (libc.so.6 + 0xac1d5)
 #7  0x00007d7768cad714 __GI___libc_malloc (libc.so.6 + 0xad714)
 #8  0x00007d77674e0825 _ZN7flyline10bash_funcs26get_cached_shell_functions17hfd559c994049ed1aE (libflyline.so.1.2.2 + 0x2e0825)
 #9  0x00007d77674eca9a _ZN3std3sys9backtrace28__rust_begin_short_backtrace17h53ca149b4de0eaacE (libflyline.so.1.2.2 + 0x2eca9a)
 #10 0x00007d77674c4a71 _ZN4core3ops8function6FnOnce40call_once$u7b$$u7b$vtable.shim$u7d$$u7d$17hc83afb1daa2308a3E (libflyline.so.1.2.2 + 0x2c4a71)
 #11 0x00007d776764a860 _RNvNvMs0_NtNtNtCs3JBboNF8E1m_3std3sys6thread4unixNtB7_6Thread3new12thread_start (libflyline.so.1.2.2 + 0x44a860)
 #12 0x00007d7768c9caa4 start_thread (libc.so.6 + 0x9caa4)
 #13 0x00007d7768d29c6c __clone3 (libc.so.6 + 0x129c6c)

 Stack trace of thread 93017:
 #0  0x00007d7767351134 _RNvXs2_NtNtCs3BFokC4QLxY_4core3str5lossyNtB5_10Utf8ChunksNtNtNtNtB9_4iter6traits8iterator8Iterator4next (libflyline.so.1.2.2 + 0x151134)
 #1  0x00007d77672d2abc _RNvMNtCs8y6E41fb8tc_5alloc6stringNtB2_6String15from_utf8_lossy (libflyline.so.1.2.2 + 0xd2abc)
 #2  0x00007d77674117b4 _ZN7flyline3app11get_command17habdabd77e02ad1f3E (libflyline.so.1.2.2 + 0x2117b4)
 #3  0x00007d77674d609e _ZN7flyline16flyline_get_char17hab835fa189bea929E (libflyline.so.1.2.2 + 0x2d609e)
 #4  0x00005bf3513b2387 n/a (bash + 0x37387)
 #5  0x00005bf35148f66b n/a (bash + 0x11466b)
 #6  0x00005bf3513b6faf yyparse (bash + 0x3bfaf)
 #7  0x00005bf3513bac00 parse_command (bash + 0x3fc00)
 #8  0x00005bf3513badf9 read_command (bash + 0x3fdf9)
 #9  0x00005bf3513bb047 reader_loop (bash + 0x40047)
 #10 0x00005bf3513aeefb main (bash + 0x33efb)
 #11 0x00007d7768c2a1ca __libc_start_call_main (libc.so.6 + 0x2a1ca)
 #12 0x00007d7768c2a28b __libc_start_main_impl (libc.so.6 + 0x2a28b)
 #13 0x00005bf3513af385 _start (bash + 0x34385)
 ELF object binary architecture: AMD x86-64
```

The stack trace made me realize that we are not calling bash functions / reading bash owned data in a single threaded manner. I wanted to keep multi threading cache warming so I put in a lock on the ffi while flyline is running and made sure that we join threads before leaving flyline.