### PR TITLE
Use mimalloc to avoid bash's non thread safe allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,7 @@ dependencies = [
  "libc",
  "log",
  "lscolors",
+ "mimalloc",
  "parking_lot",
  "parse-style",
  "pulldown-cmark",
@@ -894,6 +895,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +993,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ disallowed_methods = "deny"
 crate-type = ["cdylib"]
 
 [dependencies]
+mimalloc = { version = "0.1.52", default-features = false }
 clap = { version = "4.6.1", features = ["derive"] }
 clap_complete = { version = "4.6.3", features = ["unstable-dynamic"] }
 ratatui = { git = "https://github.com/Marlinski/ratatui.git", rev = "fd8e0f024847af467129e0a166390d7e291c1b2e", features = ["default", "unstable-rendered-line-info", "serde"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 use libc::{c_char, c_int};
 use std::sync::Mutex;
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 pub const FILENAME_INFERENCE_LIMIT: usize = 5000;
 
 #[cfg(feature = "pre_bash_4_4")]


### PR DESCRIPTION
It turns out that bash overrides the global allocator. Flyline defaults to using that non thread safe allocator.
So if multiple threads are (de)allocating rust objects like Vec simultaneously, it can cause heap corruption.

Hopefully this fixes #770 