### PR TITLE
Add zsh support (standalone editor + persistent completion broker), and local build install support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,20 @@ disallowed_methods = "deny"
 
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "flyline-standalone"
+path = "src/bin/standalone.rs"
+required-features = ["standalone"]
+
+[[test]]
+name = "zsh_completion_tests"
+path = "tests/zsh_completion_tests.rs"
+
+[[test]]
+name = "zsh_integration_tests"
+path = "tests/zsh_integration_tests.rs"
 
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
@@ -50,6 +63,7 @@ flycomp = { git = "https://github.com/HalFrgrd/flycomp.git", rev = "29813f47d0f7
 
 [features]
 pre_bash_4_4 = []
+standalone = []
 
 [dev-dependencies]
 rusty-fork = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,50 @@ curl -sSfL https://github.com/HalFrgrd/flyline/releases/latest/download/install.
 ```
 On macOS you must first install a version of Bash that supports custom builtins: `brew install bash`
 
+### Zsh
+
+The same `install.sh` also sets up zsh when `zsh` is on your `PATH`: it installs `flyline-standalone` and `libflyline.so` under `~/.local/lib` (or `FLYLINE_INSTALL_DIR`), drops `scripts/flyline.zsh` there, and adds a guarded block to `~/.zshrc`:
+
+```text
+# >>> flyline start >>>
+export FLYLINE_BIN="$HOME/.local/lib/flyline-standalone"
+[[ -r "$HOME/.local/lib/scripts/flyline.zsh" ]] && . "$HOME/.local/lib/scripts/flyline.zsh"
+# <<< flyline end <<<
+```
+
+Before the first edit, your existing `~/.zshrc` is copied to `~/.zshrc.flyline.bak.TIMESTAMP`. Re-running the installer is idempotent: it will not duplicate the marker block.
+
+**Enable / disable (current shell):**
+
+```zsh
+flyline_enable    # turn flyline on (already on after install)
+flyline_disable   # restore native ZLE for this session
+```
+
+**Uninstall:**
+
+```zsh
+flyline_uninstall   # disable flyline and unset FLYLINE_BIN in this session
+```
+
+```sh
+sh install.sh --uninstall   # remove the ~/.zshrc block, flyline-standalone, and scripts/flyline.zsh
+```
+
+`libflyline.so` is kept for Bash; remove it manually if you no longer use flyline with Bash.
+
+**Fail-open:** flyline runs as a separate process from a `zle-line-init` hook. If the binary is missing, you cancel, or flyline crashes, zsh falls back to native line editing for that line — your shell keeps working.
+
+**Completions reuse your zsh setup.** flyline drives a persistent headless zsh that loads your `~/.zshrc`, so it completes exactly what your interactive zsh does — oh-my-zsh plugins, `compinit` functions on your `fpath`, and anything you `source`. flyline does not invent completions: if a tool isn't set up to complete in your own zsh, it won't complete in flyline either. For example, `kubectl <Tab>` works only if your zsh actually configures it (add `kubectl` to your oh-my-zsh `plugins=(…)`, or `source <(kubectl completion zsh)` in `~/.zshrc`); once it does, flyline shows the same subcommands and descriptions. kubectl's warm latency (~400ms) is mostly its own API round-trip and matches native zsh.
+
+**`FLYLINE_ZSH_NO_RCS=1`** makes flyline's helper shells skip your `~/.zshrc` (a pristine `zsh -f`). Boot is faster and more predictable, but you lose user/plugin completions (only system `fpath` completions remain). Use it if a heavy prompt framework misbehaves headlessly.
+
+#### Zsh limitations
+
+- **History is file-mediated.** The widget runs `fc -AI` to flush the current session's history to `$HISTFILE` before launching flyline, which then reads the file — recent commands are visible, but this is not a live read of the parent shell's in-memory list.
+- **One-time rc boot cost.** Loading a heavy `~/.zshrc` (e.g. powerlevel10k) adds ~1–2s when the completion daemon first starts; the persistent daemon amortizes it across the session. `FLYLINE_ZSH_NO_RCS=1` avoids it.
+- **Variable introspection is partial.** Variable tooltips and `$VAR` completion use a per-call `zsh -f`, so they see exported environment variables but not unexported shell parameters.
+
 ### Arch Linux
 
 Arch users can install the [AUR package](https://aur.archlinux.org/packages/flyline):

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -113,6 +113,21 @@ target "bash-integration-tests-pre-4-4" {
     }
 }
 
+target "extract-zsh-integration-test-build-artifact" {
+    context = "."
+    output = ["type=local,dest=docker/build-zsh-integration-test"]
+    dockerfile = "docker/builder.Dockerfile"
+    target = "flyline-zsh-integration-artifact"
+}
+
+target "zsh-integration-test" {
+    context = "."
+    contexts = {
+        built-artifact = "target:extract-zsh-integration-test-build-artifact"
+    }
+    dockerfile = "docker/zsh_integration_test.Dockerfile"
+}
+
 
 
 

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -43,7 +43,8 @@ COPY Cargo.toml Cargo.lock build.rs ./
 COPY src ./src
 COPY examples ./examples
 COPY tests ./tests
-RUN cargo build --release ${CARGO_FEATURES:+--features $CARGO_FEATURES}
+RUN cargo build --release ${CARGO_FEATURES:+--features $CARGO_FEATURES} --features standalone --bin flyline-standalone \
+    && cargo build --release ${CARGO_FEATURES:+--features $CARGO_FEATURES}
 
 FROM flyline-builder AS flyline-lib-tests
 ARG CARGO_FEATURES
@@ -54,3 +55,8 @@ RUN cargo test --release ${CARGO_FEATURES:+--features $CARGO_FEATURES} --lib
 # this makes it convenient to copy the built library without creating a container
 FROM scratch AS flyline-built-artifact
 COPY --from=flyline-builder /app/target/release/libflyline.so /libflyline.so
+
+# Zsh integration artifact: lib + standalone editor binary for docker/zsh_integration_test.Dockerfile.
+FROM scratch AS flyline-zsh-integration-artifact
+COPY --from=flyline-builder /app/target/release/libflyline.so /libflyline.so
+COPY --from=flyline-builder /app/target/release/flyline-standalone /flyline-standalone

--- a/docker/zsh_integration_test.Dockerfile
+++ b/docker/zsh_integration_test.Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    zsh \
+    git \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN zsh --version
+
+COPY --from=built-artifact /flyline-standalone /usr/local/bin/flyline-standalone
+COPY --from=built-artifact /libflyline.so /usr/local/lib/libflyline.so
+COPY scripts/flyline.zsh /opt/flyline/flyline.zsh
+COPY docker/zsh_integration_test.sh /opt/flyline/test.sh
+
+RUN chmod +x /usr/local/bin/flyline-standalone /opt/flyline/test.sh \
+    && /opt/flyline/test.sh

--- a/docker/zsh_integration_test.sh
+++ b/docker/zsh_integration_test.sh
@@ -1,0 +1,80 @@
+#!/bin/zsh
+# End-to-end checks for scripts/flyline.zsh inside an interactive zsh pty.
+set -euo pipefail
+
+zmodload zsh/zpty
+zmodload zsh/datetime
+
+FLYLINE_ZSH="${FLYLINE_ZSH:-/opt/flyline/flyline.zsh}"
+FLYLINE_BIN="${FLYLINE_BIN:-/usr/local/bin/flyline-standalone}"
+
+integer pass=0 fail=0
+typeset -g _BLOB
+
+_pump() {
+  local end=$(( EPOCHREALTIME + $1 )) chunk
+  while (( EPOCHREALTIME < end )); do
+    if zpty -r -t Z chunk 2>/dev/null; then
+      _BLOB+=$chunk
+    else
+      sleep 0.05
+    fi
+  done
+}
+
+run_shell() {
+  local -a lines; lines=("$@")
+  _BLOB=""
+  zpty Z zsh -f -i
+  _pump 0.5
+  local l
+  for l in $lines; do
+    zpty -w -n Z "$l"$'\r'
+    _pump 0.7
+  done
+  _pump 0.6
+  zpty -d Z 2>/dev/null
+  print -r -- "${_BLOB//$'\r'/}"
+}
+
+check() {
+  if [[ $3 == *$2* ]]; then
+    print -r -- "  PASS: $1"
+    (( pass++ ))
+  else
+    print -r -- "  FAIL: $1  (expected: $2)"
+    (( fail++ ))
+  fi
+}
+
+print "== source flyline.zsh + flyline_enable =="
+out=$(run_shell \
+  "export FLYLINE_BIN=$FLYLINE_BIN" \
+  "source $FLYLINE_ZSH" \
+  "flyline_enable" \
+  'print ENABLED_$(( 20 + 22 ))' \
+  "exit")
+check "flyline_enable keeps native ZLE working" "ENABLED_42" "$out"
+
+print "== fail-open: missing flyline binary =="
+out=$(run_shell \
+  "export FLYLINE_BIN=/no/such/flyline" \
+  "source $FLYLINE_ZSH" \
+  "flyline_enable" \
+  'print MISSING_$(( 40 + 2 ))' \
+  "exit")
+check "native ZLE runs when binary missing" "MISSING_42" "$out"
+
+print "== flyline_disable restores native ZLE =="
+out=$(run_shell \
+  "export FLYLINE_BIN=$FLYLINE_BIN" \
+  "source $FLYLINE_ZSH" \
+  "flyline_disable" \
+  'print DISABLED_$(( 43 - 1 ))' \
+  "exit")
+check "native ZLE runs after flyline_disable" "DISABLED_42" "$out"
+
+print ""
+print "RESULT: $pass passed, $fail failed"
+(( fail == 0 )) || exit 1
+print "SUCCESS: zsh integration test completed"

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Flyline installer
 # Usage: curl -sSfL https://github.com/HalFrgrd/flyline/releases/latest/download/install.sh | sh
+#        sh install.sh --uninstall
 
 set -eu
 
@@ -21,6 +22,10 @@ else
     INSTALL_DIR="${HOME}/.local/lib"
 fi
 BASHRC="${HOME}/.bashrc"
+ZSHRC="${HOME}/.zshrc"
+FLYLINE_ZSHRC_START="# >>> flyline start >>>"
+FLYLINE_ZSHRC_END="# <<< flyline end <<<"
+STANDALONE_BIN="flyline-standalone"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -173,6 +178,182 @@ verify_sha256() {
 }
 
 # ---------------------------------------------------------------------------
+# Zsh integration
+# ---------------------------------------------------------------------------
+
+has_zsh() {
+    command -v zsh >/dev/null 2>&1
+}
+
+zshrc_has_flyline_block() {
+    [ -f "$ZSHRC" ] && grep -qF "$FLYLINE_ZSHRC_START" "$ZSHRC"
+}
+
+backup_zshrc_if_needed() {
+    if [ ! -f "$ZSHRC" ]; then
+        return
+    fi
+    if zshrc_has_flyline_block; then
+        return
+    fi
+    ts="$(date +%Y%m%d%H%M%S)"
+    cp "$ZSHRC" "${ZSHRC}.flyline.bak.${ts}"
+    say "Backed up ${ZSHRC} to ${ZSHRC}.flyline.bak.${ts}"
+}
+
+install_flyline_zsh_script() {
+    dest="${INSTALL_DIR}/scripts/flyline.zsh"
+    mkdir -p "${INSTALL_DIR}/scripts"
+
+    if [ -f "./scripts/flyline.zsh" ]; then
+        cp "./scripts/flyline.zsh" "$dest"
+        return
+    fi
+    if [ -n "${0:-}" ] && [ "$0" != "sh" ]; then
+        script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+        if [ -f "${script_dir}/scripts/flyline.zsh" ]; then
+            cp "${script_dir}/scripts/flyline.zsh" "$dest"
+            return
+        fi
+    fi
+
+    if [ -z "${VERSION:-}" ]; then
+        err "Cannot locate scripts/flyline.zsh (run install from a checkout or set FLYLINE_INSTALL_VERSION)."
+    fi
+    say "Downloading scripts/flyline.zsh..."
+    download "https://raw.githubusercontent.com/${REPO}/${VERSION}/scripts/flyline.zsh" "$dest"
+}
+
+install_zsh_integration() {
+    if ! has_zsh; then
+        return
+    fi
+
+    install_flyline_zsh_script
+
+    standalone_path="${INSTALL_DIR}/${STANDALONE_BIN}"
+    if [ -f "$standalone_path" ]; then
+        chmod +x "$standalone_path"
+        say "Installed zsh editor: ${standalone_path}"
+    else
+        warn "zsh detected but ${standalone_path} is not installed yet."
+        warn "Zsh integration will stay disabled until the standalone binary is available."
+    fi
+
+    ensure_zshrc_block
+}
+
+# Append the guarded flyline block to ~/.zshrc (idempotent; backs up first).
+ensure_zshrc_block() {
+    if zshrc_has_flyline_block; then
+        say "Flyline zsh block already present in ${ZSHRC}; skipping."
+        return
+    fi
+
+    backup_zshrc_if_needed
+    touch "$ZSHRC"
+    # shellcheck disable=SC2016
+    cat >> "$ZSHRC" <<EOF
+
+${FLYLINE_ZSHRC_START}
+export FLYLINE_BIN="${INSTALL_DIR}/${STANDALONE_BIN}"
+[[ -r "${INSTALL_DIR}/scripts/flyline.zsh" ]] && . "${INSTALL_DIR}/scripts/flyline.zsh"
+${FLYLINE_ZSHRC_END}
+EOF
+    say "Added flyline zsh block to ${ZSHRC}"
+}
+
+remove_zshrc_flyline_block() {
+    if [ ! -f "$ZSHRC" ]; then
+        return
+    fi
+    if ! grep -qF "$FLYLINE_ZSHRC_START" "$ZSHRC"; then
+        return
+    fi
+    tmp="$(mktemp "${TMPDIR:-/tmp}/flyline.zshrc.XXXXXX")"
+    awk -v start="$FLYLINE_ZSHRC_START" -v end="$FLYLINE_ZSHRC_END" '
+        $0 == start { skip = 1; next }
+        $0 == end   { skip = 0; next }
+        !skip { print }
+    ' "$ZSHRC" > "$tmp"
+    mv "$tmp" "$ZSHRC"
+    say "Removed flyline block from ${ZSHRC}"
+}
+
+# Install from locally-built artifacts (cargo build) instead of a release
+# download. Symlinks the built binary/lib and the checkout's widget script into
+# INSTALL_DIR, then wires up ~/.zshrc — so rebuilds are picked up automatically.
+# Usage: sh install.sh --local [DIST_DIR]   (DIST_DIR defaults to target/release)
+local_main() {
+    # Resolve the checkout dir (where scripts/ and target/ live).
+    if [ -n "${0:-}" ] && [ "$0" != "sh" ]; then
+        REPO_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+    else
+        REPO_DIR="$(pwd)"
+    fi
+
+    if [ -n "${1:-}" ]; then
+        DIST_DIR="$(expand_path "$1")"
+    elif [ -n "${FLYLINE_LOCAL_DIST:-}" ]; then
+        DIST_DIR="$(expand_path "$FLYLINE_LOCAL_DIST")"
+    elif [ -x "${REPO_DIR}/target/release/${STANDALONE_BIN}" ]; then
+        DIST_DIR="${REPO_DIR}/target/release"
+    else
+        DIST_DIR="${REPO_DIR}/target/debug"
+    fi
+
+    standalone_src="${DIST_DIR}/${STANDALONE_BIN}"
+    if [ ! -x "$standalone_src" ]; then
+        err "No ${STANDALONE_BIN} in ${DIST_DIR}. Build it first:
+    cargo build --release --features standalone"
+    fi
+
+    if [ ! -f "${REPO_DIR}/scripts/flyline.zsh" ]; then
+        err "Cannot find ${REPO_DIR}/scripts/flyline.zsh (run --local from the flyline checkout)."
+    fi
+
+    mkdir -p "$INSTALL_DIR" "${INSTALL_DIR}/scripts"
+
+    ln -sf "$standalone_src" "${INSTALL_DIR}/${STANDALONE_BIN}"
+    say "Linked ${INSTALL_DIR}/${STANDALONE_BIN} -> ${standalone_src}"
+
+    # Best-effort: link the Bash loadable too, if it was built.
+    for lib in libflyline.so libflyline.dylib; do
+        if [ -f "${DIST_DIR}/${lib}" ]; then
+            ln -sf "${DIST_DIR}/${lib}" "${INSTALL_DIR}/${lib}"
+            say "Linked ${INSTALL_DIR}/${lib} -> ${DIST_DIR}/${lib}"
+        fi
+    done
+
+    ln -sf "${REPO_DIR}/scripts/flyline.zsh" "${INSTALL_DIR}/scripts/flyline.zsh"
+    say "Linked ${INSTALL_DIR}/scripts/flyline.zsh -> ${REPO_DIR}/scripts/flyline.zsh"
+
+    if ! has_zsh; then
+        warn "zsh not found on PATH; installed files but skipped ~/.zshrc integration."
+        return
+    fi
+
+    ensure_zshrc_block
+
+    say ""
+    say "Local install complete."
+    say "    Activate now:        exec zsh"
+    say "    Disable in session:  flyline_disable"
+    say "    Uninstall:           sh install.sh --uninstall"
+    say "    Symlinks mean rebuilds are picked up automatically (no re-install)."
+}
+
+uninstall_main() {
+    say "Uninstalling flyline zsh integration..."
+    remove_zshrc_flyline_block
+    rm -f "${INSTALL_DIR}/${STANDALONE_BIN}" "${INSTALL_DIR}/scripts/flyline.zsh"
+    rmdir "${INSTALL_DIR}/scripts" 2>/dev/null || true
+    say "Removed zsh integration files from ${INSTALL_DIR}"
+    say "libflyline was left in place for Bash users; remove ${INSTALL_DIR}/libflyline.so (or .dylib) manually if unused."
+    say "Restart zsh or run: unfunction flyline_enable flyline_disable flyline_uninstall _flyline_edit 2>/dev/null"
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -293,6 +474,12 @@ main() {
     LIB_PATH="${INSTALL_DIR}/${LIB_NAME}"
     say "Installed: ${LIB_PATH}"
 
+    if [ -f "${INSTALL_DIR}/${STANDALONE_BIN}" ]; then
+        chmod +x "${INSTALL_DIR}/${STANDALONE_BIN}"
+    fi
+
+    install_zsh_integration
+
     # Update or add 'enable -f ... flyline' in ~/.bashrc.
     if [ -z "${FLYLINE_VERSION:-}" ]; then
         ENABLE_CMD="enable -f ${LIB_PATH} flyline"
@@ -341,6 +528,9 @@ main() {
         else
             say "        enable -d flyline && enable -f ${LIB_PATH} flyline"
         fi
+        if has_zsh && [ -f "${INSTALL_DIR}/${STANDALONE_BIN}" ]; then
+            say '    For zsh, open a new terminal (or run: exec zsh).'
+        fi
         say '    Or open a new terminal and run the tutorial:'
         say "        flyline run-tutorial"
     fi
@@ -353,4 +543,19 @@ main() {
     fi
 }
 
-main "$@"
+case "${1:-}" in
+    --uninstall|-u)
+        if [ -n "${FLYLINE_INSTALL_DIR:-}" ]; then
+            INSTALL_DIR="$(expand_path "$FLYLINE_INSTALL_DIR")"
+        elif [ -n "${FLYLINE_LOAD_DIR:-}" ]; then
+            INSTALL_DIR="$(expand_path "$FLYLINE_LOAD_DIR")"
+        fi
+        uninstall_main
+        ;;
+    --local|-l)
+        local_main "${2:-}"
+        ;;
+    *)
+        main "$@"
+        ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -338,6 +338,7 @@ local_main() {
     say ""
     say "Local install complete."
     say "    Activate now:        exec zsh"
+    say "    Run the tutorial:    flyline run-tutorial"
     say "    Disable in session:  flyline_disable"
     say "    Uninstall:           sh install.sh --uninstall"
     say "    Symlinks mean rebuilds are picked up automatically (no re-install)."
@@ -350,7 +351,7 @@ uninstall_main() {
     rmdir "${INSTALL_DIR}/scripts" 2>/dev/null || true
     say "Removed zsh integration files from ${INSTALL_DIR}"
     say "libflyline was left in place for Bash users; remove ${INSTALL_DIR}/libflyline.so (or .dylib) manually if unused."
-    say "Restart zsh or run: unfunction flyline_enable flyline_disable flyline_uninstall _flyline_edit 2>/dev/null"
+    say "Restart zsh or run: unfunction flyline flyline_enable flyline_disable flyline_uninstall _flyline_edit 2>/dev/null"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/flyline.zsh
+++ b/scripts/flyline.zsh
@@ -1,0 +1,80 @@
+# >>> flyline start >>>
+# flyline runs as a separate process from a `zle-line-init` hook: it draws its TUI
+# on the tty and returns the chosen line on fd 3. Fail-open — if flyline is
+# missing, cancelled, or crashes, native ZLE handles the line unharmed.
+
+[[ -n ${_FLYLINE_LOADED:-} ]] && return
+typeset -g _FLYLINE_LOADED=1
+
+# Default to flyline-standalone next to the install dir (parent of scripts/).
+: ${FLYLINE_BIN:=${${(%):-%x}:A:h:h}/flyline-standalone}
+
+_flyline_edit() {
+  local last_exit=$?   # capture before emulate/anything clobbers $?
+  emulate -L zsh
+  [[ -x $FLYLINE_BIN ]] || return 0   # fail open
+
+  # flyline reads history from $HISTFILE; flush this session's first.
+  fc -AI 2>/dev/null || true
+
+  # Hand flyline a prompt-format string it can `print -Pn` (don't pre-expand `%`;
+  # that mangles starship's %{...%}). starship renders via its CLI; templates we
+  # can't resolve here ($(...)/${...}, e.g. p10k) fall back to a minimal prompt.
+  local fly_ps1=$PROMPT fly_rps1=$RPROMPT
+  if (( $+commands[starship] )) && [[ $PROMPT == *starship* ]]; then
+    fly_ps1="$(starship prompt --terminal-width=$COLUMNS --status=$last_exit 2>/dev/null)"
+    fly_rps1="$(starship prompt --right --terminal-width=$COLUMNS --status=$last_exit 2>/dev/null)"
+  fi
+  [[ $fly_ps1 == *'${'* || $fly_ps1 == *'$('* || -z $fly_ps1 ]] && fly_ps1='%n@%m %1~ %# '
+  [[ $fly_rps1 == *'${'* || $fly_rps1 == *'$('* ]] && fly_rps1=''
+
+  local cmd rc
+  # In a ZLE widget, command-substitution stdin is /dev/null, so read keys from
+  # the tty (0</dev/tty). UI -> /dev/tty, chosen line -> fd 3 -> captured here.
+  cmd="$( \
+    FLYLINE_HOST=zsh \
+    FLYLINE_INIT=$BUFFER \
+    FLYLINE_LAST_EXIT=$last_exit \
+    PS1=$fly_ps1 \
+    RPS1=$fly_rps1 \
+    "$FLYLINE_BIN" 0</dev/tty 3>&1 1>/dev/tty 2>/dev/tty \
+  )"
+  rc=$?
+
+  if (( rc == 0 )); then
+    # Accept even when empty, so line-init re-fires and relaunches flyline
+    # (guarding on a non-empty buffer left blank Enter stuck in native ZLE).
+    BUFFER=$cmd
+    zle .redisplay
+    zle .accept-line
+    return 0
+  elif (( rc == 130 )); then
+    # Ctrl-C: abort to a fresh prompt (relaunches flyline) instead of raw ZLE.
+    BUFFER=
+    zle .send-break
+    return 0
+  else
+    zle .redisplay
+    return 0
+  fi
+}
+
+flyline_enable() {
+  autoload -Uz add-zle-hook-widget
+  zle -N _flyline_edit
+  add-zle-hook-widget line-init _flyline_edit
+}
+
+flyline_disable() {
+  add-zle-hook-widget -d line-init _flyline_edit 2>/dev/null
+  zle -D _flyline_edit 2>/dev/null
+  unset _FLYLINE_LOADED
+}
+
+flyline_uninstall() {
+  flyline_disable
+  unset FLYLINE_BIN
+}
+
+flyline_enable
+# <<< flyline end <<<

--- a/scripts/flyline.zsh
+++ b/scripts/flyline.zsh
@@ -85,5 +85,10 @@ flyline_uninstall() {
   unset FLYLINE_BIN
 }
 
-flyline_enable
+# Inside flyline's own headless completion daemon (spawn_comp_daemon sets this),
+# do NOT install the interactive editor hook. The daemon runs `zsh -i` to inherit
+# the user's completion setup, but launching another interactive editor from its
+# line-init hook is unnecessary and could interact with the user's controlling
+# tty. The completion machinery the daemon needs is unaffected.
+[[ -n ${FLYLINE_ZSH_DAEMON:-} ]] || flyline_enable
 # <<< flyline end <<<

--- a/scripts/flyline.zsh
+++ b/scripts/flyline.zsh
@@ -9,6 +9,15 @@ typeset -g _FLYLINE_LOADED=1
 # Default to flyline-standalone next to the install dir (parent of scripts/).
 : ${FLYLINE_BIN:=${${(%):-%x}:A:h:h}/flyline-standalone}
 
+# Forward `flyline <subcommand>` typed at the prompt to the standalone binary so
+# the full CLI surface (run-tutorial, set-style, changelog, set-cursor, ...) is
+# available just as it is for the Bash builtin. New upstream subcommands work
+# without any change here. Fail-open if the binary is missing.
+flyline() {
+  [[ -x $FLYLINE_BIN ]] || return 127
+  "$FLYLINE_BIN" "$@"
+}
+
 _flyline_edit() {
   local last_exit=$?   # capture before emulate/anything clobbers $?
   emulate -L zsh

--- a/src/active_suggestions.rs
+++ b/src/active_suggestions.rs
@@ -1173,9 +1173,9 @@ impl UnprocessedSuggestion {
 
         if comp_result_flags.filename_completion_desired {
             if path_to_use.is_none() {
-                path_to_use = Some(std::path::PathBuf::from(bash_funcs::fully_expand_path(
-                    &sug,
-                )));
+                path_to_use = Some(std::path::PathBuf::from(
+                    crate::shell::backend().expand_path(&sug),
+                ));
             }
         }
 

--- a/src/active_suggestions.rs
+++ b/src/active_suggestions.rs
@@ -150,6 +150,17 @@ pub enum SuggestionType {
     Misc,
 }
 
+/// What flycomp should do after the user approves a completion request.
+///
+/// Installing a script is the long-standing fallback for commands without a
+/// useful native completer. Suggesting options consumes flycomp's JSON model
+/// directly and must never replace a registered native completer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum FlycompRequest {
+    InstallCompletionScript,
+    SuggestOptions,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ProcessedSuggestion {
     pub s: String,
@@ -600,7 +611,7 @@ mod description_tests {
             comp_type: crate::tab_completion_context::CompType::FirstWord,
             nosort: false,
             compspec_was_useful: Some(true),
-            should_run_flycomp: false,
+            flycomp_request: None,
         };
         let mut active = ActiveSuggestions::new(
             builder,
@@ -671,7 +682,7 @@ mod description_tests {
             comp_type: crate::tab_completion_context::CompType::FirstWord,
             nosort: false,
             compspec_was_useful: Some(true),
-            should_run_flycomp: false,
+            flycomp_request: None,
         };
         let mut active = ActiveSuggestions::new(
             builder,
@@ -711,7 +722,7 @@ mod description_tests {
                 comp_type: crate::tab_completion_context::CompType::FirstWord,
                 nosort: false,
                 compspec_was_useful: Some(true),
-                should_run_flycomp: false,
+                flycomp_request: None,
             },
             SubString::new("c", "c").unwrap(),
             std::time::Duration::from_millis(0),
@@ -745,7 +756,7 @@ mod description_tests {
             comp_type: crate::tab_completion_context::CompType::FirstWord,
             nosort: false,
             compspec_was_useful: Some(true),
-            should_run_flycomp: false,
+            flycomp_request: None,
         };
 
         // mtime descending: c(200), then {a, b} (100), then d(0).
@@ -787,7 +798,7 @@ mod description_tests {
             comp_type: crate::tab_completion_context::CompType::FirstWord,
             nosort: false,
             compspec_was_useful: Some(true),
-            should_run_flycomp: false,
+            flycomp_request: None,
         };
 
         let active_alpha = ActiveSuggestions::new(
@@ -826,7 +837,7 @@ mod description_tests {
             comp_type: crate::tab_completion_context::CompType::FirstWord,
             nosort: true,
             compspec_was_useful: Some(true),
-            should_run_flycomp: false,
+            flycomp_request: None,
         };
 
         let mut active = ActiveSuggestions::new(
@@ -886,7 +897,7 @@ mod description_tests {
             comp_type: crate::tab_completion_context::CompType::FirstWord,
             nosort: false,
             compspec_was_useful: Some(true),
-            should_run_flycomp: false,
+            flycomp_request: None,
         };
         let active_boundary = ActiveSuggestions::new(
             builder_boundary,
@@ -912,7 +923,7 @@ mod description_tests {
             comp_type: crate::tab_completion_context::CompType::FirstWord,
             nosort: false,
             compspec_was_useful: Some(true),
-            should_run_flycomp: false,
+            flycomp_request: None,
         };
         let active_large = ActiveSuggestions::new(
             builder_large,
@@ -992,7 +1003,7 @@ mod description_tests {
             comp_type: crate::tab_completion_context::CompType::FirstWord,
             nosort: false,
             compspec_was_useful: Some(true),
-            should_run_flycomp: false,
+            flycomp_request: None,
         };
 
         // Case 1: pattern "oo" - should only match RegularFile and Misc, but NOT Folder (as "oo" is not a prefix of "foobar").
@@ -1311,7 +1322,7 @@ pub struct ActiveSuggestionsBuilder {
     pub comp_type: tab_completion_context::CompType,
     pub nosort: bool,
     pub compspec_was_useful: Option<bool>,
-    pub should_run_flycomp: bool,
+    pub flycomp_request: Option<FlycompRequest>,
 }
 
 impl ActiveSuggestionsBuilder {
@@ -1327,7 +1338,7 @@ impl ActiveSuggestionsBuilder {
             comp_type: tab_completion_context::CompType::default(),
             nosort: false,
             compspec_was_useful: None,
-            should_run_flycomp: false,
+            flycomp_request: None,
         }
     }
 
@@ -1360,8 +1371,8 @@ impl ActiveSuggestionsBuilder {
     }
 
     #[allow(dead_code)]
-    pub fn with_should_run_flycomp(mut self, should_run_flycomp: bool) -> Self {
-        self.should_run_flycomp = should_run_flycomp;
+    pub fn with_flycomp_request(mut self, flycomp_request: FlycompRequest) -> Self {
+        self.flycomp_request = Some(flycomp_request);
         self
     }
 

--- a/src/app/actions/keyboard.rs
+++ b/src/app/actions/keyboard.rs
@@ -319,7 +319,11 @@ impl KeyEventAction {
                 let mode = std::mem::replace(&mut app.content_mode, ContentMode::Normal);
                 if let ContentMode::TabCompletionAskForFlycomp {
                     command_word,
+                    command_identity,
                     word_under_cursor,
+                    context_before_word,
+                    buffer_snapshot,
+                    request,
                     selection,
                     sandbox,
                     ..
@@ -327,7 +331,15 @@ impl KeyEventAction {
                 {
                     match selection {
                         FlycompPromptSelection::Yes => {
-                            app.run_flycomp(command_word, word_under_cursor, sandbox.is_some());
+                            app.run_flycomp(
+                                command_word,
+                                command_identity,
+                                word_under_cursor,
+                                context_before_word,
+                                buffer_snapshot,
+                                request,
+                                sandbox.is_some(),
+                            );
                         }
                         FlycompPromptSelection::No => {}
                         FlycompPromptSelection::DontAsk => {

--- a/src/app/actions/keyboard.rs
+++ b/src/app/actions/keyboard.rs
@@ -6,6 +6,7 @@ use crate::text_buffer::WordDelim;
 use anyhow::Result;
 use clap_complete::CompletionCandidate;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
 use std::io::IsTerminal;
 use std::ops::Add;
@@ -224,6 +225,21 @@ pub enum KeyEventAction {
     PromptDirMoveToEnd,
     #[strum(message = "Return to the normal command editing mode")]
     EscapeToNormalMode,
+}
+
+/// Serialized as its camelCase action name (via strum), never as a struct.
+impl Serialize for KeyEventAction {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for KeyEventAction {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        KeyEventAction::try_from(s.as_str())
+            .map_err(|_| serde::de::Error::custom(format!("unknown action: '{s}'")))
+    }
 }
 
 impl KeyEventAction {
@@ -495,6 +511,11 @@ impl KeyEventAction {
                     app.settings
                         .cancelled_command_history_manager
                         .push_entry(buf.to_string());
+                }
+                // Cancelling during the tutorial ends it, rather than letting it
+                // resume on the next prompt.
+                if app.settings.tutorial_step.is_active() {
+                    app.settings.stop_tutorial();
                 }
                 app.mode =
                     crate::app::AppRunningState::Exiting(crate::app::ExitState::WithoutCommand);
@@ -1020,6 +1041,41 @@ impl TryFrom<&str> for KeyEventMatch {
     }
 }
 
+impl KeyEventMatch {
+    /// Canonical, human-readable string form (e.g. `ctrl+s`, `alt+enter`,
+    /// `ctrl+anychar`).  Exact inverse of [`TryFrom<&str>`]: for every key the
+    /// parser accepts, `KeyEventMatch::try_from(&kem.to_key_string()) == Ok(kem)`.
+    pub fn to_key_string(&self) -> String {
+        let mut mods: Vec<&'static str> = Vec::new();
+        let tail = match self {
+            KeyEventMatch::Exact(ev) => {
+                push_modifier_strs(ev.modifiers, &mut mods);
+                keycode_to_string(ev.code)
+            }
+            KeyEventMatch::AnyCharAndMods(m) => {
+                push_modifier_strs(*m, &mut mods);
+                "anychar".to_string()
+            }
+        };
+        let mut parts: Vec<String> = mods.into_iter().map(String::from).collect();
+        parts.push(tail);
+        parts.join("+")
+    }
+}
+
+impl Serialize for KeyEventMatch {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_key_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for KeyEventMatch {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        KeyEventMatch::try_from(s.as_str()).map_err(serde::de::Error::custom)
+    }
+}
+
 /// A key code remapping or modifier remapping registered with `flyline key remap`.
 ///
 /// Keys can only be remapped to keys, and modifiers can only be remapped to
@@ -1034,6 +1090,39 @@ pub enum KeyRemap {
         from: KeyModifiers,
         to: KeyModifiers,
     },
+}
+
+/// Human-readable serialized form of a [`KeyRemap`], e.g. `{"from":"tab","to":"z"}`
+/// or `{"from":"alt","to":"ctrl"}`.  The variant is recovered on load by
+/// [`try_parse_remap`], which detects modifier names vs key names (their name
+/// spaces do not overlap).
+#[derive(Serialize, Deserialize)]
+struct KeyRemapRepr {
+    from: String,
+    to: String,
+}
+
+impl Serialize for KeyRemap {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let repr = match self {
+            KeyRemap::Key { from, to } => KeyRemapRepr {
+                from: keycode_to_string(*from),
+                to: keycode_to_string(*to),
+            },
+            KeyRemap::Modifier { from, to } => KeyRemapRepr {
+                from: modifiers_to_string(*from),
+                to: modifiers_to_string(*to),
+            },
+        };
+        repr.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for KeyRemap {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let repr = KeyRemapRepr::deserialize(deserializer)?;
+        try_parse_remap(&repr.from, &repr.to).map_err(serde::de::Error::custom)
+    }
 }
 
 /// Parse a single key-code name (no modifiers) into a [`KeyCode`].
@@ -1155,6 +1244,117 @@ fn parse_single_modifier(s: &str) -> Result<KeyModifiers> {
         .ok_or_else(|| anyhow::anyhow!("Unknown modifier: '{}'", s))
 }
 
+/// Modifier bits in a stable display order, each paired with its canonical
+/// (first-accepted) spelling from [`MODS_TO_EQUIV_NAMES`].  This is the inverse
+/// of [`parse_single_modifier`]: `parse_single_modifier(name)? == bit`.
+const CANONICAL_MODIFIERS: &[(KeyModifiers, &str)] = &[
+    (KeyModifiers::CONTROL, "ctrl"),
+    (KeyModifiers::SHIFT, "shift"),
+    (KeyModifiers::ALT, "alt"),
+    (KeyModifiers::META, "meta"),
+    (KeyModifiers::SUPER, "super"),
+    (KeyModifiers::HYPER, "hyper"),
+];
+
+/// Append the canonical names of every set bit in `mods` to `out`, in the
+/// stable order defined by [`CANONICAL_MODIFIERS`].
+fn push_modifier_strs(mods: KeyModifiers, out: &mut Vec<&'static str>) {
+    for (bit, name) in CANONICAL_MODIFIERS {
+        if mods.contains(*bit) {
+            out.push(name);
+        }
+    }
+}
+
+/// Canonical `+`-joined string for a [`KeyModifiers`] value (used by remap
+/// serialization, where `from`/`to` are single modifier bits).
+fn modifiers_to_string(mods: KeyModifiers) -> String {
+    let mut parts = Vec::new();
+    push_modifier_strs(mods, &mut parts);
+    parts.join("+")
+}
+
+/// Canonical name for a media key, inverse of the `media:` arm of
+/// [`parse_single_keycode`].
+fn media_key_name(mk: crossterm::event::MediaKeyCode) -> &'static str {
+    use crossterm::event::MediaKeyCode;
+    match mk {
+        MediaKeyCode::Play => "play",
+        MediaKeyCode::Pause => "pause",
+        MediaKeyCode::PlayPause => "playpause",
+        MediaKeyCode::Reverse => "reverse",
+        MediaKeyCode::Stop => "stop",
+        MediaKeyCode::FastForward => "fastforward",
+        MediaKeyCode::Rewind => "rewind",
+        MediaKeyCode::TrackNext => "tracknext",
+        MediaKeyCode::TrackPrevious => "trackprevious",
+        MediaKeyCode::Record => "record",
+        MediaKeyCode::LowerVolume => "lowervolume",
+        MediaKeyCode::RaiseVolume => "raisevolume",
+        MediaKeyCode::MuteVolume => "mutevolume",
+    }
+}
+
+/// Canonical name for a standalone modifier key, inverse of the `modifier:` arm
+/// of [`parse_single_keycode`].
+fn modifier_key_name(mk: crossterm::event::ModifierKeyCode) -> &'static str {
+    use crossterm::event::ModifierKeyCode;
+    match mk {
+        ModifierKeyCode::LeftShift => "leftshift",
+        ModifierKeyCode::LeftControl => "leftcontrol",
+        ModifierKeyCode::LeftAlt => "leftalt",
+        ModifierKeyCode::LeftSuper => "leftsuper",
+        ModifierKeyCode::LeftHyper => "lefthyper",
+        ModifierKeyCode::LeftMeta => "leftmeta",
+        ModifierKeyCode::RightShift => "rightshift",
+        ModifierKeyCode::RightControl => "rightcontrol",
+        ModifierKeyCode::RightAlt => "rightalt",
+        ModifierKeyCode::RightSuper => "rightsuper",
+        ModifierKeyCode::RightHyper => "righthyper",
+        ModifierKeyCode::RightMeta => "rightmeta",
+        ModifierKeyCode::IsoLevel3Shift => "isolevel3shift",
+        ModifierKeyCode::IsoLevel5Shift => "isolevel5shift",
+    }
+}
+
+/// Canonical, human-readable string for a [`KeyCode`], the exact inverse of
+/// [`parse_single_keycode`] for every code that parser can produce.
+fn keycode_to_string(code: KeyCode) -> String {
+    match code {
+        // A literal space cannot round-trip as a single char (the parser trims
+        // whitespace first), so it uses the named form.
+        KeyCode::Char(' ') => "space".to_string(),
+        // The parser lower-cases single ASCII letters, so mirror that here.
+        KeyCode::Char(c) => c.to_ascii_lowercase().to_string(),
+        KeyCode::F(n) => format!("f{n}"),
+        KeyCode::Media(mk) => format!("media:{}", media_key_name(mk)),
+        KeyCode::Modifier(mk) => format!("modifier:{}", modifier_key_name(mk)),
+        KeyCode::Enter => "enter".to_string(),
+        KeyCode::Backspace => "backspace".to_string(),
+        KeyCode::Left => "left".to_string(),
+        KeyCode::Right => "right".to_string(),
+        KeyCode::Up => "up".to_string(),
+        KeyCode::Down => "down".to_string(),
+        KeyCode::Home => "home".to_string(),
+        KeyCode::End => "end".to_string(),
+        KeyCode::PageUp => "pageup".to_string(),
+        KeyCode::PageDown => "pagedown".to_string(),
+        KeyCode::Tab => "tab".to_string(),
+        KeyCode::BackTab => "backtab".to_string(),
+        KeyCode::Delete => "delete".to_string(),
+        KeyCode::Insert => "insert".to_string(),
+        KeyCode::Esc => "esc".to_string(),
+        KeyCode::Null => "null".to_string(),
+        KeyCode::CapsLock => "capslock".to_string(),
+        KeyCode::ScrollLock => "scrolllock".to_string(),
+        KeyCode::NumLock => "numlock".to_string(),
+        KeyCode::PrintScreen => "printscreen".to_string(),
+        KeyCode::Pause => "pause".to_string(),
+        KeyCode::Menu => "menu".to_string(),
+        KeyCode::KeypadBegin => "keypadbegin".to_string(),
+    }
+}
+
 /// Parse and validate a remap pair (from, to).  Modifiers may only be remapped
 /// to modifiers; keys may only be remapped to keys.
 pub fn try_parse_remap(from: &str, to: &str) -> Result<KeyRemap> {
@@ -1236,11 +1436,51 @@ pub fn apply_remappings(key: KeyEvent, remappings: &[KeyRemap]) -> KeyEvent {
     KeyEvent::new(new_code, new_modifiers)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Binding {
     key_events: Vec<KeyEventMatch>,
     context: ContextExpr,
     action: KeyEventAction,
+}
+
+/// Default context for a binding whose serialized form omits the `context`
+/// field: the unconditional `always` context.
+fn default_binding_context() -> ContextExpr {
+    ContextExpr::from(ContextVar::Always)
+}
+
+/// Human-readable serialized form of a [`Binding`], e.g.
+/// `{"keys":["ctrl+s"],"context":"always","action":"submitOrNewline"}`.
+/// Keys and the action serialize as strings; the context serializes as its
+/// canonical `+`-joined literal string (see [`ContextExpr`]).
+#[derive(Serialize, Deserialize)]
+struct BindingRepr {
+    keys: Vec<KeyEventMatch>,
+    #[serde(default = "default_binding_context")]
+    context: ContextExpr,
+    action: KeyEventAction,
+}
+
+impl Serialize for Binding {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        BindingRepr {
+            keys: self.key_events.clone(),
+            context: self.context.clone(),
+            action: self.action,
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Binding {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let repr = BindingRepr::deserialize(deserializer)?;
+        Ok(Binding {
+            key_events: repr.keys,
+            context: repr.context,
+            action: repr.action,
+        })
+    }
 }
 
 impl Binding {
@@ -1522,6 +1762,93 @@ mod expand_variations_tests {
                 KeyEventMatch::Exact(KeyEvent::new(KeyCode::Char('.'), KeyModifiers::META)),
             ]
         );
+    }
+}
+
+#[cfg(test)]
+mod key_string_roundtrip_tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    #[test]
+    fn key_event_match_display_is_inverse_of_parse() {
+        // For every supported key string, parse(display(parse(s))) == parse(s).
+        let cases = [
+            "ctrl+alt+s",
+            "alt+enter",
+            "f1",
+            "esc",
+            "tab",
+            "ctrl+anychar",
+            "anychar",
+            "a",
+            "space",
+            "ctrl+shift+left",
+            "media:playpause",
+            "modifier:leftshift",
+        ];
+        for s in cases {
+            let parsed =
+                KeyEventMatch::try_from(s).unwrap_or_else(|e| panic!("failed to parse '{s}': {e}"));
+            let displayed = parsed.to_key_string();
+            let reparsed = KeyEventMatch::try_from(displayed.as_str())
+                .unwrap_or_else(|e| panic!("failed to reparse '{displayed}': {e}"));
+            assert_eq!(
+                parsed, reparsed,
+                "round-trip failed for '{s}' (displayed as '{displayed}')"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_display_forms() {
+        // The canonical string is stable and human-readable.
+        let kem = KeyEventMatch::try_from("ctrl+s").unwrap();
+        assert_eq!(kem.to_key_string(), "ctrl+s");
+        let anychar = KeyEventMatch::AnyCharAndMods(KeyModifiers::CONTROL);
+        assert_eq!(anychar.to_key_string(), "ctrl+anychar");
+        let space: KeyEventMatch = KeyCode::Char(' ').into();
+        assert_eq!(space.to_key_string(), "space");
+    }
+
+    #[test]
+    fn key_remap_round_trips_via_json() {
+        let key_remap = KeyRemap::Key {
+            from: KeyCode::Tab,
+            to: KeyCode::Char('z'),
+        };
+        let json = serde_json::to_string(&key_remap).unwrap();
+        assert_eq!(json, r#"{"from":"tab","to":"z"}"#);
+        let back: KeyRemap = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, key_remap);
+
+        let mod_remap = KeyRemap::Modifier {
+            from: KeyModifiers::ALT,
+            to: KeyModifiers::CONTROL,
+        };
+        let json = serde_json::to_string(&mod_remap).unwrap();
+        assert_eq!(json, r#"{"from":"alt","to":"ctrl"}"#);
+        let back: KeyRemap = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, mod_remap);
+    }
+
+    #[test]
+    fn binding_serializes_as_human_readable_strings() {
+        let binding = Binding::try_new_from_strs("ctrl+s", "always=submitOrNewline").unwrap();
+        let json = serde_json::to_string(&binding).unwrap();
+        assert!(json.contains(r#""keys":["ctrl+s"]"#));
+        assert!(json.contains(r#""context":"always""#));
+        assert!(json.contains(r#""action":"submitOrNewline""#));
+        let back: Binding = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, binding);
+    }
+
+    #[test]
+    fn binding_context_defaults_to_always_when_omitted() {
+        let json = r#"{"keys":["ctrl+s"],"action":"submitOrNewline"}"#;
+        let back: Binding = serde_json::from_str(json).unwrap();
+        let expected = Binding::try_new_from_strs("ctrl+s", "always=submitOrNewline").unwrap();
+        assert_eq!(back, expected);
     }
 }
 

--- a/src/app/actions/mod.rs
+++ b/src/app/actions/mod.rs
@@ -159,6 +159,26 @@ where
     }
 }
 
+/// Context expressions serialize as their canonical `+`-joined literal string
+/// (the exact form accepted by [`ContextExpr::try_from`]), never as a nested
+/// struct.  This keeps persisted bindings human-readable and shell-agnostic.
+impl<V: ContextVar> serde::Serialize for ContextExpr<V> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.display())
+    }
+}
+
+impl<'de, V> serde::Deserialize<'de> for ContextExpr<V>
+where
+    V: ContextVar + std::str::FromStr,
+    <V as std::str::FromStr>::Err: std::fmt::Debug,
+{
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        ContextExpr::try_from(s.as_str()).map_err(serde::de::Error::custom)
+    }
+}
+
 impl<V> TryFrom<&str> for ContextExpr<V>
 where
     V: ContextVar + std::str::FromStr,

--- a/src/app/actions/mouse.rs
+++ b/src/app/actions/mouse.rs
@@ -1133,12 +1133,24 @@ impl MouseEventAction {
                         let mode = std::mem::replace(&mut app.content_mode, ContentMode::Normal);
                         if let ContentMode::TabCompletionAskForFlycomp {
                             command_word,
+                            command_identity,
                             word_under_cursor,
+                            context_before_word,
+                            buffer_snapshot,
+                            request,
                             sandbox,
                             ..
                         } = mode
                         {
-                            app.run_flycomp(command_word, word_under_cursor, sandbox.is_some());
+                            app.run_flycomp(
+                                command_word,
+                                command_identity,
+                                word_under_cursor,
+                                context_before_word,
+                                buffer_snapshot,
+                                request,
+                                sandbox.is_some(),
+                            );
                         }
                         MouseActionOutput::update_now()
                     } else {

--- a/src/app/formatted_buffer.rs
+++ b/src/app/formatted_buffer.rs
@@ -5,10 +5,10 @@ use crate::snake_animation::SnakeAnimation;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
-use crate::bash_funcs;
 use crate::content_builder::Tag;
 use crate::dparser::{AnnotatedToken, ClosingAnnotation, ToInclusiveRange};
 use crate::palette::Palette;
+use crate::shell::backend;
 use itertools::{EitherOrBoth, Itertools};
 use ratatui::prelude::*;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -200,14 +200,14 @@ fn get_word_info(token: &AnnotatedToken) -> Option<WordInfo> {
     if token.annotations.is_env_var && token.token.kind.is_word() {
         let env_var_name = &token.token.value;
 
-        let tooltip = bash_funcs::format_shell_var(env_var_name);
+        let tooltip = crate::shell::backend().format_var(env_var_name);
 
         return Some(WordInfo {
             tooltip: Some(tooltip),
             is_recognised_command: false,
         });
     } else if let Some(value) = &token.annotations.command_word {
-        let command_info = bash_funcs::get_command_info(value);
+        let command_info = backend().command_info(value);
         return Some(WordInfo {
             tooltip: Some(command_info.to_description()),
             is_recognised_command: command_info.is_known(),
@@ -453,7 +453,7 @@ pub fn format_buffer(
         if tok.annotations.is_env_var {
             if tok.token.kind.is_word() {
                 let name = &tok.token.value;
-                if bash_funcs::get_envvar_value(name).is_some() {
+                if crate::shell::backend().env_var(name).is_some() {
                     env_var_recognised[idx] = true;
                     if idx > 0 && annotated_tokens[idx - 1].token.kind == TokenKind::Dollar {
                         env_var_recognised[idx - 1] = true;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -29,7 +29,9 @@ pub enum RightClickCopyTarget {
     Cwd(String),
 }
 
-use crate::active_suggestions::{ActiveSuggestions, ActiveSuggestionsBuilder, COLUMN_PADDING};
+use crate::active_suggestions::{
+    ActiveSuggestions, ActiveSuggestionsBuilder, COLUMN_PADDING, FlycompRequest,
+};
 use crate::agent_mode::{AiOutputSelection, parse_ai_output};
 use crate::app::actions::KeyEventAction;
 use crate::app::formatted_buffer::{FormattedBuffer, format_agent_buffer, format_buffer};
@@ -342,14 +344,22 @@ pub(crate) enum ContentMode {
     PromptDirSelect(usize),
     TabCompletionAskForFlycomp {
         command_word: String,
+        command_identity: String,
         word_under_cursor: String,
+        context_before_word: String,
+        buffer_snapshot: String,
+        request: FlycompRequest,
         selection: FlycompPromptSelection,
         sandbox: Option<String>,
-        dump_path: String,
+        dump_path: Option<String>,
     },
     TabCompletionRunningFlycomp {
         command_word: String,
-        _word_under_cursor: String,
+        command_identity: String,
+        word_under_cursor: String,
+        context_before_word: String,
+        buffer_snapshot: String,
+        request: FlycompRequest,
         start_time: std::time::Instant,
         thread_handle: crate::threads::SharedJoinHandle<anyhow::Result<String>>,
     },
@@ -1156,61 +1166,133 @@ impl<'a> App<'a> {
             let mode = std::mem::replace(&mut self.content_mode, ContentMode::Normal);
             if let ContentMode::TabCompletionRunningFlycomp {
                 command_word,
+                command_identity,
+                word_under_cursor,
+                context_before_word,
+                buffer_snapshot,
+                request,
+                start_time,
                 thread_handle,
-                ..
             } = mode
             {
                 let join_res = thread_handle.join_value();
 
                 if let Some(res) = join_res {
                     match res {
-                        Ok(Ok(script)) => {
+                        Ok(Ok(output)) => {
                             log::info!("flycomp succeeded for command '{}'", command_word);
-                            let output_dir = self.settings.flycomp_output.as_deref();
-                            match crate::shell::backend().resolve_and_write_completion_script(
-                                &command_word,
-                                &script,
-                                output_dir,
-                            ) {
-                                Ok(write_path) => {
-                                    log::info!(
-                                        "Wrote synthesized completion script to '{}'",
-                                        write_path.display()
-                                    );
-                                }
-                                Err(e) => {
-                                    log::error!("Failed to write completion script: {}", e);
-                                }
-                            }
+                            match request {
+                                FlycompRequest::InstallCompletionScript => {
+                                    let output_dir = self.settings.flycomp_output.as_deref();
+                                    match crate::shell::backend()
+                                        .resolve_and_write_completion_script(
+                                            &command_word,
+                                            &output,
+                                            output_dir,
+                                        ) {
+                                        Ok(write_path) => {
+                                            log::info!(
+                                                "Wrote synthesized completion script to '{}'",
+                                                write_path.display()
+                                            );
+                                        }
+                                        Err(e) => {
+                                            log::error!("Failed to write completion script: {}", e);
+                                        }
+                                    }
 
-                            match crate::shell::backend().activate_completion_script(
-                                &command_word,
-                                &script,
-                                output_dir,
-                            ) {
-                                Ok(_) => {
-                                    log::info!(
-                                        "Successfully activated synthesized completion script for '{}'",
-                                        command_word
-                                    );
-                                    self.start_tab_complete(false, None);
+                                    match crate::shell::backend().activate_completion_script(
+                                        &command_word,
+                                        &output,
+                                        output_dir,
+                                    ) {
+                                        Ok(_) => {
+                                            log::info!(
+                                                "Successfully activated synthesized completion script for '{}'",
+                                                command_word
+                                            );
+                                            self.start_tab_complete(false, None);
+                                        }
+                                        Err(e) => {
+                                            log::error!(
+                                                "Failed to activate synthesized completion script: {:?}",
+                                                e
+                                            );
+                                            let error_message = format!(
+                                                "Failed to load script:\n  - {}",
+                                                e.chain()
+                                                    .map(|c| c.to_string())
+                                                    .collect::<Vec<_>>()
+                                                    .join("\n  - ")
+                                            );
+                                            self.content_mode =
+                                                ContentMode::TabCompletionFlycompResult {
+                                                    command_word,
+                                                    error_message,
+                                                };
+                                        }
+                                    }
                                 }
-                                Err(e) => {
-                                    log::error!(
-                                        "Failed to activate synthesized completion script: {:?}",
-                                        e
-                                    );
-                                    let error_message = format!(
-                                        "Failed to load script:\n  - {}",
-                                        e.chain()
-                                            .map(|c| c.to_string())
-                                            .collect::<Vec<_>>()
-                                            .join("\n  - ")
-                                    );
-                                    self.content_mode = ContentMode::TabCompletionFlycompResult {
-                                        command_word,
-                                        error_message,
-                                    };
+                                FlycompRequest::SuggestOptions => {
+                                    if self.buffer.buffer() != buffer_snapshot {
+                                        log::debug!(
+                                            "Discarding stale flycomp options for '{}'",
+                                            command_word
+                                        );
+                                        self.content_mode = ContentMode::Normal;
+                                        return true;
+                                    }
+                                    match crate::flycomp_options::parse_flycomp_json(&output) {
+                                        Ok(model) => {
+                                            if let Err(error) =
+                                                crate::flycomp_options::store_cached_model(
+                                                    &command_identity,
+                                                    &model,
+                                                )
+                                            {
+                                                log::warn!(
+                                                    "Could not cache flycomp options for '{}': {}",
+                                                    command_word,
+                                                    error
+                                                );
+                                            }
+                                            let builder =
+                                                crate::flycomp_options::suggestions_from_model(
+                                                    &model,
+                                                    &context_before_word,
+                                                    &word_under_cursor,
+                                                )
+                                                .with_comp_type(
+                                                    crate::tab_completion_context::CompType::CommandComp {
+                                                        command_word: command_word.clone(),
+                                                    },
+                                                );
+                                            let current_wuc =
+                                                self.completion_context().word_under_cursor.clone();
+                                            self.finish_tab_complete(
+                                                builder,
+                                                current_wuc,
+                                                start_time.elapsed(),
+                                                false,
+                                            );
+                                        }
+                                        Err(error) => {
+                                            log::warn!(
+                                                "Could not parse flycomp options for '{}': {:#}",
+                                                command_word,
+                                                error
+                                            );
+                                            self.content_mode =
+                                                ContentMode::TabCompletionFlycompResult {
+                                                    command_word,
+                                                    error_message: error
+                                                        .chain()
+                                                        .map(|cause| cause.to_string())
+                                                        .collect::<Vec<_>>()
+                                                        .join("\n  - "),
+                                                };
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -1244,36 +1326,28 @@ impl<'a> App<'a> {
     pub(crate) fn run_flycomp(
         &mut self,
         command_word: String,
+        command_identity: String,
         word_under_cursor: String,
+        context_before_word: String,
+        buffer_snapshot: String,
+        request: FlycompRequest,
         use_sandbox: bool,
     ) {
-        let poss_alias = crate::shell::backend().find_alias(&command_word);
-        let alias_def = poss_alias
-            .as_deref()
-            .filter(|alias| !alias.is_empty())
-            .unwrap_or(&command_word);
-        let alias_expanded_command_word = alias_def
-            .split_whitespace()
-            .next()
-            .unwrap_or(alias_def)
-            .to_string();
-
-        let mut cmd_word = alias_expanded_command_word;
-        if cmd_word.starts_with('~') || cmd_word.contains('/') {
-            let expanded = crate::shell::backend().expand_path(&cmd_word);
-            if !expanded.is_empty() {
-                cmd_word = expanded;
-            }
-        }
         let start_time = std::time::Instant::now();
-        let output_format = crate::shell::backend().flycomp_output_format();
+        let output_format = match request {
+            FlycompRequest::InstallCompletionScript => {
+                crate::shell::backend().flycomp_output_format()
+            }
+            FlycompRequest::SuggestOptions => flycomp::OutputFormat::Json,
+        };
+        let synthesis_command = command_identity.clone();
         let shared_handle =
             crate::threads::spawn_thread(crate::threads::ThreadTag::Flycomp, move || {
                 unsafe {
                     libc::signal(libc::SIGCHLD, libc::SIG_DFL);
                 }
                 flycomp::generate_completion_output(
-                    &cmd_word,
+                    &synthesis_command,
                     output_format,
                     flycomp::SynthesisStrategy::ManPageOrRunHelp,
                     use_sandbox, // sandbox
@@ -1283,7 +1357,11 @@ impl<'a> App<'a> {
             });
         self.content_mode = ContentMode::TabCompletionRunningFlycomp {
             command_word,
-            _word_under_cursor: word_under_cursor,
+            command_identity,
+            word_under_cursor,
+            context_before_word,
+            buffer_snapshot,
+            request,
             start_time,
             thread_handle: shared_handle,
         };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -35,6 +35,7 @@ use crate::app::actions::KeyEventAction;
 use crate::app::formatted_buffer::{FormattedBuffer, format_agent_buffer, format_buffer};
 use crate::content_builder::{Contents, SpanTag, Tag, TaggedLine, TaggedSpan};
 use crate::cursor::{Cursor, CursorBackend};
+use crate::dparser;
 use crate::dparser::{AnnotatedToken, ToInclusiveRange};
 use crate::history::{HistoryEntry, HistoryEntryFormatted, HistoryManager};
 use crate::iter_first_last::FirstLast;
@@ -45,7 +46,6 @@ use crate::prompt_manager::PromptManager;
 use crate::settings::{self, MatrixAnimation, MouseMode, Settings};
 use crate::shell_integration;
 use crate::text_buffer::{SubString, TextBuffer};
-use crate::{bash_funcs, dparser};
 use crate::{bash_symbols, command_acceptance};
 use crossterm::event::{
     self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent,
@@ -407,21 +407,22 @@ pub(crate) struct App<'a> {
 
 impl<'a> App<'a> {
     fn new(settings: &'a mut Settings) -> Self {
-        let unfinished_from_prev_command =
-            unsafe { crate::bash_symbols::current_command_line_count } > 0;
+        let unfinished_from_prev_command = crate::shell::backend().multiline_command_count() > 0;
         let initial_buf_val = settings.initial_buffer.take().unwrap_or_default();
         let buffer = TextBuffer::new(&initial_buf_val);
         let formatted_buffer_cache = FormattedBuffer::default();
 
-        bash_funcs::reset_caches();
+        if crate::shell::backend().is_bash() {
+            crate::shell::backend().reset_caches();
+            // Join any previous warming thread to prevent multiple active warming threads
+            crate::threads::join_bash_func_threads();
+        }
 
-        // Join any previous warming thread to prevent multiple active warming threads
-        crate::threads::join_bash_func_threads();
-
+        // Warm completions off the hot path (for zsh, boots the shared broker).
         let _ = crate::threads::spawn_thread(crate::threads::ThreadTag::Warming, || {
             let _timer = crate::perf::PerfTimer::start("warming_thread");
             let start = std::time::Instant::now();
-            crate::bash_funcs::warm_completion_caches();
+            crate::shell::backend().warm_completion_caches();
             log::info!("Warming thread finished in {:?}", start.elapsed());
         });
 
@@ -510,10 +511,9 @@ impl<'a> App<'a> {
         // Send execution finished escape codes (previous command has completed).
         time_it!("startup: escape codes", {
             if self.settings.send_shell_integration_codes == settings::ShellIntegrationLevel::Full {
-                let last_command_exit_value =
-                    unsafe { crate::bash_symbols::last_command_exit_value };
-                let hostname = bash_funcs::get_hostname();
-                let cwd = bash_funcs::get_cwd();
+                let last_command_exit_value = crate::shell::backend().last_command_exit_status();
+                let hostname = crate::shell::backend().hostname();
+                let cwd = crate::shell::backend().cwd();
 
                 shell_integration::write_startup_codes(last_command_exit_value, &hostname, &cwd)
                     .unwrap_or_else(|e| {
@@ -565,7 +565,9 @@ impl<'a> App<'a> {
                 Err(err) => panic!("Failed to create terminal: {}", err),
             };
 
-            bash_symbols::set_readline_state(bash_symbols::RL_STATE_TERMPREPPED);
+            if crate::shell::backend().is_bash() {
+                bash_symbols::set_readline_state(bash_symbols::RL_STATE_TERMPREPPED);
+            }
             terminal
         });
 
@@ -720,7 +722,7 @@ impl<'a> App<'a> {
             // In bash >= 4.4 (readline 6.0+), rl_signal_event_hook is set when
             // bash receives a terminating signal.
             // But just checking for terminating_signal works on all versions of bash, and is more direct.
-            let terminating_signal = bash_funcs::read_terminating_signal();
+            let terminating_signal = crate::shell::backend().read_terminating_signal();
 
             if terminating_signal != 0 {
                 log::info!(
@@ -732,7 +734,9 @@ impl<'a> App<'a> {
             }
         }
 
-        bash_symbols::clear_readline_state(bash_symbols::RL_STATE_TERMPREPPED);
+        if crate::shell::backend().is_bash() {
+            bash_symbols::clear_readline_state(bash_symbols::RL_STATE_TERMPREPPED);
+        }
 
         match self.mode {
             AppRunningState::Exiting(ExitState::WithCommand(cmd)) => {
@@ -1163,7 +1167,7 @@ impl<'a> App<'a> {
                         Ok(Ok(script)) => {
                             log::info!("flycomp succeeded for command '{}'", command_word);
                             let output_dir = self.settings.flycomp_output.as_deref();
-                            match crate::bash_funcs::resolve_and_write_completion_script(
+                            match crate::shell::backend().resolve_and_write_completion_script(
                                 &command_word,
                                 &script,
                                 output_dir,
@@ -1179,7 +1183,7 @@ impl<'a> App<'a> {
                                 }
                             }
 
-                            match crate::bash_funcs::evaluate_shell_string(&script) {
+                            match crate::shell::backend().evaluate_shell_string(&script) {
                                 Ok(_) => {
                                     log::info!(
                                         "Successfully evaluated synthesized completion script for '{}'",
@@ -1239,7 +1243,7 @@ impl<'a> App<'a> {
         word_under_cursor: String,
         use_sandbox: bool,
     ) {
-        let poss_alias = crate::bash_funcs::find_alias(&command_word);
+        let poss_alias = crate::shell::backend().find_alias(&command_word);
         let alias_def = poss_alias
             .as_deref()
             .filter(|alias| !alias.is_empty())
@@ -1252,7 +1256,7 @@ impl<'a> App<'a> {
 
         let mut cmd_word = alias_expanded_command_word;
         if cmd_word.starts_with('~') || cmd_word.contains('/') {
-            let expanded = crate::bash_funcs::fully_expand_path(&cmd_word);
+            let expanded = crate::shell::backend().expand_path(&cmd_word);
             if !expanded.is_empty() {
                 cmd_word = expanded;
             }
@@ -1285,7 +1289,7 @@ impl<'a> App<'a> {
             // No agent configured at all — try to find a suitable one from the example file.
             let setup_cmd = crate::agent_mode::parse_example_agent_commands()
                 .into_iter()
-                .find(|(cmd_name, _)| bash_funcs::get_command_info(cmd_name).is_known())
+                .find(|(cmd_name, _)| crate::shell::backend().command_info(cmd_name).is_known())
                 .map(|(_, flyline_cmd)| flyline_cmd);
 
             match setup_cmd {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1183,17 +1183,21 @@ impl<'a> App<'a> {
                                 }
                             }
 
-                            match crate::shell::backend().evaluate_shell_string(&script) {
+                            match crate::shell::backend().activate_completion_script(
+                                &command_word,
+                                &script,
+                                output_dir,
+                            ) {
                                 Ok(_) => {
                                     log::info!(
-                                        "Successfully evaluated synthesized completion script for '{}'",
+                                        "Successfully activated synthesized completion script for '{}'",
                                         command_word
                                     );
                                     self.start_tab_complete(false, None);
                                 }
                                 Err(e) => {
                                     log::error!(
-                                        "Failed to evaluate synthesized completion script: {:?}",
+                                        "Failed to activate synthesized completion script: {:?}",
                                         e
                                     );
                                     let error_message = format!(
@@ -1262,6 +1266,7 @@ impl<'a> App<'a> {
             }
         }
         let start_time = std::time::Instant::now();
+        let output_format = crate::shell::backend().flycomp_output_format();
         let shared_handle =
             crate::threads::spawn_thread(crate::threads::ThreadTag::Flycomp, move || {
                 unsafe {
@@ -1269,7 +1274,7 @@ impl<'a> App<'a> {
                 }
                 flycomp::generate_completion_output(
                     &cmd_word,
-                    flycomp::OutputFormat::Bash,
+                    output_format,
                     flycomp::SynthesisStrategy::ManPageOrRunHelp,
                     use_sandbox, // sandbox
                     5000,        // timeout_ms

--- a/src/app/tab_completion.rs
+++ b/src/app/tab_completion.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use std::vec;
 
 use crate::active_suggestions::{
-    ActiveSuggestions, ActiveSuggestionsBuilder, ProcessedSuggestion, SuggestionDescription,
-    UnprocessedSuggestion,
+    ActiveSuggestions, ActiveSuggestionsBuilder, FlycompRequest, ProcessedSuggestion,
+    SuggestionDescription, UnprocessedSuggestion,
 };
 use crate::app::{App, ContentMode, FlycompPromptSelection, TabCompletionHandle};
 use crate::bash_funcs::{CompletionFlags, QuoteType};
@@ -196,16 +196,126 @@ fn run_flyline_compspec(
 /// Under `cfg(test)` we always force full processing (regardless of how big
 /// the queue is) and always populate the common prefix, so that test
 /// expectations are deterministic.
+/// Whether the flycomp "synthesize completions" prompt may fire for the current
+/// tab-completion attempt, split by the reason so the `CommandComp` arm can
+/// apply each independently.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct FlycompGate {
+    /// The command has no useful native completer at all (missing / `_minimal`),
+    /// and the word is completable by flycomp (empty or option-shaped). This is
+    /// the long-standing behaviour.
+    pub when_no_completer: bool,
+    /// A native completer *is* registered but returned nothing for an
+    /// option-shaped word (`-`/`--`); offer to synthesize options from `--help`
+    /// anyway. Gated by the `flycomp_synthesize_options` setting.
+    pub when_empty_options: bool,
+}
+
+/// Decide when the flycomp prompt may fire, from the user settings and the shape
+/// of the word under the cursor. Pure so it can be unit-tested without an `App`.
+///
+/// The key distinction is empty vs. option-shaped word: an empty word with a
+/// registered completer is contextual (stay silent, like `kubectl get`), while a
+/// bare `-`/`--` that a completer can't complete signals it may not know the
+/// tool's options, so synthesizing from `--help` is worthwhile.
+pub(crate) fn compute_flycomp_gate(
+    use_flycomp: bool,
+    command_blacklisted: bool,
+    auto_started: bool,
+    word_under_cursor: &str,
+    option_candidate: bool,
+    synthesize_options: bool,
+) -> FlycompGate {
+    // flycomp is only ever offered on a manual Tab for a non-blacklisted command
+    // with the feature enabled.
+    let common = use_flycomp && !command_blacklisted && !auto_started;
+    let wuc_is_bare_dash =
+        !word_under_cursor.is_empty() && word_under_cursor.chars().all(|c| c == '-');
+    FlycompGate {
+        when_no_completer: common && (word_under_cursor.is_empty() || wuc_is_bare_dash),
+        when_empty_options: common && option_candidate && synthesize_options,
+    }
+}
+
+fn flycomp_request_for_native_result(
+    compspec_was_useful: Option<bool>,
+    native_results_empty: bool,
+    gate: FlycompGate,
+) -> Option<FlycompRequest> {
+    if compspec_was_useful == Some(false) && gate.when_no_completer {
+        Some(FlycompRequest::InstallCompletionScript)
+    } else if compspec_was_useful == Some(true) && native_results_empty && gate.when_empty_options {
+        Some(FlycompRequest::SuggestOptions)
+    } else {
+        None
+    }
+}
+
+/// Whether the word under the cursor is an option-name candidate rather than a
+/// filename or an option value.
+///
+/// A previous standalone `--` ends option parsing, while an `=` before the
+/// cursor means the user is completing the value half of `--option=value`.
+fn is_option_candidate(completion_context: &tab_completion_context::CompletionContext) -> bool {
+    let word_under_cursor = completion_context.word_under_cursor.as_ref();
+    if !word_under_cursor.starts_with('-') || completion_context.word_left_of_cursor().contains('=')
+    {
+        return false;
+    }
+
+    let before_word = context_before_word(completion_context);
+    let Some(previous_words) = shlex::split(before_word) else {
+        return false;
+    };
+    !previous_words.iter().any(|word| word == "--")
+}
+
+fn context_before_word<'a>(
+    completion_context: &'a tab_completion_context::CompletionContext<'_>,
+) -> &'a str {
+    let relative_start = completion_context
+        .word_under_cursor
+        .start
+        .saturating_sub(completion_context.context.start)
+        .min(completion_context.context.as_ref().len());
+    &completion_context.context.as_ref()[..relative_start]
+}
+
+fn resolve_flycomp_command(command_word: &str) -> String {
+    let alias = backend().find_alias(command_word);
+    let alias_def = alias
+        .as_deref()
+        .filter(|alias| !alias.is_empty())
+        .unwrap_or(command_word);
+    let mut resolved = alias_def
+        .split_whitespace()
+        .next()
+        .unwrap_or(alias_def)
+        .to_string();
+    if resolved.starts_with('~') || resolved.contains('/') {
+        let expanded = backend().expand_path(&resolved);
+        if !expanded.is_empty() {
+            resolved = expanded;
+        }
+    }
+    resolved
+}
+
+fn resolve_flycomp_option_identity(command_word: &str) -> String {
+    let resolved = resolve_flycomp_command(command_word);
+    if let CommandWordInfo::File { path, .. } = backend().command_info(&resolved) {
+        path
+    } else {
+        resolved
+    }
+}
+
 pub(crate) fn gen_completions_internal(
     completion_context: &tab_completion_context::CompletionContext,
     auto_started: bool,
-    will_run_flycomp_if_prog_comp_is_useless: bool,
+    flycomp_gate: FlycompGate,
 ) -> Option<ActiveSuggestionsBuilder> {
-    let mut builder = gen_completions_uncomitted(
-        completion_context,
-        auto_started,
-        will_run_flycomp_if_prog_comp_is_useless,
-    )?;
+    let mut builder = gen_completions_uncomitted(completion_context, auto_started, flycomp_gate)?;
 
     let all_processed = if cfg!(test) {
         // Tests demand determinism: process everything and always compute
@@ -230,11 +340,12 @@ pub(crate) fn gen_completions_internal(
 fn gen_completions_uncomitted(
     completion_context: &tab_completion_context::CompletionContext,
     auto_started: bool,
-    will_run_flycomp_if_prog_comp_is_useless: bool,
+    flycomp_gate: FlycompGate,
 ) -> Option<ActiveSuggestionsBuilder> {
     log::debug!("Completion context: {:#?}", completion_context);
 
     let word_under_cursor = &completion_context.word_under_cursor;
+    let option_candidate = is_option_candidate(completion_context);
 
     for comp_type in &completion_context.comp_types() {
         log::debug!("Processing completion type: {:?}", comp_type);
@@ -289,12 +400,41 @@ fn gen_completions_uncomitted(
                         builder.len(),
                         initial_command_word
                     );
-                    if builder.compspec_was_useful == Some(false)
-                        && will_run_flycomp_if_prog_comp_is_useless
-                    {
-                        builder.should_run_flycomp = true;
+                    // No useful native completer at all: offer flycomp for an
+                    // empty or option-shaped word (long-standing behaviour).
+                    builder.flycomp_request = flycomp_request_for_native_result(
+                        builder.compspec_was_useful,
+                        builder.is_empty(),
+                        flycomp_gate,
+                    );
+                    if builder.flycomp_request == Some(FlycompRequest::SuggestOptions) {
+                        let command_identity =
+                            resolve_flycomp_option_identity(initial_command_word);
+                        if let Some(model) =
+                            crate::flycomp_options::load_cached_model(&command_identity)
+                        {
+                            log::debug!(
+                                "Using cached flycomp option model for '{}'",
+                                command_identity
+                            );
+                            builder = crate::flycomp_options::suggestions_from_model(
+                                &model,
+                                context_before_word(completion_context),
+                                word_under_cursor.as_ref(),
+                            )
+                            .with_compspec_was_useful(Some(true));
+                        } else {
+                            builder.flycomp_request = Some(FlycompRequest::SuggestOptions);
+                        }
                     }
-                    if !builder.is_empty() || builder.should_run_flycomp {
+                    log::debug!(
+                        "CommandComp decision: is_empty={}, compspec_was_useful={:?}, gate={:?}, flycomp_request={:?}",
+                        builder.is_empty(),
+                        builder.compspec_was_useful,
+                        flycomp_gate,
+                        builder.flycomp_request,
+                    );
+                    if !builder.is_empty() || builder.flycomp_request.is_some() {
                         return Some(builder.with_comp_type(comp_type.clone()));
                     }
                 }
@@ -492,6 +632,12 @@ fn gen_completions_uncomitted(
                 }
             }
             CompType::FilenameExpansion => {
+                if option_candidate {
+                    log::debug!(
+                        "Skipping FilenameExpansion because word under cursor is an option candidate"
+                    );
+                    continue;
+                }
                 if auto_started && word_under_cursor.as_ref().trim().is_empty() {
                     log::debug!(
                         "Skipping FilenameExpansion because auto_started is true and word_under_cursor is empty"
@@ -525,6 +671,12 @@ fn gen_completions_uncomitted(
                 }
             }
             CompType::FuzzyFilenameExpansion => {
+                if option_candidate {
+                    log::debug!(
+                        "Skipping FuzzyFilenameExpansion because word under cursor is an option candidate"
+                    );
+                    continue;
+                }
                 if auto_started && word_under_cursor.as_ref().trim().is_empty() {
                     log::debug!(
                         "Skipping FuzzyFilenameExpansion because auto_started is true and word_under_cursor is empty"
@@ -1117,17 +1269,33 @@ impl App<'_> {
             .unwrap_or("")
             .to_string();
 
-        if builder.should_run_flycomp {
-            let output_dir = self.settings.flycomp_output.as_deref();
-            let dump_path = backend()
-                .resolve_completion_script_path(&command_word, output_dir)
-                .to_string_lossy()
-                .into_owned();
+        if let Some(request) = builder.flycomp_request {
+            let dump_path = if request == FlycompRequest::InstallCompletionScript {
+                let output_dir = self.settings.flycomp_output.as_deref();
+                Some(
+                    backend()
+                        .resolve_completion_script_path(&command_word, output_dir)
+                        .to_string_lossy()
+                        .into_owned(),
+                )
+            } else {
+                None
+            };
             let sandbox = flycomp::is_sandboxing_available();
+            let command_identity = match request {
+                FlycompRequest::InstallCompletionScript => resolve_flycomp_command(&command_word),
+                FlycompRequest::SuggestOptions => resolve_flycomp_option_identity(&command_word),
+            };
+            let context_before_word = context_before_word(&completion_context).to_string();
+            let buffer_snapshot = self.buffer.buffer().to_string();
 
             self.content_mode = ContentMode::TabCompletionAskForFlycomp {
                 command_word,
+                command_identity,
                 word_under_cursor: wuc_substring.s.clone(),
+                context_before_word,
+                buffer_snapshot,
+                request,
                 selection: FlycompPromptSelection::Yes,
                 sandbox,
                 dump_path,
@@ -1220,10 +1388,24 @@ impl App<'_> {
             .next()
             .unwrap_or("")
             .to_string();
-        let will_run_flycomp_if_prog_comp_is_useless = self.settings.use_flycomp
-            && !self.settings.flycomp_blacklist.contains(&command_word)
-            && !auto_started
-            && (wuc_substring.s.is_empty() || wuc_substring.s.chars().all(|c| c == '-'));
+        let flycomp_gate = compute_flycomp_gate(
+            self.settings.use_flycomp,
+            self.settings.flycomp_blacklist.contains(&command_word),
+            auto_started,
+            &wuc_substring.s,
+            is_option_candidate(&completion_context_owned),
+            self.settings.flycomp_synthesize_options,
+        );
+        log::debug!(
+            "start_tab_complete: cmd='{}', wuc='{}', auto_started={}, use_flycomp={}, synthesize_options={}, gate={:?}, comp_types={:?}",
+            command_word,
+            wuc_substring.s,
+            auto_started,
+            self.settings.use_flycomp,
+            self.settings.flycomp_synthesize_options,
+            flycomp_gate,
+            completion_context_owned.comp_types(),
+        );
 
         let start_time = std::time::Instant::now();
 
@@ -1272,11 +1454,8 @@ impl App<'_> {
                 }
             }
             let thread_start = std::time::Instant::now();
-            let result = gen_completions_internal(
-                &completion_context_owned,
-                auto_started,
-                will_run_flycomp_if_prog_comp_is_useless,
-            );
+            let result =
+                gen_completions_internal(&completion_context_owned, auto_started, flycomp_gate);
             let elapsed = thread_start.elapsed();
 
             log::info!("Child process completed");
@@ -1419,6 +1598,96 @@ mod tab_completion_tests {
 
     const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
+    #[test]
+    fn flycomp_gate_option_word_offers_synthesis_when_enabled() {
+        // `grep --`: a native completer may exist but return nothing; with the
+        // toggle on we still offer to synthesize options.
+        let gate = compute_flycomp_gate(true, false, false, "--", true, true);
+        assert!(gate.when_empty_options);
+        assert!(gate.when_no_completer);
+
+        // Single dash is also option-shaped.
+        assert!(compute_flycomp_gate(true, false, false, "-", true, true).when_empty_options);
+    }
+
+    #[test]
+    fn flycomp_gate_option_word_respects_toggle() {
+        // Same `grep --`, but synthesis toggled off: no option offer, though the
+        // no-completer-at-all path is unaffected.
+        let gate = compute_flycomp_gate(true, false, false, "--", true, false);
+        assert!(!gate.when_empty_options);
+        assert!(gate.when_no_completer);
+    }
+
+    #[test]
+    fn flycomp_gate_empty_word_never_offers_options() {
+        // `kubectl get ` (empty word): an empty native result is contextual, so
+        // we never offer option synthesis regardless of the toggle.
+        let gate = compute_flycomp_gate(true, false, false, "", false, true);
+        assert!(!gate.when_empty_options);
+        assert!(gate.when_no_completer);
+    }
+
+    #[test]
+    fn flycomp_gate_disabled_paths() {
+        // Non-option, non-empty word: nothing offered.
+        let normal = compute_flycomp_gate(true, false, false, "foo", false, true);
+        assert!(!normal.when_empty_options);
+        assert!(!normal.when_no_completer);
+
+        // Auto-started (typing, not a manual Tab): never offer.
+        let auto = compute_flycomp_gate(true, false, true, "--", true, true);
+        assert!(!auto.when_empty_options);
+        assert!(!auto.when_no_completer);
+
+        // Blacklisted command: never offer.
+        let blacklisted = compute_flycomp_gate(true, true, false, "--", true, true);
+        assert!(!blacklisted.when_empty_options);
+        assert!(!blacklisted.when_no_completer);
+
+        // flycomp disabled entirely: never offer.
+        let off = compute_flycomp_gate(false, false, false, "--", true, true);
+        assert!(!off.when_empty_options);
+        assert!(!off.when_no_completer);
+    }
+
+    #[test]
+    fn option_candidate_is_conservative_about_values_and_end_marker() {
+        let candidate = |buffer: &str| {
+            let context = get_completion_context(buffer, buffer.len());
+            is_option_candidate(&context)
+        };
+
+        assert!(candidate("grep --"));
+        assert!(candidate("grep --col"));
+        assert!(candidate("grep -5"));
+        assert!(!candidate("grep "));
+        assert!(!candidate("grep pattern"));
+        assert!(!candidate("cat -- -filename"));
+        assert!(!candidate("tool --config=./file"));
+    }
+
+    #[test]
+    fn flycomp_request_preserves_install_and_requires_registered_empty_for_options() {
+        let gate = FlycompGate {
+            when_no_completer: true,
+            when_empty_options: true,
+        };
+        assert_eq!(
+            flycomp_request_for_native_result(Some(false), true, gate),
+            Some(FlycompRequest::InstallCompletionScript)
+        );
+        assert_eq!(
+            flycomp_request_for_native_result(Some(true), true, gate),
+            Some(FlycompRequest::SuggestOptions)
+        );
+        assert_eq!(
+            flycomp_request_for_native_result(Some(true), false, gate),
+            None
+        );
+        assert_eq!(flycomp_request_for_native_result(None, true, gate), None);
+    }
+
     /// Locate a test fixture directory by trying multiple paths:
     /// 1. Relative path from current working directory (works in most test runners)
     /// 2. Path relative to CARGO_MANIFEST_DIR (works in some Docker builds)
@@ -1459,7 +1728,8 @@ mod tab_completion_tests {
     ) -> Option<(ActiveSuggestionsBuilder, CompletionContext<'static>)> {
         crate::logging::init_for_tests_once();
         let comp_context = get_completion_context(buffer.buffer(), buffer.cursor_byte_pos());
-        let Some(builder) = gen_completions_internal(&comp_context, false, false) else {
+        let Some(builder) = gen_completions_internal(&comp_context, false, FlycompGate::default())
+        else {
             return None;
         };
         Some((builder, comp_context.into_owned()))
@@ -1721,7 +1991,8 @@ mod tab_completion_tests {
             let comp_context =
                 get_completion_context(buffer.buffer(), buffer.cursor_byte_pos());
             let wuc = comp_context.word_under_cursor.clone();
-            let builder = gen_completions_internal(&comp_context, false, false).expect("some completions");
+            let builder = gen_completions_internal(&comp_context, false, FlycompGate::default())
+                .expect("some completions");
             assert_eq!(builder.comp_type, CompType::CommandComp { command_word: "gd".to_string() });
             assert_eq!(builder.len(), 1, "expected solo suggestion, got {:?}", builder.processed);
             let outcome = apply_tab_complete_to_buffer(&mut buffer, &builder, &wuc);

--- a/src/app/tab_completion.rs
+++ b/src/app/tab_completion.rs
@@ -8,10 +8,11 @@ use crate::active_suggestions::{
     UnprocessedSuggestion,
 };
 use crate::app::{App, ContentMode, FlycompPromptSelection, TabCompletionHandle};
-use crate::bash_funcs::{self, QuoteType};
+use crate::bash_funcs::{CompletionFlags, QuoteType};
 use crate::content_utils::{self, ansi_string_to_spans};
 use crate::globbing::PathPatternExpansion;
 use crate::iter_first_last::FirstLast;
+use crate::shell::{CommandWordInfo, backend};
 use crate::tab_completion_context::CompType;
 use crate::text_buffer::SubString;
 use crate::users;
@@ -52,7 +53,7 @@ fn run_comp_spec_completion(
     completion_context: &tab_completion_context::CompletionContext,
     initial_command_word: &str,
 ) -> Option<ActiveSuggestionsBuilder> {
-    let poss_alias = bash_funcs::find_alias(initial_command_word);
+    let poss_alias = backend().find_alias(initial_command_word);
     log::debug!(
         "Checking for alias for command word '{}': {:?}",
         initial_command_word,
@@ -81,7 +82,7 @@ fn run_comp_spec_completion(
     if alias_expanded_command_word == "flyline" {
         run_flyline_compspec(alias_expanded_completion_context)
     } else {
-        let poss_completions = bash_funcs::run_programmable_completions(
+        let poss_completions = backend().run_programmable_completions(
             alias_expanded_full_command,
             &alias_expanded_command_word,
             alias_expanded_word_under_cursor,
@@ -132,14 +133,14 @@ fn run_flyline_compspec(
     // attached to each candidate) are preserved as-is.
     match complete_flyline_args(full_command, word_under_cursor, cursor_byte_pos) {
         Ok(candidates) => {
-            let quote_type = bash_funcs::find_quote_type(word_under_cursor);
+            let quote_type = crate::bash_funcs::find_quote_type(word_under_cursor);
 
             let processed: Vec<ProcessedSuggestion> = candidates
                 .into_iter()
                 .filter_map(|c| {
                     let value = c.get_value().to_string_lossy().to_string();
                     let value = if let Some(qt) = quote_type {
-                        bash_funcs::quoting_function_rust(&value, qt, true, false)
+                        crate::bash_funcs::quoting_function_rust(&value, qt, true, false)
                     } else {
                         value.clone()
                     };
@@ -370,7 +371,7 @@ fn gen_completions_uncomitted(
             CompType::EnvVariable => {
                 log::debug!("CompType::EnvVariable for {}", word_under_cursor.as_ref());
                 let matching_vars =
-                    bash_funcs::get_all_variables_with_prefix(word_under_cursor.as_ref());
+                    crate::shell::backend().vars_with_prefix(word_under_cursor.as_ref());
                 log::debug!(
                     "CompType::EnvVariable found {} completions for prefix: {}",
                     matching_vars.len(),
@@ -600,7 +601,7 @@ fn tab_complete_first_word(command: &str, word_under_cursor: &str) -> ActiveSugg
 
     let mut res = vec![];
     let mut seen: HashSet<String> = HashSet::new();
-    for poss_info in bash_funcs::get_possible_command_words() {
+    for poss_info in backend().possible_command_words() {
         let cmd_name = poss_info.command();
         if cmd_name.starts_with(command) && seen.insert(cmd_name.to_string()) {
             res.push(poss_info);
@@ -620,7 +621,7 @@ fn tab_complete_first_word(command: &str, word_under_cursor: &str) -> ActiveSugg
 }
 
 fn processed_suggestions_from_command_info(
-    command_infos: Vec<bash_funcs::CommandWordInfo>,
+    command_infos: Vec<CommandWordInfo>,
 ) -> Vec<ProcessedSuggestion> {
     command_infos
         .into_iter()
@@ -632,7 +633,7 @@ fn processed_suggestions_from_command_info(
                 " ".to_string()
             };
             let description_str = info.to_description();
-            let description = if matches!(info, bash_funcs::CommandWordInfo::Unknown { .. }) {
+            let description = if matches!(info, CommandWordInfo::Unknown { .. }) {
                 SuggestionDescription::Static(vec![])
             } else {
                 SuggestionDescription::Static(vec![ratatui::text::Span::raw(description_str)])
@@ -658,7 +659,7 @@ fn tab_complete_fuzzy_first_word(command: &str) -> ActiveSuggestionsBuilder {
     let mut scored = vec![];
 
     let mut seen: HashSet<String> = HashSet::new();
-    for poss_info in bash_funcs::get_possible_command_words() {
+    for poss_info in backend().possible_command_words() {
         let cmd_name = poss_info.command();
         if seen.insert(cmd_name.to_string())
             && let Some(score) = content_utils::fuzzy_match_with_threshold(
@@ -683,7 +684,7 @@ fn tab_complete_fuzzy_first_word(command: &str) -> ActiveSuggestionsBuilder {
 /// `should_skip_hidden`: If true, skip files starting with `.` (unless pattern explicitly requests them).
 fn tab_complete_with_expanded_pattern(
     expanded: &PathPatternExpansion,
-    comp_resultflags: bash_funcs::CompletionFlags,
+    comp_resultflags: CompletionFlags,
     wuc: &str,
     should_skip_hidden: bool,
 ) -> Vec<UnprocessedSuggestion> {
@@ -751,8 +752,8 @@ fn tab_complete_with_expanded_pattern(
 fn tab_complete_glob_expansion(
     pattern: &str,
     word_under_cursor: &str,
-) -> (Vec<UnprocessedSuggestion>, bash_funcs::CompletionFlags) {
-    let mut comp_resultflags = bash_funcs::CompletionFlags::default();
+) -> (Vec<UnprocessedSuggestion>, CompletionFlags) {
+    let mut comp_resultflags = CompletionFlags::default();
     // We will handle it ourselves because the prefix should not be quoted but the found filename should be.
     // e.g. my_command $PWD/fi<TAB> should expand to:
     // my_command $PWD/file\ with\ spaces.txt
@@ -761,7 +762,7 @@ fn tab_complete_glob_expansion(
     comp_resultflags.filename_quoting_desired = false;
     comp_resultflags.filename_completion_desired = true;
 
-    comp_resultflags.quote_type = bash_funcs::find_quote_type(pattern);
+    comp_resultflags.quote_type = crate::bash_funcs::find_quote_type(pattern);
     log::debug!("found quote type: {:?}", comp_resultflags.quote_type);
 
     let expanded = PathPatternExpansion::new(pattern);
@@ -779,13 +780,13 @@ fn tab_complete_glob_expansion(
 /// but the fuzzy matcher will.
 fn tab_complete_fuzzy_filename_from_word(
     word_under_cursor: &str,
-) -> (Vec<UnprocessedSuggestion>, bash_funcs::CompletionFlags) {
+) -> (Vec<UnprocessedSuggestion>, CompletionFlags) {
     tab_complete_fuzzy_filename_impl(word_under_cursor, 0)
 }
 
 fn tab_complete_fuzzy_filename(
     completion_context: &tab_completion_context::CompletionContext,
-) -> (Vec<UnprocessedSuggestion>, bash_funcs::CompletionFlags) {
+) -> (Vec<UnprocessedSuggestion>, CompletionFlags) {
     let cursor_seg_from_right = completion_context
         .word_right_of_cursor()
         .matches('/')
@@ -799,13 +800,13 @@ fn tab_complete_fuzzy_filename(
 fn tab_complete_fuzzy_filename_impl(
     word_under_cursor: &str,
     cursor_seg_from_right: usize,
-) -> (Vec<UnprocessedSuggestion>, bash_funcs::CompletionFlags) {
-    let mut comp_res_flags = bash_funcs::CompletionFlags::default();
+) -> (Vec<UnprocessedSuggestion>, CompletionFlags) {
+    let mut comp_res_flags = CompletionFlags::default();
     comp_res_flags.filename_quoting_desired = false;
     comp_res_flags.filename_completion_desired = true;
-    comp_res_flags.quote_type = bash_funcs::find_quote_type(word_under_cursor);
+    comp_res_flags.quote_type = crate::bash_funcs::find_quote_type(word_under_cursor);
 
-    let dequoted_wuc = bash_funcs::dequoting_function_rust(word_under_cursor);
+    let dequoted_wuc = crate::bash_funcs::dequoting_function_rust(word_under_cursor);
     let (is_absolute, segments) = split_nonempty_path_segments(&dequoted_wuc);
     if segments.is_empty() {
         return (vec![], comp_res_flags);
@@ -820,7 +821,7 @@ fn tab_complete_fuzzy_filename_impl(
     }
 
     let base_input = path_from_segments(is_absolute, prefix_segments);
-    let expanded_base = PathBuf::from(bash_funcs::fully_expand_path(if base_input.is_empty() {
+    let expanded_base = PathBuf::from(backend().expand_path(if base_input.is_empty() {
         "."
     } else {
         &base_input
@@ -1118,10 +1119,10 @@ impl App<'_> {
 
         if builder.should_run_flycomp {
             let output_dir = self.settings.flycomp_output.as_deref();
-            let dump_path =
-                crate::bash_funcs::resolve_completion_script_path(&command_word, output_dir)
-                    .to_string_lossy()
-                    .into_owned();
+            let dump_path = backend()
+                .resolve_completion_script_path(&command_word, output_dir)
+                .to_string_lossy()
+                .into_owned();
             let sandbox = flycomp::is_sandboxing_available();
 
             self.content_mode = ContentMode::TabCompletionAskForFlycomp {

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -925,6 +925,7 @@ impl<'a> App<'a> {
                 selection,
                 sandbox,
                 dump_path,
+                request,
                 ..
             } if self.mode.is_running() => {
                 content.newline();
@@ -969,7 +970,15 @@ impl<'a> App<'a> {
 
                 content.write_tagged_span(&TaggedSpan::new(
                     Span::styled(
-                        format!("No completion script found for '{}'. Run ", command_word),
+                        match request {
+                            FlycompRequest::InstallCompletionScript => {
+                                format!("No completion script found for '{}'. Run ", command_word)
+                            }
+                            FlycompRequest::SuggestOptions => format!(
+                                "The native completer returned no matching options for '{}'. Run ",
+                                command_word
+                            ),
+                        },
                         self.settings.colour_palette.normal_text(),
                     ),
                     Tag::Normal,
@@ -996,26 +1005,31 @@ impl<'a> App<'a> {
 
                 content.write_tagged_span(&TaggedSpan::new(
                     Span::styled(
-                        ") to synthesize one?",
+                        match request {
+                            FlycompRequest::InstallCompletionScript => ") to synthesize one?",
+                            FlycompRequest::SuggestOptions => ") to synthesize options?",
+                        },
                         self.settings.colour_palette.normal_text(),
                     ),
                     Tag::Normal,
                 ));
-                content.newline();
-                content.write_tagged_span(&TaggedSpan::new(
-                    Span::styled(
-                        "  Would create: ",
-                        self.settings.colour_palette.normal_text(),
-                    ),
-                    Tag::Normal,
-                ));
-                content.write_tagged_span(&TaggedSpan::new(
-                    Span::styled(
-                        dump_path.to_string(),
-                        self.settings.colour_palette.key_sequence_style(),
-                    ),
-                    Tag::Normal,
-                ));
+                if let Some(dump_path) = dump_path {
+                    content.newline();
+                    content.write_tagged_span(&TaggedSpan::new(
+                        Span::styled(
+                            "  Would create: ",
+                            self.settings.colour_palette.normal_text(),
+                        ),
+                        Tag::Normal,
+                    ));
+                    content.write_tagged_span(&TaggedSpan::new(
+                        Span::styled(
+                            dump_path.to_string(),
+                            self.settings.colour_palette.key_sequence_style(),
+                        ),
+                        Tag::Normal,
+                    ));
+                }
                 content.newline();
                 content.write_tagged_span(&TaggedSpan::new(
                     Span::styled(
@@ -1093,7 +1107,7 @@ impl<'a> App<'a> {
 
                 if flycomp_hover {
                     let popup_style = self.settings.colour_palette.normal_text();
-                    let flycomp_msg = "flycomp parses CLI `--help` outputs and man pages to dynamically synthesize shell completion scripts.\nGitHub: https://github.com/HalFrgrd/flycomp";
+                    let flycomp_msg = "flycomp parses CLI `--help` outputs and man pages to dynamically synthesize completion models and shell scripts.\nGitHub: https://github.com/HalFrgrd/flycomp";
                     content.draw_popup(
                         flycomp_msg,
                         flycomp_anchor_pos.row + 1,
@@ -1107,13 +1121,20 @@ impl<'a> App<'a> {
             ContentMode::TabCompletionRunningFlycomp {
                 command_word,
                 start_time,
+                request,
                 ..
             } if self.mode.is_running() => {
                 content.newline();
-                let text = format!(
-                    "Running flycomp to synthesize completions for '{}'...",
-                    command_word
-                );
+                let text = match request {
+                    FlycompRequest::InstallCompletionScript => format!(
+                        "Running flycomp to synthesize completions for '{}'...",
+                        command_word
+                    ),
+                    FlycompRequest::SuggestOptions => format!(
+                        "Running flycomp to synthesize options for '{}'...",
+                        command_word
+                    ),
+                };
                 let line = gaussian_wave_animated(&text, now, *start_time);
                 content.write_tagged_line(&TaggedLine::from_line(line, Tag::Normal), false);
             }
@@ -2351,7 +2372,7 @@ mod tests {
             comp_type: crate::tab_completion_context::CompType::FirstWord,
             nosort: false,
             compspec_was_useful: Some(true),
-            should_run_flycomp: false,
+            flycomp_request: None,
         };
 
         let mut active = ActiveSuggestions::new(
@@ -2433,7 +2454,7 @@ mod tests {
             comp_type: crate::tab_completion_context::CompType::FirstWord,
             nosort: false,
             compspec_was_useful: Some(true),
-            should_run_flycomp: false,
+            flycomp_request: None,
         };
 
         let mut active = ActiveSuggestions::new(
@@ -2502,7 +2523,7 @@ mod tests {
             comp_type: crate::tab_completion_context::CompType::FirstWord,
             nosort: false,
             compspec_was_useful: Some(true),
-            should_run_flycomp: false,
+            flycomp_request: None,
         };
 
         let mut active = ActiveSuggestions::new(
@@ -2590,7 +2611,7 @@ mod tests {
             comp_type: crate::tab_completion_context::CompType::FirstWord,
             nosort: false,
             compspec_was_useful: Some(true),
-            should_run_flycomp: false,
+            flycomp_request: None,
         };
 
         let mut active = ActiveSuggestions::new(

--- a/src/bash_stubs.rs
+++ b/src/bash_stubs.rs
@@ -1,0 +1,225 @@
+//! Stub Bash/readline symbols for the standalone `flyline-standalone` binary.
+//!
+//! The library is normally loaded into Bash and resolves these at runtime. The
+//! standalone editor links the same rlib without a host shell, so we provide
+//! inert definitions that satisfy the linker. Zsh mode routes through
+//! `shell::zsh::ZSH_BACKEND` and must not call into real Bash FFI.
+
+#![allow(non_snake_case, dead_code, static_mut_refs)]
+
+use crate::bash_symbols::{
+    Alias, BashBuiltinType, BashInput, BufferedStream, CompSpec, FunctionDef, HistoryEntry,
+    ShellVar, StreamSaver, StreamType,
+};
+use libc::{c_char, c_int, c_uint, c_void, pid_t};
+
+macro_rules! stub_fn_ret {
+    ($name:ident($($arg:ident: $ty:ty),*) -> $ret:ty = $val:expr) => {
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn $name($($arg: $ty),*) -> $ret {
+            let _ = ($($arg),*);
+            $val
+        }
+    };
+    ($name:ident($($arg:ident: $ty:ty),*) -> $ret:ty) => {
+        stub_fn_ret!($name($($arg: $ty),*) -> $ret = Default::default());
+    };
+    ($name:ident($($arg:ident: $ty:ty),*)) => {
+        stub_fn_ret!($name($($arg: $ty),*) -> () = ());
+    };
+}
+
+fn dup_cstr(s: *const c_char) -> *mut c_char {
+    if s.is_null() {
+        return std::ptr::null_mut();
+    }
+    unsafe {
+        let len = libc::strlen(s);
+        let ptr = libc::malloc(len + 1) as *mut c_char;
+        if ptr.is_null() {
+            return std::ptr::null_mut();
+        }
+        std::ptr::copy_nonoverlapping(s, ptr, len + 1);
+        ptr
+    }
+}
+
+// --- statics ----------------------------------------------------------------
+
+#[unsafe(no_mangle)]
+pub static mut stream_list: *mut StreamSaver = std::ptr::null_mut();
+
+#[unsafe(no_mangle)]
+pub static mut bash_input: BashInput = BashInput {
+    stream_type: StreamType::None,
+    name: std::ptr::null_mut(),
+    location: crate::bash_symbols::InputStreamLocation {
+        string: std::ptr::null_mut(),
+    },
+    getter: None,
+    ungetter: None,
+};
+
+#[unsafe(no_mangle)]
+pub static interactive: c_int = 1;
+#[unsafe(no_mangle)]
+pub static interactive_shell: c_int = 1;
+#[unsafe(no_mangle)]
+pub static no_line_editing: c_int = 0;
+
+#[unsafe(no_mangle)]
+pub static mut rl_line_buffer: *mut c_char = std::ptr::null_mut();
+#[unsafe(no_mangle)]
+pub static mut rl_point: c_int = 0;
+#[unsafe(no_mangle)]
+pub static mut rl_end: c_int = 0;
+#[unsafe(no_mangle)]
+pub static mut rl_completion_found_quote: c_int = 0;
+#[unsafe(no_mangle)]
+pub static mut rl_completion_quote_character: c_int = 0;
+#[unsafe(no_mangle)]
+pub static mut rl_filename_quoting_desired: c_int = 0;
+#[unsafe(no_mangle)]
+pub static mut rl_filename_completion_desired: c_int = 0;
+#[cfg(not(feature = "pre_bash_4_4"))]
+#[unsafe(no_mangle)]
+pub static mut rl_completion_suppress_append: c_int = 0;
+#[unsafe(no_mangle)]
+pub static mut rl_completion_append_character: c_int = b' ' as c_int;
+#[cfg(not(feature = "pre_bash_4_4"))]
+#[unsafe(no_mangle)]
+pub static mut rl_sort_completion_matches: c_int = 1;
+#[unsafe(no_mangle)]
+pub static mut rl_filename_dequoting_function: Option<
+    extern "C" fn(*const c_char, c_int) -> *mut c_char,
+> = None;
+#[unsafe(no_mangle)]
+pub static mut rl_filename_quoting_function: Option<
+    extern "C" fn(*const c_char, c_int, *const c_char) -> *mut c_char,
+> = None;
+
+#[unsafe(no_mangle)]
+pub static mut shell_builtins: *mut BashBuiltinType = std::ptr::null_mut();
+#[unsafe(no_mangle)]
+pub static mut num_shell_builtins: c_int = 0;
+#[unsafe(no_mangle)]
+pub static mut rl_readline_state: libc::c_ulong = 0;
+#[unsafe(no_mangle)]
+pub static mut current_command_line_count: c_int = 0;
+#[unsafe(no_mangle)]
+pub static mut current_readline_prompt: *mut c_char = std::ptr::null_mut();
+#[unsafe(no_mangle)]
+pub static mut terminating_signal: c_int = 0;
+#[cfg(not(feature = "pre_bash_4_4"))]
+#[unsafe(no_mangle)]
+pub static mut rl_signal_event_hook: Option<extern "C" fn()> = None;
+#[unsafe(no_mangle)]
+pub static mut job_control: c_int = 0;
+#[unsafe(no_mangle)]
+pub static mut shell_pgrp: pid_t = 0;
+#[unsafe(no_mangle)]
+pub static mut last_command_exit_value: c_int = 0;
+#[unsafe(no_mangle)]
+pub static mut current_host_name: *mut c_char = std::ptr::null_mut();
+#[unsafe(no_mangle)]
+pub static mut array_needs_making: c_int = 0;
+
+// --- functions --------------------------------------------------------------
+
+stub_fn_ret!(push_stream(reset_lineno: c_int));
+stub_fn_ret!(pop_stream());
+stub_fn_ret!(with_input_from_stdin());
+stub_fn_ret!(get_alias_value(_name: *const c_char) -> *mut c_char = std::ptr::null_mut());
+stub_fn_ret!(find_function_def(_name: *const c_char) -> *mut FunctionDef = std::ptr::null_mut());
+stub_fn_ret!(describe_command(_command: *const c_char, _dflags: c_int) -> c_int = 1);
+stub_fn_ret!(
+    programmable_completions(
+        _cmd: *const c_char,
+        _word: *const c_char,
+        _start: c_int,
+        _end: c_int,
+        _foundp: *mut c_int
+    ) -> *mut *mut c_char = std::ptr::null_mut()
+);
+stub_fn_ret!(progcomp_search(_cmd: *const c_char) -> *mut CompSpec = std::ptr::null_mut());
+stub_fn_ret!(
+    bash_default_completion(
+        _text: *const c_char,
+        _start: c_int,
+        _end: c_int,
+        _qc: c_int,
+        _compflags: c_int
+    ) -> *mut *mut c_char = std::ptr::null_mut()
+);
+#[cfg(not(feature = "pre_bash_4_4"))]
+stub_fn_ret!(pcomp_set_readline_variables(_flags: c_int, _nval: c_int));
+stub_fn_ret!(all_aliases() -> *mut *mut Alias = std::ptr::null_mut());
+stub_fn_ret!(
+    all_variables_matching_prefix(_prefix: *const c_char) -> *mut *mut c_char =
+        std::ptr::null_mut()
+);
+stub_fn_ret!(all_shell_functions() -> *mut *mut ShellVar = std::ptr::null_mut());
+stub_fn_ret!(history_list() -> *mut *mut HistoryEntry = std::ptr::null_mut());
+stub_fn_ret!(find_variable(_name: *const c_char) -> *mut ShellVar = std::ptr::null_mut());
+stub_fn_ret!(bind_variable(_name: *const c_char, _value: *const c_char, _flags: c_int) -> *mut ShellVar = std::ptr::null_mut());
+stub_fn_ret!(unbind_variable(_name: *const c_char) -> c_int = 0);
+#[cfg(not(feature = "pre_bash_4_4"))]
+stub_fn_ret!(evalstring(_string: *mut c_char, _from_file: *const c_char, _flags: c_int) -> c_int = 0);
+#[cfg(feature = "pre_bash_4_4")]
+stub_fn_ret!(parse_and_execute(_string: *mut c_char, _from_file: *const c_char, _flags: c_int) -> c_int = 0);
+stub_fn_ret!(termsig_handler(_sig: c_int));
+stub_fn_ret!(give_terminal_to(_pgrp: pid_t, _force: c_int) -> c_int = 0);
+stub_fn_ret!(get_working_directory(_for_whom: *const c_char) -> *mut c_char = std::ptr::null_mut());
+stub_fn_ret!(show_var_attributes(_var: *mut ShellVar, _flags: c_int, _output_fd: c_int) -> c_int = 0);
+
+// NOTE: do NOT stub `getenv`. A `#[no_mangle] getenv` here interposes the libc
+// symbol for the whole process, and calling `libc::getenv` from it resolves
+// straight back to itself — infinite tail-recursion that spins at 100% CPU and
+// wedges the shell (Rust's `std::env::var` calls `getenv`). The bash_symbols
+// extern reference is satisfied by the real libc `getenv` at link time.
+
+#[cfg(not(feature = "pre_bash_4_4"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn decode_prompt_string(
+    string: *const c_char,
+    _is_prompt: c_int,
+) -> *mut c_char {
+    dup_cstr(string)
+}
+
+#[cfg(feature = "pre_bash_4_4")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn decode_prompt_string(string: *const c_char) -> *mut c_char {
+    dup_cstr(string)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn expand_string_to_string(
+    string: *const c_char,
+    _quoted: c_int,
+) -> *mut c_char {
+    dup_cstr(string)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xmalloc(size: libc::size_t) -> *mut c_void {
+    unsafe { libc::malloc(size) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xrealloc(ptr: *mut c_void, size: libc::size_t) -> *mut c_void {
+    unsafe { libc::realloc(ptr, size) }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn xfree(ptr: *mut c_void) {
+    if !ptr.is_null() {
+        unsafe { libc::free(ptr) };
+    }
+}
+
+// Silence unused import warnings from struct fields in static initializers.
+const _: () = {
+    let _ = std::mem::size_of::<BufferedStream>();
+    let _ = std::mem::size_of::<c_uint>();
+};

--- a/src/bin/standalone.rs
+++ b/src/bin/standalone.rs
@@ -1,0 +1,78 @@
+//! Standalone flyline editor for zsh host integration.
+//!
+//! Launched from the `zle-line-init` widget in `scripts/flyline.zsh`. Draws the
+//! TUI on `/dev/tty` and writes the accepted command line to fd 3. Exit codes:
+//!   0   — command accepted
+//!   130 — cancelled (Ctrl-C / empty abort)
+//!   1   — EOF or internal error
+
+use flyline::{
+    ExitState, Settings, ZSH_BACKEND, get_command, init_standalone_logging, run_comp_broker,
+    set_backend, set_cloexec,
+};
+
+fn catch_unwind_safe<T>(f: impl FnOnce() -> T) -> Result<T, ()> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).map_err(|_| ())
+}
+
+fn write_command_fd3(cmd: &str) {
+    use std::io::Write;
+    use std::os::fd::{FromRawFd, RawFd};
+
+    // ponytail: fd 3 is owned by the zsh parent; never close it on drop.
+    let fd = RawFd::from(3);
+    let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+    let _ = file.write_all(cmd.as_bytes());
+    let _ = file.write_all(b"\n");
+    std::mem::forget(file);
+}
+
+fn run() -> i32 {
+    // Broker mode: serve completions over a Unix socket instead of editing a line.
+    // Detached from the tty, so it must not touch fd 3 or FLYLINE_HOST/UI state.
+    if let Some(sock) = std::env::var_os("FLYLINE_COMP_BROKER") {
+        set_backend(&ZSH_BACKEND);
+        let _ = init_standalone_logging();
+        return run_comp_broker(std::path::Path::new(&sock));
+    }
+
+    // SAFETY: standalone is a fresh process; no other threads read these yet.
+    unsafe {
+        std::env::set_var("FLYLINE_HOST", "zsh");
+    }
+    // Mark the fd 3 handoff pipe close-on-exec so helper grandchildren can't hold
+    // it open and wedge the parent's `$( ... 3>&1 )` (write_command_fd3 still works).
+    set_cloexec(3);
+    set_backend(&ZSH_BACKEND);
+
+    if let Err(e) = init_standalone_logging() {
+        eprintln!("flyline: failed to initialize logging: {e}");
+    }
+
+    let mut settings = Settings::default();
+    if let Ok(init) = std::env::var("FLYLINE_INIT") {
+        settings.initial_buffer = Some(init);
+    }
+
+    match get_command(&mut settings) {
+        ExitState::WithCommand(cmd) => {
+            write_command_fd3(&cmd);
+            0
+        }
+        ExitState::WithoutCommand => 130,
+        ExitState::EOF => 1,
+    }
+}
+
+fn main() {
+    let code = match catch_unwind_safe(run) {
+        Ok(code) => code,
+        Err(()) => {
+            eprintln!(
+                "flyline: panicked; please report at https://github.com/HalFrgrd/flyline/issues"
+            );
+            1
+        }
+    };
+    std::process::exit(code);
+}

--- a/src/bin/standalone.rs
+++ b/src/bin/standalone.rs
@@ -7,8 +7,8 @@
 //!   1   — EOF or internal error
 
 use flyline::{
-    ExitState, Settings, ZSH_BACKEND, get_command, init_standalone_logging, run_comp_broker,
-    set_backend, set_cloexec,
+    ExitState, ZSH_BACKEND, backend, get_command, init_standalone_logging, run_comp_broker,
+    run_flyline_command, set_backend, set_cloexec,
 };
 
 fn catch_unwind_safe<T>(f: impl FnOnce() -> T) -> Result<T, ()> {
@@ -40,28 +40,59 @@ fn run() -> i32 {
     unsafe {
         std::env::set_var("FLYLINE_HOST", "zsh");
     }
+    set_backend(&ZSH_BACKEND);
+
+    // Subcommand dispatch: `flyline <args>` (invoked via the shell forwarding
+    // function) runs the same CLI as the Bash builtin against the persisted
+    // settings snapshot, then exits without drawing the editor or touching fd 3.
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    if !argv.is_empty() {
+        let _ = init_standalone_logging();
+        let mut settings = backend().load_persisted_settings();
+        // Overlay per-terminal session state (e.g. `flyline run-tutorial` sets
+        // the tutorial running for the subsequent prompts of this terminal).
+        settings.apply_session_state(&backend().load_session_state());
+        let arg_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
+        let code = run_flyline_command(&mut settings, &arg_refs);
+        backend().persist_settings(&settings);
+        backend().persist_session_state(&settings.session_state());
+        return code;
+    }
+
     // Mark the fd 3 handoff pipe close-on-exec so helper grandchildren can't hold
     // it open and wedge the parent's `$( ... 3>&1 )` (write_command_fd3 still works).
     set_cloexec(3);
-    set_backend(&ZSH_BACKEND);
 
     if let Err(e) = init_standalone_logging() {
         eprintln!("flyline: failed to initialize logging: {e}");
     }
 
-    let mut settings = Settings::default();
+    let mut settings = backend().load_persisted_settings();
+    // Overlay per-terminal session state (tutorial progress) so the tutorial
+    // advances across this terminal's per-prompt processes, like the long-lived
+    // Bash builtin — without leaking into other terminals or the durable config.
+    settings.apply_session_state(&backend().load_session_state());
     if let Ok(init) = std::env::var("FLYLINE_INIT") {
         settings.initial_buffer = Some(init);
     }
 
-    match get_command(&mut settings) {
+    let exit_code = match get_command(&mut settings) {
         ExitState::WithCommand(cmd) => {
+            // Progress the tutorial on empty submit, matching the Bash builtin
+            // (which does this between prompts in its long-lived process).
+            settings.advance_tutorial_on_submit(&cmd);
             write_command_fd3(&cmd);
             0
         }
         ExitState::WithoutCommand => 130,
         ExitState::EOF => 1,
-    }
+    };
+
+    // Persist durable settings, plus session-scoped tutorial progress for the
+    // next prompt in this terminal.
+    backend().persist_settings(&settings);
+    backend().persist_session_state(&settings.session_state());
+    exit_code
 }
 
 fn main() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -516,6 +516,10 @@ enum Commands {
         /// Enable or disable flycomp for synthesizing shell completions when no useful compspec is found.
         #[arg(long = "use-flycomp", default_missing_value = "true", num_args = 0..=1)]
         use_flycomp: Option<bool>,
+        /// Offer flycomp option synthesis when a native completer is registered
+        /// but returns nothing for an option-shaped word (e.g. `grep --`).
+        #[arg(long = "flycomp-synthesize-options", default_missing_value = "true", num_args = 0..=1)]
+        flycomp_synthesize_options: Option<bool>,
         /// How to sort suggestions when fuzzy scores are tied (mtime, alphabetical).
         #[arg(long = "sort-order", value_name = "ORDER")]
         sort_order: Option<settings::SuggestionSortOrder>,
@@ -1256,6 +1260,7 @@ pub fn run_flyline_command(cfg: &mut settings::Settings, args: &[&str]) -> c_int
                     subcommand,
                     auto_suggest,
                     use_flycomp,
+                    flycomp_synthesize_options,
                     sort_order,
                     num_suggestion_rows,
                     flycomp_output,
@@ -1280,6 +1285,10 @@ pub fn run_flyline_command(cfg: &mut settings::Settings, args: &[&str]) -> c_int
                     if let Some(enabled) = use_flycomp {
                         log::info!("Use flycomp set to {}", enabled);
                         cfg.use_flycomp = enabled;
+                    }
+                    if let Some(enabled) = flycomp_synthesize_options {
+                        log::info!("Flycomp synthesize options set to {}", enabled);
+                        cfg.flycomp_synthesize_options = enabled;
                     }
                     if let Some(order) = sort_order {
                         log::info!("Suggestion sort order set to {:?}", order);
@@ -1563,6 +1572,14 @@ mod tests {
         let code = run_flyline_command(&mut cfg, &["suggestions", "--num-suggestion-rows", "7"]);
         assert_eq!(code, OK);
         assert_eq!(cfg.num_suggestion_rows, 7);
+
+        assert!(cfg.flycomp_synthesize_options);
+        let code = run_flyline_command(
+            &mut cfg,
+            &["suggestions", "--flycomp-synthesize-options", "false"],
+        );
+        assert_eq!(code, OK);
+        assert!(!cfg.flycomp_synthesize_options);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -864,661 +864,662 @@ impl Flyline {
             }
         }
         log::debug!("flyline called with args: {:?}", args);
+        run_flyline_command(&mut self.settings, &args)
+    }
+}
 
-        // args contains words from WordList; first word is not the command name unlike argv
-        let args_with_prog = std::iter::once("flyline").chain(args.iter().copied());
+/// Parse `args` (without the leading program name) as flyline CLI arguments and
+/// apply them to `cfg`. Shared by the Bash builtin and standalone hosts so both
+/// dispatch identical commands; returns a builtin exit code.
+pub fn run_flyline_command(cfg: &mut settings::Settings, args: &[&str]) -> c_int {
+    // args contains words from WordList; first word is not the command name unlike argv
+    let args_with_prog = std::iter::once("flyline").chain(args.iter().copied());
 
-        match FlylineArgs::try_parse_from(args_with_prog) {
-            Ok(parsed) if !args.is_empty() => {
-                log::debug!("Parsed flyline arguments: {:?}", parsed);
+    match FlylineArgs::try_parse_from(args_with_prog) {
+        Ok(parsed) if !args.is_empty() => {
+            log::debug!("Parsed flyline arguments: {:?}", parsed);
 
-                if parsed.version {
-                    println!(
-                        "flyline version {} ({}) git:{} built:{}",
-                        env!("CARGO_PKG_VERSION"),
-                        if cfg!(debug_assertions) {
-                            "debug"
-                        } else {
-                            "release"
+            if parsed.version {
+                println!(
+                    "flyline version {} ({}) git:{} built:{}",
+                    env!("CARGO_PKG_VERSION"),
+                    if cfg!(debug_assertions) {
+                        "debug"
+                    } else {
+                        "release"
+                    },
+                    env!("GIT_HASH"),
+                    env!("BUILD_TIME"),
+                );
+            }
+
+            if let Some(path) = parsed.load_zsh_history {
+                cfg.zsh_history_path = Some(path);
+            }
+
+            if let Some(enabled) = parsed.show_animations {
+                log::info!("Animations disabled: {}", enabled);
+                cfg.show_animations = enabled;
+            }
+
+            if let Some(val) = parsed.matrix_animation {
+                log::info!("Matrix animation set to {:?}", val);
+                cfg.matrix_animation = val;
+            }
+
+            if let Some(fps) = parsed.frame_rate {
+                log::info!("Frame rate set to {}", fps);
+                cfg.frame_rate = fps;
+            }
+
+            if let Some(mode) = parsed.mouse_mode {
+                log::info!("Mouse mode set to {:?}", mode);
+                cfg.mouse_mode = mode;
+            }
+
+            if let Some(level) = parsed.send_shell_integration_codes {
+                log::info!("Shell integration codes set to {:?}", level);
+                cfg.send_shell_integration_codes = level;
+            }
+
+            if let Some(enabled) = parsed.enable_extended_key_codes {
+                log::info!("Extended keyboard codes enabled: {}", enabled);
+                cfg.enable_extended_key_codes = enabled;
+            }
+
+            match parsed.command {
+                Some(Commands::AgentMode {
+                    system_prompt,
+                    trigger_prefix,
+                    command,
+                }) => {
+                    let command_args: Vec<String> = shlex::split(&command)
+                        .unwrap_or_else(|| command.split_whitespace().map(String::from).collect());
+                    if command_args.is_empty() {
+                        return_usage_error!("flyline set-agent-mode: --command must not be empty");
+                    }
+                    log::info!(
+                        "AI command set: {:?} (trigger_prefix={:?})",
+                        command_args,
+                        trigger_prefix
+                    );
+                    cfg.agent_commands.insert(
+                        trigger_prefix.clone(),
+                        settings::AgentModeCommand {
+                            command: command_args,
+                            system_prompt: system_prompt.clone(),
                         },
-                        env!("GIT_HASH"),
-                        env!("BUILD_TIME"),
                     );
                 }
-
-                if let Some(path) = parsed.load_zsh_history {
-                    self.settings.zsh_history_path = Some(path);
-                }
-
-                if let Some(enabled) = parsed.show_animations {
-                    log::info!("Animations disabled: {}", enabled);
-                    self.settings.show_animations = enabled;
-                }
-
-                if let Some(val) = parsed.matrix_animation {
-                    log::info!("Matrix animation set to {:?}", val);
-                    self.settings.matrix_animation = val;
-                }
-
-                if let Some(fps) = parsed.frame_rate {
-                    log::info!("Frame rate set to {}", fps);
-                    self.settings.frame_rate = fps;
-                }
-
-                if let Some(mode) = parsed.mouse_mode {
-                    log::info!("Mouse mode set to {:?}", mode);
-                    self.settings.mouse_mode = mode;
-                }
-
-                if let Some(level) = parsed.send_shell_integration_codes {
-                    log::info!("Shell integration codes set to {:?}", level);
-                    self.settings.send_shell_integration_codes = level;
-                }
-
-                if let Some(enabled) = parsed.enable_extended_key_codes {
-                    log::info!("Extended keyboard codes enabled: {}", enabled);
-                    self.settings.enable_extended_key_codes = enabled;
-                }
-
-                match parsed.command {
-                    Some(Commands::AgentMode {
-                        system_prompt,
-                        trigger_prefix,
+                Some(Commands::CreatePromptWidget { subcommand }) => match subcommand {
+                    PromptWidgetSubcommands::Animation {
+                        name,
+                        fps,
+                        frames,
+                        ping_pong,
+                    } => {
+                        if fps <= 0.0 {
+                            return_usage_error!(
+                                "flyline create-prompt-widget animation: --fps must be greater than 0 (got {}); animation '{}' not registered",
+                                fps,
+                                name
+                            );
+                        }
+                        log::info!(
+                            "Registering animation '{}' at {} fps with {} frame(s) (ping_pong={})",
+                            name,
+                            fps,
+                            frames.len(),
+                            ping_pong
+                        );
+                        cfg.custom_animations.insert(
+                            name.clone(),
+                            settings::PromptAnimation {
+                                name,
+                                fps,
+                                frames,
+                                ping_pong,
+                            },
+                        );
+                    }
+                    PromptWidgetSubcommands::MouseMode {
+                        name,
+                        enabled_text,
+                        disabled_text,
+                    } => {
+                        log::info!(
+                            "Registering mouse-mode widget '{}' (enabled={:?}, disabled={:?})",
+                            name,
+                            enabled_text,
+                            disabled_text
+                        );
+                        cfg.custom_prompt_widgets.insert(
+                            name.clone(),
+                            settings::PromptWidget::MouseMode {
+                                name,
+                                enabled_text,
+                                disabled_text,
+                            },
+                        );
+                    }
+                    PromptWidgetSubcommands::CopyBuffer { name, text } => {
+                        log::info!(
+                            "Registering copy-buffer widget '{}' (text={:?})",
+                            name,
+                            text
+                        );
+                        cfg.custom_prompt_widgets.insert(
+                            name.clone(),
+                            settings::PromptWidget::CopyBuffer { name, text },
+                        );
+                    }
+                    PromptWidgetSubcommands::Custom {
+                        name,
                         command,
-                    }) => {
+                        block,
+                        placeholder,
+                    } => {
                         let command_args: Vec<String> =
                             shlex::split(&command).unwrap_or_else(|| {
                                 command.split_whitespace().map(String::from).collect()
                             });
                         if command_args.is_empty() {
                             return_usage_error!(
-                                "flyline set-agent-mode: --command must not be empty"
+                                "flyline create-prompt-widget custom: --command must not be empty"
                             );
                         }
-                        log::info!(
-                            "AI command set: {:?} (trigger_prefix={:?})",
-                            command_args,
-                            trigger_prefix
-                        );
-                        self.settings.agent_commands.insert(
-                            trigger_prefix.clone(),
-                            settings::AgentModeCommand {
-                                command: command_args,
-                                system_prompt: system_prompt.clone(),
+                        if let Some(ms) = block
+                            && ms < 0
+                        {
+                            return_usage_error!(
+                                "flyline create-prompt-widget custom: --block timeout must be non-negative (got {})",
+                                ms
+                            );
+                        }
+                        let placeholder_spec = match placeholder {
+                            None => None,
+                            Some(ref s) if s == "prev" => Some(settings::Placeholder::Prev),
+                            Some(ref s) => match s.parse::<usize>() {
+                                Ok(n) => Some(settings::Placeholder::Spaces(n)),
+                                Err(_) => {
+                                    return_usage_error!(
+                                        "flyline create-prompt-widget custom: --placeholder must be a number or 'prev', got {:?}",
+                                        s
+                                    );
+                                }
                             },
+                        };
+                        log::info!(
+                            "Registering custom widget '{}' (command={:?}, block={:?}, placeholder={:?})",
+                            name,
+                            command_args,
+                            block,
+                            placeholder
+                        );
+                        cfg.custom_prompt_widgets.insert(
+                            name.clone(),
+                            settings::PromptWidget::Custom(settings::PromptWidgetCustom {
+                                name,
+                                command: command_args,
+                                block,
+                                placeholder: placeholder_spec.unwrap_or_default(),
+                                prev_output: std::sync::Arc::new(std::sync::Mutex::new(vec![])),
+                            }),
                         );
                     }
-                    Some(Commands::CreatePromptWidget { subcommand }) => match subcommand {
-                        PromptWidgetSubcommands::Animation {
-                            name,
-                            fps,
-                            frames,
-                            ping_pong,
-                        } => {
-                            if fps <= 0.0 {
+                    PromptWidgetSubcommands::LastCommandDuration { name } => {
+                        log::info!("Registering last-command-duration widget '{}'", name);
+                        cfg.custom_prompt_widgets.insert(
+                            name.clone(),
+                            settings::PromptWidget::LastCommandDuration { name },
+                        );
+                    }
+                },
+                Some(Commands::SetColour {
+                    default_theme,
+                    styles,
+                }) => {
+                    if let Some(preset) = default_theme {
+                        cfg.colour_palette.apply_theme(preset);
+                        log::info!("Colour theme set to {:?}", preset);
+                    }
+
+                    for spec in &styles {
+                        let Some((name, style_str)) = spec.split_once('=') else {
+                            return_usage_error!(
+                                "flyline set-style: argument must be NAME=STYLE, got {:?}",
+                                spec
+                            );
+                        };
+                        let kind = match name.parse::<palette::PaletteStyleKind>() {
+                            Ok(k) => k,
+                            Err(_) => {
                                 return_usage_error!(
-                                    "flyline create-prompt-widget animation: --fps must be greater than 0 (got {}); animation '{}' not registered",
-                                    fps,
+                                    "flyline set-style: unknown style name {:?}. Run 'flyline set-style --help' for valid names.",
                                     name
                                 );
                             }
-                            log::info!(
-                                "Registering animation '{}' at {} fps with {} frame(s) (ping_pong={})",
-                                name,
-                                fps,
-                                frames.len(),
-                                ping_pong
-                            );
-                            self.settings.custom_animations.insert(
-                                name.clone(),
-                                settings::PromptAnimation {
+                        };
+                        match palette::parse_str_to_style(style_str) {
+                            Ok(style) => {
+                                cfg.colour_palette.set(kind, style);
+                                log::info!("{} style set to {:?}", name, style_str);
+                            }
+                            Err(e) => {
+                                return_usage_error!(
+                                    "flyline set-style: invalid style for {:?}: {}",
                                     name,
-                                    fps,
-                                    frames,
-                                    ping_pong,
-                                },
-                            );
-                        }
-                        PromptWidgetSubcommands::MouseMode {
-                            name,
-                            enabled_text,
-                            disabled_text,
-                        } => {
-                            log::info!(
-                                "Registering mouse-mode widget '{}' (enabled={:?}, disabled={:?})",
-                                name,
-                                enabled_text,
-                                disabled_text
-                            );
-                            self.settings.custom_prompt_widgets.insert(
-                                name.clone(),
-                                settings::PromptWidget::MouseMode {
-                                    name,
-                                    enabled_text,
-                                    disabled_text,
-                                },
-                            );
-                        }
-                        PromptWidgetSubcommands::CopyBuffer { name, text } => {
-                            log::info!(
-                                "Registering copy-buffer widget '{}' (text={:?})",
-                                name,
-                                text
-                            );
-                            self.settings.custom_prompt_widgets.insert(
-                                name.clone(),
-                                settings::PromptWidget::CopyBuffer { name, text },
-                            );
-                        }
-                        PromptWidgetSubcommands::Custom {
-                            name,
-                            command,
-                            block,
-                            placeholder,
-                        } => {
-                            let command_args: Vec<String> =
-                                shlex::split(&command).unwrap_or_else(|| {
-                                    command.split_whitespace().map(String::from).collect()
-                                });
-                            if command_args.is_empty() {
-                                return_usage_error!(
-                                    "flyline create-prompt-widget custom: --command must not be empty"
-                                );
-                            }
-                            if let Some(ms) = block
-                                && ms < 0
-                            {
-                                return_usage_error!(
-                                    "flyline create-prompt-widget custom: --block timeout must be non-negative (got {})",
-                                    ms
-                                );
-                            }
-                            let placeholder_spec = match placeholder {
-                                None => None,
-                                Some(ref s) if s == "prev" => Some(settings::Placeholder::Prev),
-                                Some(ref s) => match s.parse::<usize>() {
-                                    Ok(n) => Some(settings::Placeholder::Spaces(n)),
-                                    Err(_) => {
-                                        return_usage_error!(
-                                            "flyline create-prompt-widget custom: --placeholder must be a number or 'prev', got {:?}",
-                                            s
-                                        );
-                                    }
-                                },
-                            };
-                            log::info!(
-                                "Registering custom widget '{}' (command={:?}, block={:?}, placeholder={:?})",
-                                name,
-                                command_args,
-                                block,
-                                placeholder
-                            );
-                            self.settings.custom_prompt_widgets.insert(
-                                name.clone(),
-                                settings::PromptWidget::Custom(settings::PromptWidgetCustom {
-                                    name,
-                                    command: command_args,
-                                    block,
-                                    placeholder: placeholder_spec.unwrap_or_default(),
-                                    prev_output: std::sync::Arc::new(std::sync::Mutex::new(vec![])),
-                                }),
-                            );
-                        }
-                        PromptWidgetSubcommands::LastCommandDuration { name } => {
-                            log::info!("Registering last-command-duration widget '{}'", name);
-                            self.settings.custom_prompt_widgets.insert(
-                                name.clone(),
-                                settings::PromptWidget::LastCommandDuration { name },
-                            );
-                        }
-                    },
-                    Some(Commands::SetColour {
-                        default_theme,
-                        styles,
-                    }) => {
-                        if let Some(preset) = default_theme {
-                            self.settings.colour_palette.apply_theme(preset);
-                            log::info!("Colour theme set to {:?}", preset);
-                        }
-
-                        for spec in &styles {
-                            let Some((name, style_str)) = spec.split_once('=') else {
-                                return_usage_error!(
-                                    "flyline set-style: argument must be NAME=STYLE, got {:?}",
-                                    spec
-                                );
-                            };
-                            let kind = match name.parse::<palette::PaletteStyleKind>() {
-                                Ok(k) => k,
-                                Err(_) => {
-                                    return_usage_error!(
-                                        "flyline set-style: unknown style name {:?}. Run 'flyline set-style --help' for valid names.",
-                                        name
-                                    );
-                                }
-                            };
-                            match palette::parse_str_to_style(style_str) {
-                                Ok(style) => {
-                                    self.settings.colour_palette.set(kind, style);
-                                    log::info!("{} style set to {:?}", name, style_str);
-                                }
-                                Err(e) => {
-                                    return_usage_error!(
-                                        "flyline set-style: invalid style for {:?}: {}",
-                                        name,
-                                        e
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    Some(Commands::Key { debug, subcommand }) => {
-                        if let Some(enabled) = debug {
-                            log::info!("Key debug mode enabled: {}", enabled);
-                            self.settings.key_debug = enabled;
-                        }
-
-                        match subcommand {
-                            Some(KeySubcommands::Bind {
-                                key_sequence,
-                                context_and_action,
-                            }) => {
-                                let binding = actions::Binding::try_new_from_strs(
-                                    &key_sequence,
-                                    &context_and_action,
-                                );
-                                match binding {
-                                    Ok(binding) => {
-                                        log::info!(
-                                            "Registering key binding: {} -> {}",
-                                            key_sequence,
-                                            context_and_action
-                                        );
-                                        self.settings.keybindings.push(binding);
-                                    }
-                                    Err(e) => {
-                                        return_usage_error!(
-                                            "flyline key bind: failed to parse key sequence '{}' or context/action '{}': {}",
-                                            key_sequence,
-                                            context_and_action,
-                                            e
-                                        );
-                                    }
-                                }
-                            }
-                            Some(KeySubcommands::List { key_sequence }) => {
-                                actions::print_bindings_table(
-                                    &self.settings.keybindings,
-                                    key_sequence.as_deref(),
-                                    &self.settings.key_remappings,
-                                );
-                            }
-                            Some(KeySubcommands::Remap { from, to }) => {
-                                match actions::try_parse_remap(&from, &to) {
-                                    Ok(remap) => {
-                                        log::info!("Registering key remap: {} -> {}", from, to);
-                                        self.settings.key_remappings.push(remap);
-                                    }
-                                    Err(e) => {
-                                        return_usage_error!(
-                                            "flyline key remap: failed to parse remap '{}' -> '{}': {}",
-                                            from,
-                                            to,
-                                            e
-                                        );
-                                    }
-                                }
-                            }
-                            None => {}
-                        }
-                    }
-                    Some(Commands::Mouse {
-                        debug,
-                        change_shape,
-                        mode,
-                    }) => {
-                        if let Some(enabled) = debug {
-                            log::info!("Mouse debug mode enabled: {}", enabled);
-                            self.settings.mouse_debug = enabled;
-                        }
-                        if let Some(enabled) = change_shape {
-                            log::info!("Mouse change shape enabled: {}", enabled);
-                            self.settings.mouse_change_shape = enabled;
-                        }
-                        if let Some(m) = mode {
-                            log::info!("Mouse mode set to {:?}", m);
-                            self.settings.mouse_mode = m;
-                        }
-                    }
-                    None => {}
-                    Some(Commands::Log { subcommand }) => match subcommand {
-                        LogSubcommands::Dump => {
-                            if let Err(e) = logging::dump_logs_stdout() {
-                                eprintln!("Failed to dump logs: {}", e);
-                            }
-                        }
-                        LogSubcommands::SetLevel { level } => {
-                            let filter = log::LevelFilter::from(level);
-                            log::set_max_level(filter);
-                            log::info!("Log level set to {:?}", filter);
-                        }
-                        LogSubcommands::Stream { dest } => match logging::stream_logs(&dest) {
-                            Ok(()) => {
-                                if dest == "terminal" {
-                                    log::info!("Log streaming to terminal");
-                                } else {
-                                    println!("Flyline logs streaming to {}", dest);
-                                }
-                            }
-                            Err(e) => eprintln!("Failed to stream logs: {}", e),
-                        },
-                    },
-                    Some(Commands::RunTutorial { enabled }) => {
-                        let enabled = enabled.unwrap_or(true);
-                        log::info!("Run tutorial set to {}", enabled);
-                        self.settings.run_tutorial = enabled;
-                        if enabled {
-                            self.settings.tutorial_step = tutorial::TutorialStep::Welcome;
-                            // clear the terminal:
-                            if let Err(e) = crossterm::execute!(
-                                std::io::stdout(),
-                                crossterm::terminal::Clear(crossterm::terminal::ClearType::All),
-                                crossterm::cursor::MoveTo(0, 0)
-                            ) {
-                                log::warn!("Failed to clear terminal: {}", e);
-                            }
-                        } else {
-                            self.settings.tutorial_step = tutorial::TutorialStep::NotRunning;
-                        }
-                    }
-                    Some(Commands::Editor {
-                        auto_close_chars,
-                        show_inline_history,
-                        select_with_mouse,
-                    }) => {
-                        if let Some(enabled) = auto_close_chars {
-                            log::info!("Auto closing char set to {}", enabled);
-                            self.settings.auto_close_chars = enabled;
-                        }
-                        if let Some(enabled) = show_inline_history {
-                            log::info!("Inline history suggestions set to {}", enabled);
-                            self.settings.show_inline_history = enabled;
-                        }
-                        if let Some(enabled) = select_with_mouse {
-                            log::info!("Select with mouse set to {}", enabled);
-                            self.settings.select_with_mouse = enabled;
-                        }
-                    }
-                    Some(Commands::Suggestions {
-                        subcommand,
-                        auto_suggest,
-                        use_flycomp,
-                        sort_order,
-                        num_suggestion_rows,
-                        flycomp_output,
-                        flycomp_blacklist,
-                    }) => {
-                        if let Some(sub) = subcommand {
-                            match sub {
-                                SuggestionsSubcommands::SetFuzzyMode { mode } => {
-                                    log::info!("Fuzzy mode set to {:?}", mode);
-                                    self.settings.fuzzy_mode = mode;
-                                }
-                            }
-                        }
-                        if let Some(list) = flycomp_blacklist {
-                            log::info!("Flycomp blacklist set to {:?}", list);
-                            self.settings.flycomp_blacklist = list.into_iter().collect();
-                        }
-                        if let Some(enabled) = auto_suggest {
-                            log::info!("Auto tab-completion suggestions set to {}", enabled);
-                            self.settings.auto_suggest = enabled;
-                        }
-                        if let Some(enabled) = use_flycomp {
-                            log::info!("Use flycomp set to {}", enabled);
-                            self.settings.use_flycomp = enabled;
-                        }
-                        if let Some(order) = sort_order {
-                            log::info!("Suggestion sort order set to {:?}", order);
-                            self.settings.suggestion_sort_order = order;
-                        }
-                        if let Some(num) = num_suggestion_rows {
-                            if num == 0 {
-                                return_usage_error!(
-                                    "flyline suggestions: --num-suggestion-rows must be greater than 0"
-                                );
-                            }
-                            log::info!("Suggestion row limit set to {}", num);
-                            self.settings.num_suggestion_rows = num;
-                        }
-                        if let Some(path) = flycomp_output {
-                            log::info!("Flycomp output directory set to '{}'", path);
-                            self.settings.flycomp_output = Some(path);
-                        }
-                    }
-                    Some(Commands::Time { format }) => {
-                        if let Some(fmt) = format {
-                            let has_error = chrono::format::strftime::StrftimeItems::new(&fmt)
-                                .any(|item| matches!(item, chrono::format::Item::Error));
-                            if has_error {
-                                return_usage_error!(
-                                    "flyline time: invalid Chrono format string: {:?}",
-                                    fmt
-                                );
-                            }
-                            println!("{}", chrono::Local::now().format(&fmt));
-                        } else {
-                            let ns = std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .unwrap_or_default()
-                                .as_nanos();
-                            println!("{}", ns);
-                        }
-                    }
-                    Some(Commands::SetCursor {
-                        backend,
-                        interpolate,
-                        interpolate_easing,
-                        style,
-                        effect,
-                        effect_speed,
-                        effect_easing,
-                    }) => {
-                        // set backend first since it affects the validity of other options
-                        if let Some(b) = backend {
-                            log::info!("Cursor backend set to {:?}", b);
-                            self.settings.cursor_config.backend = b;
-                            if b == cursor::CursorBackend::Terminal
-                                && (style.is_some()
-                                    || effect.is_some()
-                                    || effect_speed.is_some()
-                                    || effect_easing.is_some())
-                            {
-                                return_usage_error!(
-                                    "flyline set-cursor: --style, --effect, --effect-speed, and --effect-easing require --backend flyline"
+                                    e
                                 );
                             }
                         }
-
-                        // Helper closure: every flyline-only option emits the same error.
-                        // Returning a `bool` lets callers chain it with the option-presence check.
-                        let backend_is_terminal =
-                            self.settings.cursor_config.backend == cursor::CursorBackend::Terminal;
-
-                        if let Some(interp_str) = interpolate {
-                            if interp_str.eq_ignore_ascii_case("none") {
-                                log::info!("Cursor interpolation disabled");
-                                self.settings.cursor_config.interpolate = None;
-                            } else {
-                                match interp_str.parse::<f32>() {
-                                    Ok(speed) if speed > 0.0 => {
-                                        log::info!("Cursor interpolation speed set to {}", speed);
-                                        self.settings.cursor_config.interpolate = Some(speed);
-                                    }
-                                    _ => {
-                                        return_usage_error!(
-                                            "flyline set-cursor: --interpolate must be a positive number or 'none' (got {:?})",
-                                            interp_str
-                                        );
-                                    }
-                                }
-                            }
-                        }
-
-                        if let Some(easing) = interpolate_easing {
-                            log::info!("Cursor interpolation easing set to {:?}", easing);
-                            self.settings.cursor_config.interpolate_easing = easing;
-                        }
-
-                        if let Some(style_str) = style {
-                            if backend_is_terminal {
-                                return_usage_error!(
-                                    "flyline set-cursor: --style requires --backend flyline"
-                                );
-                            }
-                            match palette::parse_cursor_style_str(&style_str) {
-                                Ok(s) => {
-                                    log::info!("Cursor style set to {:?}", s);
-                                    self.settings.cursor_config.style = s;
-                                }
-                                Err(e) => {
-                                    return_usage_error!(
-                                        "flyline set-cursor: invalid --style {:?}: {}",
-                                        style_str,
-                                        e
-                                    );
-                                }
-                            }
-                        }
-
-                        if let Some(eff) = effect {
-                            if backend_is_terminal {
-                                return_usage_error!(
-                                    "flyline set-cursor: --effect requires --backend flyline"
-                                );
-                            }
-                            if eff == cursor::CursorEffect::Fade
-                                && let CursorStyleConfig::Custom(style) =
-                                    self.settings.cursor_config.style
-                                && !matches!(style.bg, Some(ratatui::style::Color::Rgb(..)))
-                            {
-                                return_usage_error!(
-                                    "flyline set-cursor: --effect fade requires a custom style with an RGB background color (e.g. '#ff0000')"
-                                );
-                            }
-                            log::info!("Cursor effect set to {:?}", eff);
-                            self.settings.cursor_config.effect = eff;
-                        }
-
-                        if let Some(speed) = effect_speed {
-                            if backend_is_terminal {
-                                return_usage_error!(
-                                    "flyline set-cursor: --effect-speed requires --backend flyline"
-                                );
-                            }
-                            if speed > 0.0 {
-                                log::info!("Cursor effect speed set to {}", speed);
-                                self.settings.cursor_config.effect_speed = speed;
-                            } else {
-                                return_usage_error!(
-                                    "flyline set-cursor: --effect-speed must be positive (got {})",
-                                    speed
-                                );
-                            }
-                        }
-
-                        if let Some(easing) = effect_easing {
-                            if backend_is_terminal {
-                                return_usage_error!(
-                                    "flyline set-cursor: --effect-easing requires --backend flyline"
-                                );
-                            }
-                            log::info!("Cursor effect easing set to {:?}", easing);
-                            self.settings.cursor_config.effect_easing = easing;
-                        }
-                    }
-                    Some(Commands::Perf { subcommand }) => match subcommand {
-                        PerfSubcommands::Start => {
-                            crate::perf::start_recording();
-                            println!("Performance recording started.");
-                        }
-                        PerfSubcommands::Stop => {
-                            crate::perf::stop_recording();
-                            println!("Performance recording stopped.");
-                        }
-                        PerfSubcommands::Dump => {
-                            crate::perf::dump_to_stdout();
-                        }
-                    },
-                    Some(Commands::Changelog) => {
-                        let content = crate::changelog::CHANGELOG;
-                        let pager = std::env::var("PAGER").unwrap_or_else(|_| "less".to_string());
-                        let mut parts = pager.split_whitespace();
-                        if let Some(bin) = parts.next() {
-                            let args: Vec<&str> = parts.collect();
-                            let mut cmd = std::process::Command::new(bin);
-                            cmd.args(&args);
-                            if bin == "less" && args.is_empty() {
-                                cmd.args(["-R", "-F", "-X"]);
-                            }
-                            cmd.stdin(std::process::Stdio::piped());
-                            match cmd.spawn() {
-                                Ok(mut child_proc) => {
-                                    if let Some(mut stdin) = child_proc.stdin.take() {
-                                        use std::io::Write;
-                                        if stdin.write_all(content.as_bytes()).is_ok() {
-                                            drop(stdin); // close stdin to signal EOF to the pager
-                                            let _ = child_proc.wait();
-                                        }
-                                    }
-                                }
-                                Err(_) => {
-                                    println!("{}", content);
-                                }
-                            }
-                        } else {
-                            println!("{}", content);
-                        }
-                    }
-                    Some(Commands::Upgrade) => {
-                        println!("Flyline is a purely offline piece of software. Please run:");
-                        println!(
-                            "curl -sSfL https://github.com/HalFrgrd/flyline/releases/latest/download/install.sh | sh"
-                        );
-                        self.settings.initial_buffer = Some("curl -sSfL https://github.com/HalFrgrd/flyline/releases/latest/download/install.sh | sh".to_string());
                     }
                 }
+                Some(Commands::Key { debug, subcommand }) => {
+                    if let Some(enabled) = debug {
+                        log::info!("Key debug mode enabled: {}", enabled);
+                        cfg.key_debug = enabled;
+                    }
 
-                bash_symbols::BuiltinExitCode::ExecutionSuccess as c_int
+                    match subcommand {
+                        Some(KeySubcommands::Bind {
+                            key_sequence,
+                            context_and_action,
+                        }) => {
+                            let binding = actions::Binding::try_new_from_strs(
+                                &key_sequence,
+                                &context_and_action,
+                            );
+                            match binding {
+                                Ok(binding) => {
+                                    log::info!(
+                                        "Registering key binding: {} -> {}",
+                                        key_sequence,
+                                        context_and_action
+                                    );
+                                    cfg.keybindings.push(binding);
+                                }
+                                Err(e) => {
+                                    return_usage_error!(
+                                        "flyline key bind: failed to parse key sequence '{}' or context/action '{}': {}",
+                                        key_sequence,
+                                        context_and_action,
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                        Some(KeySubcommands::List { key_sequence }) => {
+                            actions::print_bindings_table(
+                                &cfg.keybindings,
+                                key_sequence.as_deref(),
+                                &cfg.key_remappings,
+                            );
+                        }
+                        Some(KeySubcommands::Remap { from, to }) => {
+                            match actions::try_parse_remap(&from, &to) {
+                                Ok(remap) => {
+                                    log::info!("Registering key remap: {} -> {}", from, to);
+                                    cfg.key_remappings.push(remap);
+                                }
+                                Err(e) => {
+                                    return_usage_error!(
+                                        "flyline key remap: failed to parse remap '{}' -> '{}': {}",
+                                        from,
+                                        to,
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                        None => {}
+                    }
+                }
+                Some(Commands::Mouse {
+                    debug,
+                    change_shape,
+                    mode,
+                }) => {
+                    if let Some(enabled) = debug {
+                        log::info!("Mouse debug mode enabled: {}", enabled);
+                        cfg.mouse_debug = enabled;
+                    }
+                    if let Some(enabled) = change_shape {
+                        log::info!("Mouse change shape enabled: {}", enabled);
+                        cfg.mouse_change_shape = enabled;
+                    }
+                    if let Some(m) = mode {
+                        log::info!("Mouse mode set to {:?}", m);
+                        cfg.mouse_mode = m;
+                    }
+                }
+                None => {}
+                Some(Commands::Log { subcommand }) => match subcommand {
+                    LogSubcommands::Dump => {
+                        if let Err(e) = logging::dump_logs_stdout() {
+                            eprintln!("Failed to dump logs: {}", e);
+                        }
+                    }
+                    LogSubcommands::SetLevel { level } => {
+                        let filter = log::LevelFilter::from(level);
+                        log::set_max_level(filter);
+                        log::info!("Log level set to {:?}", filter);
+                    }
+                    LogSubcommands::Stream { dest } => match logging::stream_logs(&dest) {
+                        Ok(()) => {
+                            if dest == "terminal" {
+                                log::info!("Log streaming to terminal");
+                            } else {
+                                println!("Flyline logs streaming to {}", dest);
+                            }
+                        }
+                        Err(e) => eprintln!("Failed to stream logs: {}", e),
+                    },
+                },
+                Some(Commands::RunTutorial { enabled }) => {
+                    let enabled = enabled.unwrap_or(true);
+                    log::info!("Run tutorial set to {}", enabled);
+                    cfg.run_tutorial = enabled;
+                    if enabled {
+                        cfg.tutorial_step = tutorial::TutorialStep::Welcome;
+                        // clear the terminal:
+                        if let Err(e) = crossterm::execute!(
+                            std::io::stdout(),
+                            crossterm::terminal::Clear(crossterm::terminal::ClearType::All),
+                            crossterm::cursor::MoveTo(0, 0)
+                        ) {
+                            log::warn!("Failed to clear terminal: {}", e);
+                        }
+                    } else {
+                        cfg.tutorial_step = tutorial::TutorialStep::NotRunning;
+                    }
+                }
+                Some(Commands::Editor {
+                    auto_close_chars,
+                    show_inline_history,
+                    select_with_mouse,
+                }) => {
+                    if let Some(enabled) = auto_close_chars {
+                        log::info!("Auto closing char set to {}", enabled);
+                        cfg.auto_close_chars = enabled;
+                    }
+                    if let Some(enabled) = show_inline_history {
+                        log::info!("Inline history suggestions set to {}", enabled);
+                        cfg.show_inline_history = enabled;
+                    }
+                    if let Some(enabled) = select_with_mouse {
+                        log::info!("Select with mouse set to {}", enabled);
+                        cfg.select_with_mouse = enabled;
+                    }
+                }
+                Some(Commands::Suggestions {
+                    subcommand,
+                    auto_suggest,
+                    use_flycomp,
+                    sort_order,
+                    num_suggestion_rows,
+                    flycomp_output,
+                    flycomp_blacklist,
+                }) => {
+                    if let Some(sub) = subcommand {
+                        match sub {
+                            SuggestionsSubcommands::SetFuzzyMode { mode } => {
+                                log::info!("Fuzzy mode set to {:?}", mode);
+                                cfg.fuzzy_mode = mode;
+                            }
+                        }
+                    }
+                    if let Some(list) = flycomp_blacklist {
+                        log::info!("Flycomp blacklist set to {:?}", list);
+                        cfg.flycomp_blacklist = list.into_iter().collect();
+                    }
+                    if let Some(enabled) = auto_suggest {
+                        log::info!("Auto tab-completion suggestions set to {}", enabled);
+                        cfg.auto_suggest = enabled;
+                    }
+                    if let Some(enabled) = use_flycomp {
+                        log::info!("Use flycomp set to {}", enabled);
+                        cfg.use_flycomp = enabled;
+                    }
+                    if let Some(order) = sort_order {
+                        log::info!("Suggestion sort order set to {:?}", order);
+                        cfg.suggestion_sort_order = order;
+                    }
+                    if let Some(num) = num_suggestion_rows {
+                        if num == 0 {
+                            return_usage_error!(
+                                "flyline suggestions: --num-suggestion-rows must be greater than 0"
+                            );
+                        }
+                        log::info!("Suggestion row limit set to {}", num);
+                        cfg.num_suggestion_rows = num;
+                    }
+                    if let Some(path) = flycomp_output {
+                        log::info!("Flycomp output directory set to '{}'", path);
+                        cfg.flycomp_output = Some(path);
+                    }
+                }
+                Some(Commands::Time { format }) => {
+                    if let Some(fmt) = format {
+                        let has_error = chrono::format::strftime::StrftimeItems::new(&fmt)
+                            .any(|item| matches!(item, chrono::format::Item::Error));
+                        if has_error {
+                            return_usage_error!(
+                                "flyline time: invalid Chrono format string: {:?}",
+                                fmt
+                            );
+                        }
+                        println!("{}", chrono::Local::now().format(&fmt));
+                    } else {
+                        let ns = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_nanos();
+                        println!("{}", ns);
+                    }
+                }
+                Some(Commands::SetCursor {
+                    backend,
+                    interpolate,
+                    interpolate_easing,
+                    style,
+                    effect,
+                    effect_speed,
+                    effect_easing,
+                }) => {
+                    // set backend first since it affects the validity of other options
+                    if let Some(b) = backend {
+                        log::info!("Cursor backend set to {:?}", b);
+                        cfg.cursor_config.backend = b;
+                        if b == cursor::CursorBackend::Terminal
+                            && (style.is_some()
+                                || effect.is_some()
+                                || effect_speed.is_some()
+                                || effect_easing.is_some())
+                        {
+                            return_usage_error!(
+                                "flyline set-cursor: --style, --effect, --effect-speed, and --effect-easing require --backend flyline"
+                            );
+                        }
+                    }
+
+                    // Helper closure: every flyline-only option emits the same error.
+                    // Returning a `bool` lets callers chain it with the option-presence check.
+                    let backend_is_terminal =
+                        cfg.cursor_config.backend == cursor::CursorBackend::Terminal;
+
+                    if let Some(interp_str) = interpolate {
+                        if interp_str.eq_ignore_ascii_case("none") {
+                            log::info!("Cursor interpolation disabled");
+                            cfg.cursor_config.interpolate = None;
+                        } else {
+                            match interp_str.parse::<f32>() {
+                                Ok(speed) if speed > 0.0 => {
+                                    log::info!("Cursor interpolation speed set to {}", speed);
+                                    cfg.cursor_config.interpolate = Some(speed);
+                                }
+                                _ => {
+                                    return_usage_error!(
+                                        "flyline set-cursor: --interpolate must be a positive number or 'none' (got {:?})",
+                                        interp_str
+                                    );
+                                }
+                            }
+                        }
+                    }
+
+                    if let Some(easing) = interpolate_easing {
+                        log::info!("Cursor interpolation easing set to {:?}", easing);
+                        cfg.cursor_config.interpolate_easing = easing;
+                    }
+
+                    if let Some(style_str) = style {
+                        if backend_is_terminal {
+                            return_usage_error!(
+                                "flyline set-cursor: --style requires --backend flyline"
+                            );
+                        }
+                        match palette::parse_cursor_style_str(&style_str) {
+                            Ok(s) => {
+                                log::info!("Cursor style set to {:?}", s);
+                                cfg.cursor_config.style = s;
+                            }
+                            Err(e) => {
+                                return_usage_error!(
+                                    "flyline set-cursor: invalid --style {:?}: {}",
+                                    style_str,
+                                    e
+                                );
+                            }
+                        }
+                    }
+
+                    if let Some(eff) = effect {
+                        if backend_is_terminal {
+                            return_usage_error!(
+                                "flyline set-cursor: --effect requires --backend flyline"
+                            );
+                        }
+                        if eff == cursor::CursorEffect::Fade
+                            && let CursorStyleConfig::Custom(style) = cfg.cursor_config.style
+                            && !matches!(style.bg, Some(ratatui::style::Color::Rgb(..)))
+                        {
+                            return_usage_error!(
+                                "flyline set-cursor: --effect fade requires a custom style with an RGB background color (e.g. '#ff0000')"
+                            );
+                        }
+                        log::info!("Cursor effect set to {:?}", eff);
+                        cfg.cursor_config.effect = eff;
+                    }
+
+                    if let Some(speed) = effect_speed {
+                        if backend_is_terminal {
+                            return_usage_error!(
+                                "flyline set-cursor: --effect-speed requires --backend flyline"
+                            );
+                        }
+                        if speed > 0.0 {
+                            log::info!("Cursor effect speed set to {}", speed);
+                            cfg.cursor_config.effect_speed = speed;
+                        } else {
+                            return_usage_error!(
+                                "flyline set-cursor: --effect-speed must be positive (got {})",
+                                speed
+                            );
+                        }
+                    }
+
+                    if let Some(easing) = effect_easing {
+                        if backend_is_terminal {
+                            return_usage_error!(
+                                "flyline set-cursor: --effect-easing requires --backend flyline"
+                            );
+                        }
+                        log::info!("Cursor effect easing set to {:?}", easing);
+                        cfg.cursor_config.effect_easing = easing;
+                    }
+                }
+                Some(Commands::Perf { subcommand }) => match subcommand {
+                    PerfSubcommands::Start => {
+                        crate::perf::start_recording();
+                        println!("Performance recording started.");
+                    }
+                    PerfSubcommands::Stop => {
+                        crate::perf::stop_recording();
+                        println!("Performance recording stopped.");
+                    }
+                    PerfSubcommands::Dump => {
+                        crate::perf::dump_to_stdout();
+                    }
+                },
+                Some(Commands::Changelog) => {
+                    let content = crate::changelog::CHANGELOG;
+                    let pager = std::env::var("PAGER").unwrap_or_else(|_| "less".to_string());
+                    let mut parts = pager.split_whitespace();
+                    if let Some(bin) = parts.next() {
+                        let args: Vec<&str> = parts.collect();
+                        let mut cmd = std::process::Command::new(bin);
+                        cmd.args(&args);
+                        if bin == "less" && args.is_empty() {
+                            cmd.args(["-R", "-F", "-X"]);
+                        }
+                        cmd.stdin(std::process::Stdio::piped());
+                        match cmd.spawn() {
+                            Ok(mut child_proc) => {
+                                if let Some(mut stdin) = child_proc.stdin.take() {
+                                    use std::io::Write;
+                                    if stdin.write_all(content.as_bytes()).is_ok() {
+                                        drop(stdin); // close stdin to signal EOF to the pager
+                                        let _ = child_proc.wait();
+                                    }
+                                }
+                            }
+                            Err(_) => {
+                                println!("{}", content);
+                            }
+                        }
+                    } else {
+                        println!("{}", content);
+                    }
+                }
+                Some(Commands::Upgrade) => {
+                    println!("Flyline is a purely offline piece of software. Please run:");
+                    println!(
+                        "curl -sSfL https://github.com/HalFrgrd/flyline/releases/latest/download/install.sh | sh"
+                    );
+                    cfg.initial_buffer = Some("curl -sSfL https://github.com/HalFrgrd/flyline/releases/latest/download/install.sh | sh".to_string());
+                }
             }
-            Ok(_) => {
-                log::debug!("No arguments provided to flyline");
-                FlylineArgs::command().print_help().ok();
-                bash_symbols::BuiltinExitCode::Usage as c_int
-            }
-            Err(err) => {
-                match err.kind() {
-                    ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
-                        // user asked for --help / --version
-                        err.print().unwrap();
-                        bash_symbols::BuiltinExitCode::ExecutionSuccess as c_int
-                    }
-                    ErrorKind::UnknownArgument
-                    | ErrorKind::InvalidValue
-                    | ErrorKind::InvalidSubcommand
-                    | ErrorKind::MissingRequiredArgument
-                    | ErrorKind::TooManyValues
-                    | ErrorKind::TooFewValues
-                    | ErrorKind::ValueValidation => {
-                        // user mistake → show error + usage
-                        err.print().unwrap();
-                        bash_symbols::BuiltinExitCode::Usage as c_int
-                    }
-                    _ => {
-                        // unexpected / internal error
-                        eprintln!("{err}");
-                        bash_symbols::BuiltinExitCode::Usage as c_int
-                    }
+
+            bash_symbols::BuiltinExitCode::ExecutionSuccess as c_int
+        }
+        Ok(_) => {
+            log::debug!("No arguments provided to flyline");
+            FlylineArgs::command().print_help().ok();
+            bash_symbols::BuiltinExitCode::Usage as c_int
+        }
+        Err(err) => {
+            match err.kind() {
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
+                    // user asked for --help / --version
+                    err.print().unwrap();
+                    bash_symbols::BuiltinExitCode::ExecutionSuccess as c_int
+                }
+                ErrorKind::UnknownArgument
+                | ErrorKind::InvalidValue
+                | ErrorKind::InvalidSubcommand
+                | ErrorKind::MissingRequiredArgument
+                | ErrorKind::TooManyValues
+                | ErrorKind::TooFewValues
+                | ErrorKind::ValueValidation => {
+                    // user mistake → show error + usage
+                    err.print().unwrap();
+                    bash_symbols::BuiltinExitCode::Usage as c_int
+                }
+                _ => {
+                    // unexpected / internal error
+                    eprintln!("{err}");
+                    bash_symbols::BuiltinExitCode::Usage as c_int
                 }
             }
         }
@@ -1542,5 +1543,35 @@ mod tests {
         assert!(values.contains(&"start".to_string()));
         assert!(values.contains(&"stop".to_string()));
         assert!(values.contains(&"dump".to_string()));
+    }
+
+    const OK: c_int = bash_symbols::BuiltinExitCode::ExecutionSuccess as c_int;
+
+    #[test]
+    fn run_flyline_command_run_tutorial_mutates_settings() {
+        let mut cfg = settings::Settings::default();
+        assert!(!cfg.run_tutorial);
+        let code = run_flyline_command(&mut cfg, &["run-tutorial"]);
+        assert_eq!(code, OK);
+        assert!(cfg.run_tutorial);
+        assert_eq!(cfg.tutorial_step, tutorial::TutorialStep::Welcome);
+    }
+
+    #[test]
+    fn run_flyline_command_suggestions_mutates_settings() {
+        let mut cfg = settings::Settings::default();
+        let code = run_flyline_command(&mut cfg, &["suggestions", "--num-suggestion-rows", "7"]);
+        assert_eq!(code, OK);
+        assert_eq!(cfg.num_suggestion_rows, 7);
+    }
+
+    #[test]
+    fn run_flyline_command_action_leaves_settings_unchanged() {
+        let mut cfg = settings::Settings::default();
+        let before = serde_json::to_string(&cfg).unwrap();
+        let code = run_flyline_command(&mut cfg, &["time"]);
+        assert_eq!(code, OK);
+        let after = serde_json::to_string(&cfg).unwrap();
+        assert_eq!(before, after);
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -13,7 +13,9 @@ use strum::{AsRefStr, EnumString, VariantArray};
 pub const CURSOR_INTENSITY_UNFOCUSED: u8 = 80;
 
 /// Which backend renders the cursor.
-#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(
+    ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize,
+)]
 pub enum CursorBackend {
     /// Flyline renders a custom cursor.
     #[default]
@@ -26,7 +28,19 @@ pub enum CursorBackend {
 ///
 /// Corresponds to the standard easings from the `easing-function` crate:
 /// <https://docs.rs/easing-function/latest/easing_function/easings/index.html>
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, AsRefStr, VariantArray, EnumString)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    AsRefStr,
+    VariantArray,
+    EnumString,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[strum(serialize_all = "kebab-case")]
 pub enum CursorEasing {
     #[default]
@@ -163,7 +177,9 @@ pub fn cursor_effect_animation_frames(
 }
 
 /// Visual effect applied to the cursor.
-#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(
+    ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize,
+)]
 pub enum CursorEffect {
     /// Smoothly oscillate the cursor brightness (default).
     #[default]
@@ -175,7 +191,7 @@ pub enum CursorEffect {
 }
 
 /// How the cursor should be styled.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, serde::Serialize, serde::Deserialize)]
 pub enum CursorStyleConfig {
     /// Default: an intensity-modulated grey/white block (original flyline cursor).
     #[default]
@@ -188,7 +204,7 @@ pub enum CursorStyleConfig {
 }
 
 /// Complete cursor configuration set by `flyline set-cursor`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CursorConfig {
     /// Which backend renders the cursor.
     pub backend: CursorBackend,

--- a/src/flycomp_options.rs
+++ b/src/flycomp_options.rs
@@ -1,0 +1,502 @@
+use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use anyhow::Context;
+use ratatui::text::Span;
+use serde::{Deserialize, Serialize};
+
+use crate::active_suggestions::{
+    ActiveSuggestionsBuilder, ProcessedSuggestion, SuggestionDescription,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct FlycompOptionModel {
+    pub metadata: FlycompMetadata,
+    pub command: FlycompCommand,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct FlycompMetadata {
+    pub flycomp_version: String,
+    pub command_path: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub(crate) struct FlycompCommand {
+    pub name: Option<String>,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    #[serde(default)]
+    pub args: Vec<FlycompArg>,
+    #[serde(default)]
+    pub subcommands: Vec<FlycompCommand>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub(crate) struct FlycompArg {
+    pub long: Option<String>,
+    pub short: Option<String>,
+    pub description: Option<String>,
+    pub value_name: Option<String>,
+    pub num_args: Option<String>,
+    pub value_enum: Option<Vec<String>>,
+    #[serde(default)]
+    pub value_hint: String,
+}
+
+const CACHE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct ExecutableFingerprint {
+    len: u64,
+    modified_secs: u64,
+    modified_nanos: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedOptionModel {
+    schema_version: u32,
+    command_identity: String,
+    executable: Option<ExecutableFingerprint>,
+    model: FlycompOptionModel,
+}
+
+impl FlycompArg {
+    fn takes_value(&self) -> bool {
+        self.value_name.is_some()
+            || self.num_args.is_some()
+            || self.short.as_ref().is_some_and(|flag| flag.ends_with('#'))
+            || self.long.as_ref().is_some_and(|flag| flag.ends_with('#'))
+    }
+
+    fn display_description(&self) -> String {
+        let mut details = Vec::new();
+        if let Some(value_name) = self.value_name.as_deref() {
+            let value_name = value_name.trim();
+            if !value_name.is_empty() {
+                if value_name.starts_with(['<', '[']) {
+                    details.push(value_name.to_string());
+                } else {
+                    details.push(format!("<{value_name}>"));
+                }
+            }
+        } else if self.takes_value() {
+            details.push("<VALUE>".to_string());
+        }
+
+        if let Some(values) = self.value_enum.as_ref().filter(|values| !values.is_empty()) {
+            details.push(format!("[{}]", values.join("|")));
+        }
+
+        if let Some(description) = self.description.as_deref() {
+            let description = description.split_whitespace().collect::<Vec<_>>().join(" ");
+            if !description.is_empty() {
+                details.push(description);
+            }
+        }
+        details.join("  ")
+    }
+}
+
+pub(crate) fn parse_flycomp_json(json: &str) -> anyhow::Result<FlycompOptionModel> {
+    let model: FlycompOptionModel =
+        serde_json::from_str(json).context("invalid flycomp JSON output")?;
+    validate_model(&model)?;
+    Ok(model)
+}
+
+fn validate_model(model: &FlycompOptionModel) -> anyhow::Result<()> {
+    if model.metadata.flycomp_version.trim().is_empty() {
+        anyhow::bail!("flycomp JSON metadata has no version");
+    }
+    if model.metadata.command_path.trim().is_empty() {
+        anyhow::bail!("flycomp JSON metadata has no command path");
+    }
+    if model
+        .command
+        .name
+        .as_deref()
+        .unwrap_or("")
+        .trim()
+        .is_empty()
+    {
+        anyhow::bail!("flycomp JSON has no command name");
+    }
+    Ok(())
+}
+
+fn command_for_context<'a>(
+    root: &'a FlycompCommand,
+    context_before_word: &str,
+) -> &'a FlycompCommand {
+    let Some(words) = shlex::split(context_before_word) else {
+        return root;
+    };
+
+    let mut command = root;
+    for word in words.into_iter().skip(1) {
+        if let Some(subcommand) = command.subcommands.iter().find(|subcommand| {
+            subcommand.name.as_deref() == Some(word.as_str())
+                || subcommand.aliases.iter().any(|alias| alias == &word)
+        }) {
+            command = subcommand;
+        }
+    }
+    command
+}
+
+pub(crate) fn suggestions_from_model(
+    model: &FlycompOptionModel,
+    context_before_word: &str,
+    typed_prefix: &str,
+) -> ActiveSuggestionsBuilder {
+    let command = command_for_context(&model.command, context_before_word);
+    let mut seen = HashSet::new();
+    let mut suggestions = Vec::new();
+
+    for arg in &command.args {
+        let description_text = arg.display_description();
+        let description = if description_text.is_empty() {
+            SuggestionDescription::Static(Vec::new())
+        } else {
+            SuggestionDescription::Static(vec![Span::raw(description_text)])
+        };
+
+        for flag in [arg.long.as_deref(), arg.short.as_deref()]
+            .into_iter()
+            .flatten()
+        {
+            let flag = flag.trim_end_matches('#');
+            if !flag.starts_with('-')
+                || !flag.starts_with(typed_prefix)
+                || !seen.insert(flag.to_string())
+            {
+                continue;
+            }
+            suggestions.push(
+                ProcessedSuggestion::new(flag, "", " ").with_description(description.clone()),
+            );
+        }
+    }
+
+    let mut builder = ActiveSuggestionsBuilder::from_processed(suggestions);
+    builder.set_common_prefix();
+    builder
+}
+
+fn executable_fingerprint(command_identity: &str) -> Option<ExecutableFingerprint> {
+    let metadata = std::fs::metadata(command_identity).ok()?;
+    if !metadata.is_file() {
+        return None;
+    }
+    let modified = metadata.modified().ok()?.duration_since(UNIX_EPOCH).ok()?;
+    Some(ExecutableFingerprint {
+        len: metadata.len(),
+        modified_secs: modified.as_secs(),
+        modified_nanos: modified.subsec_nanos(),
+    })
+}
+
+pub(crate) fn option_cache_root() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".cache")))?;
+    Some(base.join("flyline").join("flycomp-options"))
+}
+
+fn cache_path(root: &Path, command_identity: &str) -> PathBuf {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    command_identity.hash(&mut hasher);
+    let hash = hasher.finish();
+    let name = Path::new(command_identity)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("command")
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    root.join(format!("{name}-{hash:016x}.json"))
+}
+
+pub(crate) fn load_cached_model(command_identity: &str) -> Option<FlycompOptionModel> {
+    let root = option_cache_root()?;
+    load_cached_model_from(&root, command_identity)
+}
+
+fn load_cached_model_from(root: &Path, command_identity: &str) -> Option<FlycompOptionModel> {
+    let path = cache_path(root, command_identity);
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return None,
+        Err(error) => {
+            log::debug!("Could not read flycomp option cache {path:?}: {error}");
+            return None;
+        }
+    };
+    let cached: CachedOptionModel = match serde_json::from_str(&contents) {
+        Ok(cached) => cached,
+        Err(error) => {
+            log::warn!("Ignoring malformed flycomp option cache {path:?}: {error}");
+            return None;
+        }
+    };
+    if cached.schema_version != CACHE_SCHEMA_VERSION
+        || cached.command_identity != command_identity
+        || cached.executable != executable_fingerprint(command_identity)
+        || validate_model(&cached.model).is_err()
+    {
+        log::debug!("Ignoring stale flycomp option cache {path:?}");
+        return None;
+    }
+    Some(cached.model)
+}
+
+pub(crate) fn store_cached_model(
+    command_identity: &str,
+    model: &FlycompOptionModel,
+) -> anyhow::Result<()> {
+    let Some(root) = option_cache_root() else {
+        anyhow::bail!("neither XDG_CACHE_HOME nor HOME is set");
+    };
+    store_cached_model_at(&root, command_identity, model)
+}
+
+fn store_cached_model_at(
+    root: &Path,
+    command_identity: &str,
+    model: &FlycompOptionModel,
+) -> anyhow::Result<()> {
+    validate_model(model)?;
+    if model.metadata.command_path != command_identity {
+        anyhow::bail!(
+            "flycomp JSON command path {:?} does not match {:?}",
+            model.metadata.command_path,
+            command_identity
+        );
+    }
+
+    std::fs::create_dir_all(root)
+        .with_context(|| format!("could not create flycomp option cache {root:?}"))?;
+    let path = cache_path(root, command_identity);
+    let cached = CachedOptionModel {
+        schema_version: CACHE_SCHEMA_VERSION,
+        command_identity: command_identity.to_string(),
+        executable: executable_fingerprint(command_identity),
+        model: model.clone(),
+    };
+    let json = serde_json::to_vec_pretty(&cached).context("could not serialize option cache")?;
+    let temp_path = root.join(format!(
+        ".{}.{}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("flycomp-options"),
+        std::process::id()
+    ));
+
+    let write_result = (|| -> anyhow::Result<()> {
+        let mut file = std::fs::File::create(&temp_path)
+            .with_context(|| format!("could not create temporary cache {temp_path:?}"))?;
+        file.write_all(&json)
+            .with_context(|| format!("could not write temporary cache {temp_path:?}"))?;
+        file.sync_all()
+            .with_context(|| format!("could not flush temporary cache {temp_path:?}"))?;
+        std::fs::rename(&temp_path, &path)
+            .with_context(|| format!("could not replace option cache {path:?}"))?;
+        Ok(())
+    })();
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    write_result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_json(command_path: &str) -> String {
+        format!(
+            r#"{{
+                "metadata": {{
+                    "flycomp_version": "1.1.0",
+                    "command_path": {command_path:?},
+                    "generated_at": "2026-07-11T00:00:00Z"
+                }},
+                "command": {{
+                    "name": "tool",
+                    "args": [
+                        {{
+                            "long": "--color",
+                            "short": "-c",
+                            "description": "choose output color",
+                            "value_name": "WHEN",
+                            "value_enum": ["always", "never"]
+                        }},
+                        {{
+                            "long": "--verbose",
+                            "short": "-v",
+                            "description": "show more detail"
+                        }}
+                    ],
+                    "subcommands": [
+                        {{
+                            "name": "remote",
+                            "aliases": ["r"],
+                            "args": [
+                                {{
+                                    "long": "--delete",
+                                    "description": "delete a remote"
+                                }}
+                            ]
+                        }}
+                    ]
+                }}
+            }}"#
+        )
+    }
+
+    fn sample_model(command_path: &str) -> FlycompOptionModel {
+        parse_flycomp_json(&sample_json(command_path)).unwrap()
+    }
+
+    fn temp_dir(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "flyline-flycomp-options-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn parses_and_filters_root_options_with_descriptions() {
+        let model = sample_model("tool");
+        let mut builder = suggestions_from_model(&model, "tool ", "--col");
+        builder.process_all_blocking();
+
+        assert_eq!(builder.processed.len(), 1);
+        assert_eq!(builder.processed[0].s, "--color");
+        assert_eq!(builder.processed[0].suffix, " ");
+        let SuggestionDescription::Static(spans) = &builder.processed[0].description else {
+            panic!("expected static description");
+        };
+        assert_eq!(
+            spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>(),
+            "<WHEN>  [always|never]  choose output color"
+        );
+    }
+
+    #[test]
+    fn resolves_subcommands_and_aliases() {
+        let model = sample_model("tool");
+        for context in ["tool remote ", "tool r "] {
+            let mut builder = suggestions_from_model(&model, context, "--");
+            builder.process_all_blocking();
+            assert_eq!(
+                builder
+                    .processed
+                    .iter()
+                    .map(|suggestion| suggestion.s.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["--delete"]
+            );
+        }
+    }
+
+    #[test]
+    fn emits_short_and_long_flags_without_duplicates() {
+        let mut model = sample_model("tool");
+        model.command.args.push(FlycompArg {
+            long: Some("--verbose".to_string()),
+            description: Some("duplicate".to_string()),
+            ..FlycompArg::default()
+        });
+        let mut builder = suggestions_from_model(&model, "tool ", "-");
+        builder.process_all_blocking();
+        let values = builder
+            .processed
+            .iter()
+            .map(|suggestion| suggestion.s.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(values, vec!["--color", "-c", "--verbose", "-v"]);
+    }
+
+    #[test]
+    fn rejects_malformed_or_incomplete_json() {
+        assert!(parse_flycomp_json("not json").is_err());
+        assert!(
+            parse_flycomp_json(
+                r#"{"metadata":{"flycomp_version":"1","command_path":"tool"},"command":{}}"#
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn cache_round_trip_and_atomic_replacement() {
+        let root = temp_dir("round-trip");
+        let identity = "tool";
+        let mut model = sample_model(identity);
+        store_cached_model_at(&root, identity, &model).unwrap();
+        assert_eq!(
+            load_cached_model_from(&root, identity)
+                .unwrap()
+                .command
+                .args
+                .len(),
+            2
+        );
+
+        model.command.args.clear();
+        store_cached_model_at(&root, identity, &model).unwrap();
+        assert!(
+            load_cached_model_from(&root, identity)
+                .unwrap()
+                .command
+                .args
+                .is_empty()
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn cache_invalidates_when_executable_changes() {
+        let root = temp_dir("fingerprint");
+        std::fs::create_dir_all(&root).unwrap();
+        let executable = root.join("tool");
+        std::fs::write(&executable, "one").unwrap();
+        let identity = executable.to_string_lossy().into_owned();
+        let model = sample_model(&identity);
+        store_cached_model_at(&root, &identity, &model).unwrap();
+        assert!(load_cached_model_from(&root, &identity).is_some());
+
+        std::fs::write(&executable, "different length").unwrap();
+        assert!(load_cached_model_from(&root, &identity).is_none());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn malformed_cache_is_a_miss() {
+        let root = temp_dir("malformed");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(cache_path(&root, "tool"), "{broken").unwrap();
+        assert!(load_cached_model_from(&root, "tool").is_none());
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/src/globbing.rs
+++ b/src/globbing.rs
@@ -145,7 +145,7 @@ impl PathPatternExpansion {
         let split = split_glob_pattern(pattern);
         let raw_prefix = split.raw_prefix.to_string();
         let rhs_pattern = split.rhs_pattern.to_string();
-        let expanded_prefix = bash_funcs::fully_expand_path(&raw_prefix);
+        let expanded_prefix = crate::shell::backend().expand_path(&raw_prefix);
 
         let rhs_pattern = bash_funcs::dequoting_function_rust(&rhs_pattern);
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -2,11 +2,12 @@ use std::cell::OnceCell;
 use std::time::Instant;
 use std::vec;
 
+use crate::content_utils;
 use crate::content_utils::apply_match_indices_to_lines;
 use crate::palette::Palette;
 use crate::settings::Settings;
+use crate::shell::backend;
 use crate::stateful_sliding_window::StatefulSlidingWindow;
-use crate::{bash_symbols, content_utils};
 use flash::lexer::TokenKind;
 use itertools::Itertools;
 use ratatui::text::{Line, Span};
@@ -160,51 +161,11 @@ impl HistoryManager {
     }
 
     pub fn parse_bash_history_from_memory() -> Vec<HistoryEntry> {
-        let mut res = Vec::with_capacity(4096);
-        unsafe {
-            let hist_array = bash_symbols::history_list();
-            if hist_array.is_null() {
-                log::warn!("History list is null");
-                return res;
-            }
-
-            let mut index = 0;
-            loop {
-                let entry_ptr = *hist_array.offset(index);
-                if entry_ptr.is_null() {
-                    break;
-                }
-
-                let hist_entry = &*entry_ptr;
-
-                // Check if line pointer is valid before dereferencing
-                if !hist_entry.line.is_null() {
-                    let command_cstr = std::ffi::CStr::from_ptr(hist_entry.line);
-                    let command_str = command_cstr.to_string_lossy().into_owned();
-
-                    // Parse timestamp if available
-                    let timestamp = if !hist_entry.timestamp.is_null() {
-                        let timestamp_cstr = std::ffi::CStr::from_ptr(hist_entry.timestamp);
-                        if let Ok(timestamp_str) = timestamp_cstr.to_str() {
-                            // If there are no timestamps in the history file,
-                            // Bash will use the current time for all entries, which can lead to many identical timestamps.
-                            let ts_str = timestamp_str.trim_start_matches('#').trim();
-                            ts_str.parse::<u64>().ok()
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    };
-
-                    let entry = HistoryEntry::new(timestamp, index as usize, command_str);
-                    res.push(entry);
-                }
-
-                index += 1;
-            }
-        }
-        res
+        backend()
+            .parse_history_from_memory()
+            .into_iter()
+            .map(|record| HistoryEntry::new(record.timestamp, record.index, record.command))
+            .collect()
     }
 
     fn parse_zsh_history(custom_path: Option<&str>) -> Vec<HistoryEntry> {
@@ -251,21 +212,24 @@ impl HistoryManager {
     }
 
     pub fn new(settings: &Settings) -> HistoryManager {
-        // Bash will load the history into memory, so we can read it from there
-        // Bash parses it after bashrc is loaded.
-        let bash_entries = Self::parse_bash_history_from_memory();
-        Self::log_recent_entries(&bash_entries, "bash");
-
-        // Alternative is to do it ourselves
-        // let bash_entries = Self::parse_bash_history_from_file();
-
-        let entries = if let Some(ref zsh_path) = settings.zsh_history_path {
-            // As a Zsh user migrating to Bash, I want to have my Zsh history available too
-            let zsh_entries = Self::parse_zsh_history(Some(zsh_path.as_str()));
-            Self::log_recent_entries(&zsh_entries, "Zsh");
-            Self::merge_history_entries(zsh_entries, bash_entries)
+        let entries = if Settings::is_zsh_host() {
+            let zsh_path = settings.zsh_history_path.as_deref();
+            let zsh_entries = Self::parse_zsh_history(zsh_path);
+            Self::log_recent_entries(&zsh_entries, "zsh");
+            Self::normalize_entries(zsh_entries)
         } else {
-            Self::normalize_entries(bash_entries)
+            // Bash loads history into memory after bashrc; read it from there.
+            let bash_entries = Self::parse_bash_history_from_memory();
+            Self::log_recent_entries(&bash_entries, "bash");
+
+            if let Some(ref zsh_path) = settings.zsh_history_path {
+                // As a Zsh user migrating to Bash, merge Zsh file history too.
+                let zsh_entries = Self::parse_zsh_history(Some(zsh_path.as_str()));
+                Self::log_recent_entries(&zsh_entries, "Zsh");
+                Self::merge_history_entries(zsh_entries, bash_entries)
+            } else {
+                Self::normalize_entries(bash_entries)
+            }
         };
 
         let index = entries.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ mod content_builder;
 mod content_utils;
 mod cursor;
 mod dparser;
+mod flycomp_options;
 mod globbing;
 mod history;
 pub mod hostnames;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ mod active_suggestions;
 mod agent_mode;
 mod app;
 mod bash_funcs;
+#[cfg(feature = "standalone")]
+mod bash_stubs;
 mod bash_symbols;
 mod changelog;
 mod cli;
@@ -30,6 +32,7 @@ mod mouse_state;
 mod palette;
 mod prompt_manager;
 mod settings;
+mod shell;
 mod shell_integration;
 mod snake_animation;
 mod stateful_sliding_window;
@@ -40,6 +43,20 @@ pub(crate) mod threads;
 mod tutorial;
 pub mod unicode_helpers;
 mod users;
+
+#[cfg(feature = "standalone")]
+pub use app::{ExitState, get_command};
+#[cfg(feature = "standalone")]
+pub use settings::Settings;
+#[cfg(feature = "standalone")]
+pub use shell::zsh::{ZSH_BACKEND, run_comp_broker, set_cloexec};
+#[cfg(feature = "standalone")]
+pub use shell::{backend, is_zsh_host_env, set_backend};
+
+#[cfg(feature = "standalone")]
+pub fn init_standalone_logging() -> anyhow::Result<()> {
+    logging::init()
+}
 
 // Global state for our custom input stream
 static FLYLINE_INSTANCE_PTR: Mutex<Option<Box<Flyline>>> = Mutex::new(None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ mod users;
 #[cfg(feature = "standalone")]
 pub use app::{ExitState, get_command};
 #[cfg(feature = "standalone")]
+pub use cli::run_flyline_command;
+#[cfg(feature = "standalone")]
 pub use settings::Settings;
 #[cfg(feature = "standalone")]
 pub use shell::zsh::{ZSH_BACKEND, run_comp_broker, set_cloexec};
@@ -214,16 +216,7 @@ impl Flyline {
 
             self.content = match result {
                 app::ExitState::WithCommand(cmd) => {
-                    if self.settings.tutorial_step.is_active() && cmd.trim().is_empty() {
-                        self.settings.tutorial_step.next();
-                        log::info!(
-                            "Tutorial step advanced to {:?}",
-                            self.settings.tutorial_step
-                        );
-                        if !self.settings.tutorial_step.is_active() {
-                            self.settings.run_tutorial = false;
-                        }
-                    }
+                    self.settings.advance_tutorial_on_submit(&cmd);
                     cmd.into_bytes()
                 }
                 app::ExitState::EOF => {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -89,16 +89,19 @@ static TEST_LOG_INIT: Once = Once::new();
 
 pub fn init() -> Result<()> {
     let logger = LOGGER.get_or_init(MemoryLogger::new);
-    match log::set_logger(logger) {
-        Ok(()) => {
-            log::set_max_level(LevelFilter::Trace);
-            Ok(())
-        }
-        Err(_) => {
-            log::set_max_level(LevelFilter::Trace);
-            Ok(())
-        }
+    let _ = log::set_logger(logger);
+    log::set_max_level(LevelFilter::Trace);
+
+    // Opt-in file sink. Per-prompt hosts (e.g. the standalone zsh editor) run a
+    // fresh process each prompt, so their in-memory logs vanish; pointing
+    // FLYLINE_LOG_FILE at a path appends every process's logs there for
+    // debugging (entries are pid-tagged). Harmless when unset.
+    if let Ok(path) = std::env::var("FLYLINE_LOG_FILE")
+        && !path.is_empty()
+    {
+        let _ = stream_logs(&path);
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -186,7 +186,7 @@ pub enum PaletteStyleKind {
 /// Use [`Palette::apply_theme`] to reset all slots from a built-in preset,
 /// then call [`Palette::set`] (or set the public fields directly) to customise
 /// individual slots.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Palette {
     recognised_command: Style,
     unrecognised_command: Style,

--- a/src/prompt_manager.rs
+++ b/src/prompt_manager.rs
@@ -1,8 +1,7 @@
-use crate::bash_funcs;
-use crate::bash_symbols;
 use crate::content_builder::{Tag, TaggedLine, TaggedSpan};
 use crate::kill_on_drop_child::KillOnDropChild;
 use crate::settings::{Placeholder, PromptAnimation, PromptWidget, PromptWidgetCustom};
+use crate::shell::backend;
 #[cfg(not(test))]
 use ansi_to_tui::IntoText;
 use ratatui::style::{Color, Modifier, Style};
@@ -204,33 +203,10 @@ fn expand_prompt_through_bash(raw: String) -> Option<Vec<Line<'static>>> {
     }
 
     // Strip literal `\[` / `\]` non-printing-sequence markers before handing
-    // the string to `decode_prompt_string`.
+    // the string to the shell's prompt decoder.
     let raw = raw.replace("\\[", "").replace("\\]", "");
 
-    let c_prompt = std::ffi::CString::new(raw).ok()?;
-
-    let _guard = crate::bash_symbols::BASH_LOCK.lock();
-
-    let decoded = unsafe {
-        #[cfg(not(feature = "pre_bash_4_4"))]
-        let decoded_prompt_cstr = bash_symbols::decode_prompt_string(c_prompt.as_ptr(), 1);
-        #[cfg(feature = "pre_bash_4_4")]
-        let decoded_prompt_cstr = bash_symbols::decode_prompt_string(c_prompt.as_ptr());
-        if decoded_prompt_cstr.is_null() {
-            log::warn!("decode_prompt_string returned null");
-            return None;
-        }
-
-        let decoded = std::ffi::CStr::from_ptr(decoded_prompt_cstr)
-            .to_str()
-            .ok()?
-            .to_string();
-
-        // `decode_prompt_string` returns an allocated buffer.
-        bash_symbols::locked_xfree(decoded_prompt_cstr as *mut std::ffi::c_void);
-
-        decoded
-    };
+    let decoded = backend().decode_prompt(&raw, true)?;
 
     let mut lines = decoded.into_text().ok()?.lines;
     for line in &mut lines {
@@ -256,7 +232,8 @@ fn expand_prompt_through_bash(raw: String) -> Option<Vec<Line<'static>>> {
     if raw.is_empty() {
         return Some(vec![]);
     }
-    Some(vec![Line::raw(raw)])
+    let decoded = backend().decode_prompt(&raw, true)?;
+    Some(vec![Line::raw(decoded)])
 }
 
 /// Builds expanded prompt segment lines from raw bash prompt strings while
@@ -1350,8 +1327,8 @@ impl PromptManager {
             // Widget segments (including process spawning) are created lazily
             // inside split_static_span_by_widgets as each widget name is found.
             log::debug!("Widget count: {}", widgets.len());
-            let cwd = bash_funcs::get_cwd();
-            let home = bash_funcs::get_envvar_value("HOME");
+            let cwd = backend().cwd();
+            let home = backend().env_var("HOME");
             log::debug!("CWD for prompt detection: {:?}, HOME: {:?}", cwd, home);
             let mut builder = PromptStringBuilder::new(processed_animations, widgets)
                 .with_cwd(cwd.clone(), home)
@@ -1359,7 +1336,7 @@ impl PromptManager {
 
             // Read the raw PS1 env var so we can intercept time format codes
             // before handing the string to decode_prompt_string.
-            let ps1_raw = bash_funcs::get_envvar_value("PS1");
+            let ps1_raw = backend().env_var("PS1");
 
             let ps1 = ps1_raw
                 .and_then(|raw| builder.expand_prompt_string(raw))
@@ -1371,14 +1348,16 @@ impl PromptManager {
             // Examples:
             // RPS1='\e[01;32m\t\e[0m'
             // export RPROMPT='\e[01;32m\D{%H:%M:%S}\e[0m'
-            let rps1 = bash_funcs::get_envvar_value("RPS1")
-                .or_else(|| bash_funcs::get_envvar_value("RPROMPT"))
+            let rps1 = backend()
+                .env_var("RPS1")
+                .or_else(|| backend().env_var("RPROMPT"))
                 .and_then(|raw| builder.expand_prompt_string(raw))
                 .unwrap_or_default();
 
             log::debug!("Parsed RPS1: {:?}", rps1);
 
-            let fill_span = bash_funcs::get_envvar_value("PS1_FILL")
+            let fill_span = backend()
+                .env_var("PS1_FILL")
                 .map(|raw| {
                     if raw.is_empty() {
                         vec![]
@@ -1391,13 +1370,14 @@ impl PromptManager {
                 })
                 .unwrap_or_else(|| vec![PromptSegment::Static(Span::raw(" "))]);
 
-            let ps1_final_raw = bash_funcs::get_envvar_value("PS1_FINAL");
+            let ps1_final_raw = backend().env_var("PS1_FINAL");
             let ps1_final = ps1_final_raw.and_then(|raw| builder.expand_prompt_string(raw));
 
-            let rps1_final = bash_funcs::get_envvar_value("RPS1_FINAL")
+            let rps1_final = backend()
+                .env_var("RPS1_FINAL")
                 .and_then(|raw| builder.expand_prompt_string(raw));
 
-            let fill_span_final = bash_funcs::get_envvar_value("PS1_FILL_FINAL").map(|raw| {
+            let fill_span_final = backend().env_var("PS1_FILL_FINAL").map(|raw| {
                 if raw.is_empty() {
                     vec![]
                 } else {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -278,10 +278,28 @@ pub struct Settings {
     pub initial_buffer: Option<String>,
 }
 
+impl Settings {
+    /// True when flyline runs as the standalone zsh line editor (`FLYLINE_HOST=zsh`).
+    pub fn is_zsh_host() -> bool {
+        crate::shell::is_zsh_host_env()
+    }
+
+    fn default_zsh_history_path() -> Option<String> {
+        if Self::is_zsh_host() {
+            Some(std::env::var("HISTFILE").unwrap_or_else(|_| {
+                let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+                format!("{home}/.zsh_history")
+            }))
+        } else {
+            None
+        }
+    }
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            zsh_history_path: None,
+            zsh_history_path: Self::default_zsh_history_path(),
             run_tutorial: false,
             tutorial_step: TutorialStep::default(),
             show_animations: true,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -266,6 +266,17 @@ pub struct Settings {
     pub auto_suggest: bool,
     /// Whether to use flycomp to synthesize completions.
     pub use_flycomp: bool,
+    /// Whether to offer flycomp option synthesis when a native completer *is*
+    /// registered but returns nothing for an option-shaped word (`-`/`--`).
+    ///
+    /// Many tools ship a completer that lags their `--help` (e.g. BSD `grep`,
+    /// whose zsh/bash completers target GNU options), so `grep --<Tab>` yields
+    /// nothing. When `true`, flyline treats that empty result as a cue to offer
+    /// synthesizing options from `--help`, instead of silently falling back to
+    /// filename completion. It does NOT change behaviour for non-option words
+    /// (e.g. `kubectl get <Tab>` stays silent, since an empty result there is
+    /// contextual, not a missing-options signal). Requires `use_flycomp`.
+    pub flycomp_synthesize_options: bool,
     /// Optional path to the directory where flycomp output is saved.
     /// When `None`, defaults to `~/.local/share/bash-completion/completions/`.
     pub flycomp_output: Option<String>,
@@ -439,6 +450,7 @@ impl Default for Settings {
             show_animations: true,
             auto_suggest: true,
             use_flycomp: true,
+            flycomp_synthesize_options: true,
             flycomp_output: None,
             suggestion_sort_order: SuggestionSortOrder::default(),
             fuzzy_mode: FuzzyMode::default(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -51,7 +51,7 @@ pub enum FuzzyMode {
 }
 
 /// A single custom prompt animation registered with `flyline create-prompt-widget animation`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PromptAnimation {
     /// Name used as placeholder in prompt strings (e.g., `COOL_SPINNER`).
     pub name: String,
@@ -65,7 +65,7 @@ pub struct PromptAnimation {
 }
 
 /// A custom prompt widget registered with `flyline create-prompt-widget`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum PromptWidget {
     /// Show different text depending on whether mouse capture is enabled.
     MouseMode {
@@ -111,7 +111,7 @@ impl PromptWidget {
 
 /// What to show as a placeholder while a non-blocking (or timed-out blocking)
 /// custom widget command is still running.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub enum Placeholder {
     /// Show N spaces.
     Spaces(usize),
@@ -121,7 +121,7 @@ pub enum Placeholder {
 }
 
 /// A prompt widget that runs a shell command and displays its output.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PromptWidgetCustom {
     /// Name used as placeholder in prompt strings (e.g., `CUSTOM_WIDGET1`).
     pub name: String,
@@ -138,11 +138,14 @@ pub struct PromptWidgetCustom {
     pub placeholder: Placeholder,
     /// Most recent successful output of the command; shared across clones so
     /// that the `Placeholder::Prev` option can pick it up on subsequent renders.
+    ///
+    /// Runtime-only cache: reset to empty on load.
+    #[serde(skip)]
     pub prev_output: std::sync::Arc<std::sync::Mutex<Vec<TaggedSpan<'static>>>>,
 }
 
 /// A configured agent-mode command with its optional system prompt.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct AgentModeCommand {
     /// Command (and arguments) to invoke. The current buffer is appended as the
     /// final argument.  Stored as a `Vec<String>` after splitting the
@@ -153,8 +156,32 @@ pub struct AgentModeCommand {
     pub system_prompt: Option<String>,
 }
 
+/// (De)serialization for [`Settings::agent_commands`].  A JSON object cannot key
+/// on `Option<String>` (the `None` default command has no string key), so the
+/// map is represented on disk as an array of `[key, command]` pairs, where
+/// `key` is either `null` or a prefix string.
+mod agent_commands_serde {
+    use super::{AgentModeCommand, HashMap};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(
+        map: &HashMap<Option<String>, AgentModeCommand>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let pairs: Vec<(&Option<String>, &AgentModeCommand)> = map.iter().collect();
+        pairs.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<HashMap<Option<String>, AgentModeCommand>, D::Error> {
+        let pairs: Vec<(Option<String>, AgentModeCommand)> = Vec::deserialize(deserializer)?;
+        Ok(pairs.into_iter().collect())
+    }
+}
+
 /// Controls whether and when the matrix animation is shown.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum MatrixAnimation {
     /// Never show the matrix animation.
     #[default]
@@ -167,7 +194,9 @@ pub enum MatrixAnimation {
 }
 
 /// Controls how flyline manages mouse capture.
-#[derive(clap::ValueEnum, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(
+    clap::ValueEnum, Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize,
+)]
 pub enum MouseMode {
     /// Never capture mouse events.
     Disabled,
@@ -181,7 +210,17 @@ pub enum MouseMode {
 }
 
 /// How many shell integration escape codes (OSC 133 / OSC 633) flyline sends.
-#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(
+    clap::ValueEnum,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum ShellIntegrationLevel {
     /// Send no shell integration codes.
     None,
@@ -193,15 +232,31 @@ pub enum ShellIntegrationLevel {
     Full,
 }
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
 pub struct Settings {
     /// Optional path to the Zsh history file. When `None`, Zsh history is not loaded.
     /// When `Some`, Zsh history is loaded in addition to Bash history; an empty string or no
     /// value means use the default path (`$HOME/.zsh_history`).
+    ///
+    /// Runtime-only: re-derived per host from the environment in `Default`, so it
+    /// is not persisted.
+    #[serde(skip)]
     pub zsh_history_path: Option<String>,
     /// Whether the interactive tutorial is active.
+    ///
+    /// Transient, per-terminal-session state — NOT durable config. It is
+    /// deliberately excluded from the persisted settings snapshot (which is
+    /// global and permanent) so that starting the tutorial in one terminal does
+    /// not force it onto every other terminal, now and forever. Per-prompt
+    /// hosts carry it across their processes via [`SessionState`] instead; the
+    /// long-lived Bash builtin keeps it live in-process. See [`SessionState`].
+    #[serde(skip)]
     pub run_tutorial: bool,
-    /// Current tutorial step.
+    /// Current tutorial step. Transient session state; see [`run_tutorial`].
+    ///
+    /// [`run_tutorial`]: Settings::run_tutorial
+    #[serde(skip)]
     pub tutorial_step: TutorialStep,
     /// Whether to show all animations (cursor movement, cursor fading, dynamic time).
     pub show_animations: bool,
@@ -234,6 +289,10 @@ pub struct Settings {
     /// - `None` key: the default command invoked via Alt+Enter (no prefix match needed).
     /// - `Some(prefix)` key: activated when the user presses Enter and the buffer starts
     ///   with `prefix`; the prefix is stripped before the buffer is sent to the command.
+    ///
+    /// Persisted as an array of `[key, command]` pairs (the `Option<String>` key
+    /// cannot be a JSON object key); see [`agent_commands_serde`].
+    #[serde(with = "agent_commands_serde")]
     pub agent_commands: HashMap<Option<String>, AgentModeCommand>,
     /// Custom prompt animations registered with `flyline create-prompt-widget animation`.
     pub custom_animations: HashMap<String, PromptAnimation>,
@@ -254,9 +313,14 @@ pub struct Settings {
     pub flycomp_blacklist: HashSet<String>,
     /// Configurable colour palette for UI elements.
     pub colour_palette: Palette,
-    /// User defined keybindings
+    /// User defined keybindings.
+    ///
+    /// Persisted via each binding's human-readable string form (keys like
+    /// `ctrl+s`, the context expression, and the camelCase action name).
     pub keybindings: Vec<actions::Binding>,
     /// User defined key remappings (applied before matching bindings).
+    ///
+    /// Persisted as `{from, to}` string pairs.
     pub key_remappings: Vec<actions::KeyRemap>,
     /// Show the last key event and dispatched action above the prompt.
     pub key_debug: bool,
@@ -265,23 +329,93 @@ pub struct Settings {
     /// Whether to change the mouse cursor shape depending on what is hovered.
     pub mouse_change_shape: bool,
     /// Tracks commands that were cancelled via Ctrl+C (non-empty buffer).
+    #[serde(skip)]
     pub cancelled_command_history_manager: HistoryManager,
     /// Tracks prompts that were submitted to agent mode.
+    #[serde(skip)]
     pub agent_prompt_history_manager: HistoryManager,
     /// Timestamp of the most recent flyline app session close.
     ///
     /// Set to `Some(Instant::now())` immediately after each `app::get_command`
     /// call returns. Used by the `last-command-duration` prompt widget to
     /// compute and display the elapsed time since the last command.
+    #[serde(skip)]
     pub last_app_closed_at: Option<std::time::Instant>,
     /// Initial buffer content to pre-fill the command line when Flyline starts.
+    #[serde(skip)]
     pub initial_buffer: Option<String>,
+}
+
+/// Transient, per-terminal-session state for hosts that run flyline as a fresh
+/// process on every prompt (e.g. the standalone editor).
+///
+/// This is deliberately separate from [`Settings`]: [`Settings`] is durable,
+/// global config that lives forever in one shared file, whereas this captures
+/// state that must survive across a single terminal's per-prompt processes but
+/// must NOT leak into other terminals or outlive the terminal — most notably
+/// the interactive tutorial. Per-prompt hosts persist it to a session-scoped
+/// location (keyed to the terminal session); the long-lived Bash builtin keeps
+/// the equivalent state live in-process and does not use this at all.
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct SessionState {
+    /// Whether the interactive tutorial is active in this terminal session.
+    pub run_tutorial: bool,
+    /// The tutorial step reached in this terminal session.
+    pub tutorial_step: TutorialStep,
+}
+
+impl SessionState {
+    /// True when there is nothing worth persisting for the session (the
+    /// tutorial is not running), so the backing file can be removed.
+    pub fn is_empty(&self) -> bool {
+        !self.run_tutorial && !self.tutorial_step.is_active()
+    }
 }
 
 impl Settings {
     /// True when flyline runs as the standalone zsh line editor (`FLYLINE_HOST=zsh`).
     pub fn is_zsh_host() -> bool {
         crate::shell::is_zsh_host_env()
+    }
+
+    /// Advance the interactive tutorial when the user submits an empty command
+    /// while a tutorial step is active, disabling the tutorial once it ends.
+    ///
+    /// Host-agnostic: every host calls this after an accepted command so the
+    /// tutorial progresses identically whether flyline runs as a long-lived
+    /// Bash builtin or as a per-prompt standalone process.
+    pub fn advance_tutorial_on_submit(&mut self, command: &str) {
+        if self.tutorial_step.is_active() && command.trim().is_empty() {
+            self.tutorial_step.next();
+            log::info!("Tutorial step advanced to {:?}", self.tutorial_step);
+            if !self.tutorial_step.is_active() {
+                self.run_tutorial = false;
+            }
+        }
+    }
+
+    /// End the interactive tutorial immediately (e.g. when the user cancels
+    /// with Ctrl+C) so it does not resume on the next prompt.
+    pub fn stop_tutorial(&mut self) {
+        self.run_tutorial = false;
+        self.tutorial_step = TutorialStep::NotRunning;
+    }
+
+    /// Overlay transient session state (e.g. tutorial progress) onto these
+    /// settings after the durable snapshot has been loaded.
+    pub fn apply_session_state(&mut self, state: &SessionState) {
+        self.run_tutorial = state.run_tutorial;
+        self.tutorial_step = state.tutorial_step;
+    }
+
+    /// Extract the transient, per-terminal-session state from these settings so
+    /// a per-prompt host can hand it to the next process in the same terminal.
+    pub fn session_state(&self) -> SessionState {
+        SessionState {
+            run_tutorial: self.run_tutorial,
+            tutorial_step: self.tutorial_step,
+        }
     }
 
     fn default_zsh_history_path() -> Option<String> {
@@ -333,5 +467,189 @@ impl Default for Settings {
             last_app_closed_at: None,
             initial_buffer: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settings_round_trip_via_json() {
+        let mut s = Settings::default();
+        s.num_suggestion_rows = 42;
+        s.frame_rate = 60;
+        s.use_flycomp = false;
+        s.mouse_mode = MouseMode::Disabled;
+
+        let json = serde_json::to_string(&s).expect("serialize settings");
+        let back: Settings = serde_json::from_str(&json).expect("deserialize settings");
+
+        assert_eq!(back.num_suggestion_rows, 42);
+        assert_eq!(back.frame_rate, 60);
+        assert!(!back.use_flycomp);
+        assert_eq!(back.mouse_mode, MouseMode::Disabled);
+    }
+
+    #[test]
+    fn settings_partial_json_falls_back_to_defaults() {
+        // An old/partial snapshot missing most fields must still load, with the
+        // absent fields taking their `Default` values (container `serde(default)`).
+        let back: Settings =
+            serde_json::from_str(r#"{ "num_suggestion_rows": 7 }"#).expect("deserialize partial");
+        assert_eq!(back.num_suggestion_rows, 7);
+        assert_eq!(back.frame_rate, Settings::default().frame_rate);
+        assert_eq!(back.use_flycomp, Settings::default().use_flycomp);
+    }
+
+    #[test]
+    fn tutorial_state_is_transient_session_state_not_durable_config() {
+        // Tutorial fields are session-scoped, not durable config: they must
+        // never appear in the persisted settings snapshot, otherwise starting
+        // the tutorial in one terminal would resurface it in every other.
+        let mut s = Settings::default();
+        s.run_tutorial = true;
+        s.tutorial_step = TutorialStep::Welcome;
+
+        let json = serde_json::to_string(&s).expect("serialize settings");
+        assert!(!json.contains("run_tutorial"));
+        assert!(!json.contains("tutorial_step"));
+
+        let back: Settings = serde_json::from_str(&json).expect("deserialize settings");
+        assert!(!back.run_tutorial);
+        assert_eq!(back.tutorial_step, TutorialStep::NotRunning);
+
+        // It survives via SessionState instead.
+        let round_tripped: SessionState = serde_json::from_str(
+            &serde_json::to_string(&s.session_state()).expect("serialize session state"),
+        )
+        .expect("deserialize session state");
+        assert!(round_tripped.run_tutorial);
+        assert_eq!(round_tripped.tutorial_step, TutorialStep::Welcome);
+
+        let mut fresh = Settings::default();
+        fresh.apply_session_state(&round_tripped);
+        assert!(fresh.run_tutorial);
+        assert_eq!(fresh.tutorial_step, TutorialStep::Welcome);
+    }
+
+    #[test]
+    fn tutorial_advances_on_empty_submit_only() {
+        let mut s = Settings::default();
+        s.run_tutorial = true;
+        s.tutorial_step = TutorialStep::Welcome;
+
+        // Empty submit advances a step.
+        s.advance_tutorial_on_submit("");
+        assert_ne!(s.tutorial_step, TutorialStep::Welcome);
+        assert!(s.tutorial_step.is_active());
+        assert!(s.run_tutorial);
+
+        // A real command does not advance the tutorial.
+        let step = s.tutorial_step;
+        s.advance_tutorial_on_submit("ls -la");
+        assert_eq!(s.tutorial_step, step);
+
+        // Stepping to the end deactivates the tutorial.
+        for _ in 0..20 {
+            s.advance_tutorial_on_submit("");
+        }
+        assert_eq!(s.tutorial_step, TutorialStep::NotRunning);
+        assert!(!s.run_tutorial);
+    }
+
+    #[test]
+    fn stop_tutorial_ends_it_immediately() {
+        let mut s = Settings::default();
+        s.run_tutorial = true;
+        s.tutorial_step = TutorialStep::Welcome;
+
+        s.stop_tutorial();
+
+        assert!(!s.run_tutorial);
+        assert_eq!(s.tutorial_step, TutorialStep::NotRunning);
+        assert!(s.session_state().is_empty());
+    }
+
+    #[test]
+    fn settings_skipped_fields_are_not_serialized() {
+        let s = Settings::default();
+        let json = serde_json::to_string(&s).expect("serialize settings");
+        // Genuine runtime-only fields must never appear in the snapshot.
+        assert!(!json.contains("initial_buffer"));
+        assert!(!json.contains("zsh_history_path"));
+        // Formerly-skipped fields are now persisted (present even when empty).
+        assert!(json.contains("keybindings"));
+        assert!(json.contains("agent_commands"));
+        assert!(json.contains("key_remappings"));
+    }
+
+    #[test]
+    fn settings_keybindings_remappings_agent_commands_round_trip() {
+        use crate::app::actions::{Binding, KeyRemap};
+        use crossterm::event::{KeyCode, KeyModifiers};
+
+        let mut s = Settings::default();
+
+        // A ctrl+s style binding and an anychar+mods binding.
+        s.keybindings = vec![
+            Binding::try_new_from_strs("ctrl+s", "always=submitOrNewline").expect("ctrl+s binding"),
+            Binding::try_new_from_strs("ctrl+anychar", "tabCompletion=insertChar")
+                .expect("anychar binding"),
+        ];
+
+        // Both remap variants.
+        s.key_remappings = vec![
+            KeyRemap::Key {
+                from: KeyCode::Tab,
+                to: KeyCode::Char('z'),
+            },
+            KeyRemap::Modifier {
+                from: KeyModifiers::ALT,
+                to: KeyModifiers::CONTROL,
+            },
+        ];
+
+        // Agent commands with both a None key and a Some(prefix) key.
+        s.agent_commands.insert(
+            None,
+            AgentModeCommand {
+                command: vec!["llm".to_string(), "-m".to_string()],
+                system_prompt: Some("be concise".to_string()),
+            },
+        );
+        s.agent_commands.insert(
+            Some("? ".to_string()),
+            AgentModeCommand {
+                command: vec!["explain".to_string()],
+                system_prompt: None,
+            },
+        );
+
+        let json = serde_json::to_string(&s).expect("serialize settings");
+        let back: Settings = serde_json::from_str(&json).expect("deserialize settings");
+
+        assert_eq!(back.keybindings, s.keybindings);
+        assert_eq!(back.key_remappings, s.key_remappings);
+        assert_eq!(back.agent_commands, s.agent_commands);
+    }
+
+    #[test]
+    fn settings_persisted_fields_are_human_readable_strings() {
+        use crate::app::actions::Binding;
+
+        let mut s = Settings::default();
+        s.keybindings =
+            vec![Binding::try_new_from_strs("ctrl+s", "always=submitOrNewline").unwrap()];
+
+        let json = serde_json::to_string(&s).expect("serialize settings");
+
+        // Human-readable key + action names appear verbatim.
+        assert!(json.contains("ctrl+s"));
+        assert!(json.contains("submitOrNewline"));
+        // Crossterm-internal representations must NOT leak into the snapshot.
+        assert!(!json.contains("CONTROL"));
+        assert!(!json.contains(r#""code""#));
+        assert!(!json.contains(r#""modifiers""#));
     }
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1,0 +1,557 @@
+//! Host shell abstraction. `ShellBackend` is the seam over the original Bash
+//! `bash_funcs` FFI that lets a second host (zsh) plug in: the app talks to
+//! `shell::backend()` instead of Bash-specific free functions.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+pub use crate::bash_funcs::{CommandWordInfo, ProgrammableCompleteReturn};
+
+pub mod zsh;
+
+/// One entry from the host shell's in-memory command history.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HistoryRecord {
+    pub timestamp: Option<u64>,
+    pub index: usize,
+    pub command: String,
+}
+
+/// The host shell `flyline` is embedded in.
+///
+/// Implementors must be `Sync`: a single backend is shared, by `&'static`
+/// reference, across flyline's threads.
+pub trait ShellBackend: Sync {
+    /// True when flyline runs as a Bash loadable builtin; false for standalone zsh.
+    fn is_bash(&self) -> bool {
+        true
+    }
+
+    /// Working directory as the shell sees it (used for prompt + OSC 7 reporting).
+    fn cwd(&self) -> String;
+
+    /// Value of a shell/environment variable, if set.
+    fn env_var(&self, name: &str) -> Option<String>;
+
+    /// Host name for the prompt / shell-integration OSC sequences.
+    fn hostname(&self) -> String;
+
+    /// A variable rendered for display (`name=value` plus any attributes), as
+    /// shown in the variable tooltip.
+    fn format_var(&self, name: &str) -> String;
+
+    /// Names (each `$`-prefixed) of variables whose name starts with `prefix`
+    /// (a leading `$` on `prefix` is ignored). Drives `$VAR` completion.
+    fn vars_with_prefix(&self, prefix: &str) -> Vec<String>;
+
+    /// Expand a path through the shell (tilde, env vars, relative → absolute).
+    fn expand_path(&self, path: &str) -> String;
+
+    /// Expand a filename through the shell's string expansion rules.
+    fn expand_filename(&self, filename: &str) -> String;
+
+    /// Run a prompt string through the host shell's prompt decoder.
+    fn decode_prompt(&self, raw: &str, is_prompt: bool) -> Option<String>;
+
+    /// Look up a shell alias definition for `cmd`, if one exists.
+    fn find_alias(&self, cmd: &str) -> Option<String>;
+
+    /// Classify a command word (alias, builtin, file on PATH, etc.).
+    fn command_info(&self, cmd: &str) -> CommandWordInfo;
+
+    /// Run programmable tab-completion for the given context.
+    fn run_programmable_completions(
+        &self,
+        full_command: &str,
+        command_word: &str,
+        word_under_cursor: &str,
+        cursor_byte_pos: usize,
+        word_under_cursor_byte_end: usize,
+    ) -> anyhow::Result<ProgrammableCompleteReturn>;
+
+    /// All potential first-word completions (aliases, keywords, functions, etc.).
+    fn possible_command_words(&self) -> Vec<CommandWordInfo>;
+
+    /// Evaluate a shell script string in the host shell context.
+    fn evaluate_shell_string(&self, script: &str) -> anyhow::Result<()>;
+
+    /// Clear host-shell caches (command info, aliases, etc.).
+    fn reset_caches(&self);
+
+    /// Pre-warm completion caches in a background-friendly way.
+    fn warm_completion_caches(&self);
+
+    /// Non-zero when the host shell received a terminating signal.
+    fn read_terminating_signal(&self) -> libc::c_int;
+
+    /// Resolve where a synthesized completion script should be written.
+    fn resolve_completion_script_path(
+        &self,
+        command_word: &str,
+        flycomp_output: Option<&str>,
+    ) -> PathBuf;
+
+    /// Write a synthesized completion script to the resolved path.
+    fn resolve_and_write_completion_script(
+        &self,
+        command_word: &str,
+        script: &str,
+        flycomp_output: Option<&str>,
+    ) -> Result<PathBuf, std::io::Error>;
+
+    /// Read command history from the host shell's in-memory list.
+    fn parse_history_from_memory(&self) -> Vec<HistoryRecord>;
+
+    /// Exit status of the last command run in the shell.
+    fn last_command_exit_status(&self) -> i32;
+
+    /// Number of lines in the current (possibly unfinished) multiline command.
+    fn multiline_command_count(&self) -> i32;
+
+    /// Process group ID of the shell (used in shell-integration OSC sequences).
+    fn shell_pgrp(&self) -> libc::pid_t;
+}
+
+/// The original Bash host; delegates to `bash_funcs`, adding no new behavior.
+pub struct BashBackend;
+
+impl ShellBackend for BashBackend {
+    fn is_bash(&self) -> bool {
+        true
+    }
+
+    fn cwd(&self) -> String {
+        crate::bash_funcs::get_cwd()
+    }
+
+    fn env_var(&self, name: &str) -> Option<String> {
+        crate::bash_funcs::get_envvar_value(name)
+    }
+
+    fn hostname(&self) -> String {
+        crate::bash_funcs::get_hostname()
+    }
+
+    fn format_var(&self, name: &str) -> String {
+        crate::bash_funcs::format_shell_var(name)
+    }
+
+    fn vars_with_prefix(&self, prefix: &str) -> Vec<String> {
+        crate::bash_funcs::get_all_variables_with_prefix(prefix)
+    }
+
+    fn expand_path(&self, path: &str) -> String {
+        crate::bash_funcs::fully_expand_path(path)
+    }
+
+    fn expand_filename(&self, filename: &str) -> String {
+        crate::bash_funcs::expand_filename(filename)
+    }
+
+    fn decode_prompt(&self, raw: &str, is_prompt: bool) -> Option<String> {
+        bash_decode_prompt(raw, is_prompt)
+    }
+
+    fn find_alias(&self, cmd: &str) -> Option<String> {
+        crate::bash_funcs::find_alias(cmd)
+    }
+
+    fn command_info(&self, cmd: &str) -> CommandWordInfo {
+        crate::bash_funcs::get_command_info(cmd)
+    }
+
+    fn run_programmable_completions(
+        &self,
+        full_command: &str,
+        command_word: &str,
+        word_under_cursor: &str,
+        cursor_byte_pos: usize,
+        word_under_cursor_byte_end: usize,
+    ) -> anyhow::Result<ProgrammableCompleteReturn> {
+        crate::bash_funcs::run_programmable_completions(
+            full_command,
+            command_word,
+            word_under_cursor,
+            cursor_byte_pos,
+            word_under_cursor_byte_end,
+        )
+    }
+
+    fn possible_command_words(&self) -> Vec<CommandWordInfo> {
+        crate::bash_funcs::get_possible_command_words().collect()
+    }
+
+    fn evaluate_shell_string(&self, script: &str) -> anyhow::Result<()> {
+        crate::bash_funcs::evaluate_shell_string(script)
+    }
+
+    fn reset_caches(&self) {
+        crate::bash_funcs::reset_caches();
+    }
+
+    fn warm_completion_caches(&self) {
+        crate::bash_funcs::warm_completion_caches();
+    }
+
+    fn read_terminating_signal(&self) -> libc::c_int {
+        crate::bash_funcs::read_terminating_signal()
+    }
+
+    fn resolve_completion_script_path(
+        &self,
+        command_word: &str,
+        flycomp_output: Option<&str>,
+    ) -> PathBuf {
+        crate::bash_funcs::resolve_completion_script_path(command_word, flycomp_output)
+    }
+
+    fn resolve_and_write_completion_script(
+        &self,
+        command_word: &str,
+        script: &str,
+        flycomp_output: Option<&str>,
+    ) -> Result<PathBuf, std::io::Error> {
+        crate::bash_funcs::resolve_and_write_completion_script(command_word, script, flycomp_output)
+    }
+
+    fn parse_history_from_memory(&self) -> Vec<HistoryRecord> {
+        parse_bash_history_from_memory()
+    }
+
+    fn last_command_exit_status(&self) -> i32 {
+        read_last_command_exit_status()
+    }
+
+    fn multiline_command_count(&self) -> i32 {
+        read_multiline_command_count()
+    }
+
+    fn shell_pgrp(&self) -> libc::pid_t {
+        read_shell_pgrp()
+    }
+}
+
+#[cfg(not(test))]
+fn bash_decode_prompt(raw: &str, is_prompt: bool) -> Option<String> {
+    if raw.is_empty() {
+        return Some(String::new());
+    }
+
+    let c_prompt = std::ffi::CString::new(raw).ok()?;
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
+
+    let decoded = unsafe {
+        #[cfg(not(feature = "pre_bash_4_4"))]
+        let decoded_prompt_cstr =
+            crate::bash_symbols::decode_prompt_string(c_prompt.as_ptr(), is_prompt as i32);
+        #[cfg(feature = "pre_bash_4_4")]
+        let decoded_prompt_cstr = crate::bash_symbols::decode_prompt_string(c_prompt.as_ptr());
+        if decoded_prompt_cstr.is_null() {
+            log::warn!("decode_prompt_string returned null");
+            return None;
+        }
+
+        let decoded = std::ffi::CStr::from_ptr(decoded_prompt_cstr)
+            .to_str()
+            .ok()?
+            .to_string();
+
+        crate::bash_symbols::locked_xfree(decoded_prompt_cstr as *mut std::ffi::c_void);
+        decoded
+    };
+
+    Some(decoded)
+}
+
+#[cfg(test)]
+fn bash_decode_prompt(raw: &str, _is_prompt: bool) -> Option<String> {
+    if raw.is_empty() {
+        Some(String::new())
+    } else {
+        Some(raw.to_string())
+    }
+}
+
+#[cfg(not(test))]
+fn parse_bash_history_from_memory() -> Vec<HistoryRecord> {
+    let mut res = Vec::with_capacity(4096);
+    unsafe {
+        let hist_array = crate::bash_symbols::history_list();
+        if hist_array.is_null() {
+            log::warn!("History list is null");
+            return res;
+        }
+
+        let mut index = 0;
+        loop {
+            let entry_ptr = *hist_array.offset(index);
+            if entry_ptr.is_null() {
+                break;
+            }
+
+            let hist_entry = &*entry_ptr;
+
+            if !hist_entry.line.is_null() {
+                let command_cstr = std::ffi::CStr::from_ptr(hist_entry.line);
+                let command_str = command_cstr.to_string_lossy().into_owned();
+
+                let timestamp = if !hist_entry.timestamp.is_null() {
+                    let timestamp_cstr = std::ffi::CStr::from_ptr(hist_entry.timestamp);
+                    if let Ok(timestamp_str) = timestamp_cstr.to_str() {
+                        let ts_str = timestamp_str.trim_start_matches('#').trim();
+                        ts_str.parse::<u64>().ok()
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                res.push(HistoryRecord {
+                    timestamp,
+                    index: index as usize,
+                    command: command_str,
+                });
+            }
+
+            index += 1;
+        }
+    }
+    res
+}
+
+#[cfg(test)]
+fn parse_bash_history_from_memory() -> Vec<HistoryRecord> {
+    Vec::new()
+}
+
+#[cfg(not(test))]
+fn read_last_command_exit_status() -> i32 {
+    unsafe { crate::bash_symbols::last_command_exit_value }
+}
+
+#[cfg(test)]
+fn read_last_command_exit_status() -> i32 {
+    0
+}
+
+#[cfg(not(test))]
+fn read_multiline_command_count() -> i32 {
+    unsafe { crate::bash_symbols::current_command_line_count }
+}
+
+#[cfg(test)]
+fn read_multiline_command_count() -> i32 {
+    0
+}
+
+#[cfg(not(test))]
+fn read_shell_pgrp() -> libc::pid_t {
+    unsafe { crate::bash_symbols::shell_pgrp }
+}
+
+#[cfg(test)]
+fn read_shell_pgrp() -> libc::pid_t {
+    0
+}
+
+static BASH: BashBackend = BashBackend;
+static ACTIVE: OnceLock<&'static dyn ShellBackend> = OnceLock::new();
+
+/// True when `FLYLINE_HOST=zsh` selects the standalone zsh backend.
+pub fn is_zsh_host_env() -> bool {
+    std::env::var("FLYLINE_HOST").as_deref() == Ok("zsh")
+}
+
+fn init_backend() -> &'static dyn ShellBackend {
+    if is_zsh_host_env() {
+        &zsh::ZSH_BACKEND
+    } else {
+        &BASH
+    }
+}
+
+/// The active host shell backend. Defaults to Bash unless `FLYLINE_HOST=zsh`.
+pub fn backend() -> &'static dyn ShellBackend {
+    *ACTIVE.get_or_init(init_backend)
+}
+
+/// Select the host backend once, at load, before the first `backend()` call.
+/// ponytail: single process-global backend, matching flyline's global shell state.
+#[allow(dead_code)]
+pub fn set_backend(b: &'static dyn ShellBackend) {
+    let _ = ACTIVE.set(b);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The seam must be behavior-neutral: `backend()` routes through the same
+    // `bash_funcs` calls (test fixtures under cfg(test)) the old call sites used.
+
+    #[test]
+    fn default_backend_is_bash() {
+        assert!(backend().is_bash());
+    }
+
+    #[test]
+    fn default_backend_delegates_hostname() {
+        assert_eq!(backend().hostname(), crate::bash_funcs::get_hostname());
+        assert_eq!(backend().hostname(), "test-host");
+    }
+
+    #[test]
+    fn default_backend_delegates_cwd() {
+        assert_eq!(backend().cwd(), crate::bash_funcs::get_cwd());
+    }
+
+    #[test]
+    fn default_backend_delegates_known_env_var() {
+        assert_eq!(backend().env_var("USER"), Some("john".to_string()));
+        assert_eq!(
+            backend().env_var("PATH"),
+            crate::bash_funcs::get_envvar_value("PATH"),
+        );
+    }
+
+    #[test]
+    fn default_backend_returns_none_for_unset_env_var() {
+        assert_eq!(backend().env_var("FLYLINE_DEFINITELY_UNSET_VAR"), None);
+    }
+
+    #[test]
+    fn default_backend_delegates_format_var() {
+        assert_eq!(
+            backend().format_var("FOO"),
+            crate::bash_funcs::format_shell_var("FOO"),
+        );
+    }
+
+    #[test]
+    fn default_backend_delegates_vars_with_prefix() {
+        assert_eq!(
+            backend().vars_with_prefix("P"),
+            crate::bash_funcs::get_all_variables_with_prefix("P"),
+        );
+        assert_eq!(backend().vars_with_prefix("$P"), vec!["$PATH", "$PWD"]);
+    }
+
+    #[test]
+    fn default_backend_delegates_expand_path() {
+        assert_eq!(
+            backend().expand_path("."),
+            crate::bash_funcs::fully_expand_path("."),
+        );
+    }
+
+    #[test]
+    fn default_backend_delegates_expand_filename() {
+        assert_eq!(
+            backend().expand_filename("$HOME"),
+            crate::bash_funcs::expand_filename("$HOME"),
+        );
+    }
+
+    #[test]
+    fn default_backend_delegates_decode_prompt() {
+        assert_eq!(
+            backend().decode_prompt("\\u@\\h", true),
+            bash_decode_prompt("\\u@\\h", true),
+        );
+    }
+
+    #[test]
+    fn default_backend_delegates_find_alias() {
+        assert_eq!(
+            backend().find_alias("gd"),
+            crate::bash_funcs::find_alias("gd"),
+        );
+        assert_eq!(backend().find_alias("gd"), Some("git diff".to_string()));
+    }
+
+    #[test]
+    fn default_backend_delegates_command_info() {
+        assert_eq!(
+            backend().command_info("git"),
+            crate::bash_funcs::get_command_info("git"),
+        );
+    }
+
+    #[test]
+    fn default_backend_delegates_run_programmable_completions() {
+        let via_backend = backend()
+            .run_programmable_completions("git comm", "git", "comm", 4, 8)
+            .unwrap();
+        let via_bash =
+            crate::bash_funcs::run_programmable_completions("git comm", "git", "comm", 4, 8)
+                .unwrap();
+        assert_eq!(via_backend.completions, via_bash.completions);
+    }
+
+    #[test]
+    fn default_backend_delegates_possible_command_words() {
+        let via_backend = backend().possible_command_words();
+        let via_bash: Vec<_> = crate::bash_funcs::get_possible_command_words().collect();
+        assert_eq!(via_backend, via_bash);
+    }
+
+    #[test]
+    fn default_backend_delegates_evaluate_shell_string() {
+        assert!(backend().evaluate_shell_string("true").is_ok());
+        assert!(crate::bash_funcs::evaluate_shell_string("true").is_ok());
+    }
+
+    #[test]
+    fn default_backend_delegates_reset_and_warm_caches() {
+        backend().reset_caches();
+        crate::bash_funcs::reset_caches();
+        backend().warm_completion_caches();
+        crate::bash_funcs::warm_completion_caches();
+    }
+
+    #[test]
+    fn default_backend_delegates_read_terminating_signal() {
+        assert_eq!(
+            backend().read_terminating_signal(),
+            crate::bash_funcs::read_terminating_signal(),
+        );
+    }
+
+    #[test]
+    fn default_backend_delegates_resolve_completion_script_path() {
+        assert_eq!(
+            backend().resolve_completion_script_path("git", None),
+            crate::bash_funcs::resolve_completion_script_path("git", None),
+        );
+    }
+
+    #[test]
+    fn default_backend_delegates_parse_history_from_memory() {
+        assert_eq!(
+            backend().parse_history_from_memory(),
+            parse_bash_history_from_memory(),
+        );
+    }
+
+    #[test]
+    fn default_backend_delegates_last_command_exit_status() {
+        assert_eq!(
+            backend().last_command_exit_status(),
+            read_last_command_exit_status(),
+        );
+    }
+
+    #[test]
+    fn default_backend_delegates_multiline_command_count() {
+        assert_eq!(
+            backend().multiline_command_count(),
+            read_multiline_command_count(),
+        );
+    }
+
+    #[test]
+    fn default_backend_delegates_shell_pgrp() {
+        assert_eq!(backend().shell_pgrp(), read_shell_pgrp());
+    }
+}

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -134,6 +134,126 @@ pub trait ShellBackend: Sync {
 
     /// Process group ID of the shell (used in shell-integration OSC sequences).
     fn shell_pgrp(&self) -> libc::pid_t;
+
+    // ── Settings persistence (ephemeral, per-prompt hosts only) ──────────
+    //
+    // These exist ONLY for hosts that run flyline as a fresh process on every
+    // prompt (e.g. the standalone editor), which therefore need a settings
+    // snapshot on disk to survive across invocations. The Bash builtin is
+    // long-lived and keeps its settings live in-process, so it deliberately
+    // does NOT participate: it leaves `persisted_settings_path()` at the
+    // default `None`, which makes load return defaults and persist a no-op.
+    // Do not wire the Bash builtin into this path.
+
+    /// Path to the on-disk settings snapshot for a per-prompt host, or `None`
+    /// for hosts (like Bash) that keep settings live in-process and never
+    /// persist. Returning `None` disables `load_persisted_settings` /
+    /// `persist_settings` entirely.
+    fn persisted_settings_path(&self) -> Option<PathBuf> {
+        None
+    }
+
+    /// Load a per-prompt host's persisted settings, overlaying the on-disk
+    /// snapshot (if any) onto the defaults. With no path (e.g. Bash), or a
+    /// missing/unreadable file, this returns `Settings::default()`.
+    fn load_persisted_settings(&self) -> crate::settings::Settings {
+        let Some(path) = self.persisted_settings_path() else {
+            return crate::settings::Settings::default();
+        };
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            return crate::settings::Settings::default();
+        };
+        match serde_json::from_str(&contents) {
+            Ok(settings) => settings,
+            Err(err) => {
+                log::warn!("Ignoring unreadable flyline settings at {path:?}: {err}");
+                crate::settings::Settings::default()
+            }
+        }
+    }
+
+    /// Persist a per-prompt host's `settings` snapshot (a no-op for hosts, like
+    /// Bash, whose `persisted_settings_path()` is `None`).
+    /// Best-effort and fail-open: any error is logged, never propagated, so a
+    /// read-only or full disk can never break the prompt.
+    fn persist_settings(&self, settings: &crate::settings::Settings) {
+        let Some(path) = self.persisted_settings_path() else {
+            return;
+        };
+        if let Some(parent) = path.parent()
+            && let Err(err) = std::fs::create_dir_all(parent)
+        {
+            log::warn!("Could not create flyline settings dir {parent:?}: {err}");
+            return;
+        }
+        match serde_json::to_string_pretty(settings) {
+            Ok(json) => {
+                if let Err(err) = std::fs::write(&path, json) {
+                    log::warn!("Could not write flyline settings to {path:?}: {err}");
+                }
+            }
+            Err(err) => log::warn!("Could not serialize flyline settings: {err}"),
+        }
+    }
+
+    // ── Session state (transient, per-terminal, per-prompt hosts only) ───
+    //
+    // Distinct from the durable settings snapshot above: this carries state
+    // that must survive across a single terminal's per-prompt processes but
+    // must NOT leak to other terminals or persist after the terminal closes —
+    // most notably the interactive tutorial. The path is therefore scoped to
+    // the terminal session, not to global config. The long-lived Bash builtin
+    // keeps this state live in-process and opts out (default `None`).
+
+    /// Path to the on-disk session-state file for a per-prompt host, scoped to
+    /// the current terminal session, or `None` for hosts (like Bash) that keep
+    /// session state live in-process. Returning `None` makes load return the
+    /// default and persist a no-op.
+    fn session_state_path(&self) -> Option<PathBuf> {
+        None
+    }
+
+    /// Load this terminal session's transient state (e.g. tutorial progress).
+    /// With no path (e.g. Bash) or a missing/unreadable file, returns the
+    /// default (tutorial not running).
+    fn load_session_state(&self) -> crate::settings::SessionState {
+        let Some(path) = self.session_state_path() else {
+            return crate::settings::SessionState::default();
+        };
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            return crate::settings::SessionState::default();
+        };
+        serde_json::from_str(&contents).unwrap_or_default()
+    }
+
+    /// Persist this terminal session's transient `state`. A no-op for hosts
+    /// (like Bash) with no `session_state_path()`. When the state is empty
+    /// (tutorial finished), the backing file is removed rather than left as a
+    /// stale marker. Best-effort and fail-open: errors are logged, never
+    /// propagated, so they can't break the prompt.
+    fn persist_session_state(&self, state: &crate::settings::SessionState) {
+        let Some(path) = self.session_state_path() else {
+            return;
+        };
+        if state.is_empty() {
+            let _ = std::fs::remove_file(&path);
+            return;
+        }
+        if let Some(parent) = path.parent()
+            && let Err(err) = std::fs::create_dir_all(parent)
+        {
+            log::warn!("Could not create flyline session dir {parent:?}: {err}");
+            return;
+        }
+        match serde_json::to_string(state) {
+            Ok(json) => {
+                if let Err(err) = std::fs::write(&path, json) {
+                    log::warn!("Could not write flyline session state to {path:?}: {err}");
+                }
+            }
+            Err(err) => log::warn!("Could not serialize flyline session state: {err}"),
+        }
+    }
 }
 
 /// The original Bash host; delegates to `bash_funcs`, adding no new behavior.
@@ -577,5 +697,104 @@ mod tests {
     #[test]
     fn default_backend_delegates_shell_pgrp() {
         assert_eq!(backend().shell_pgrp(), read_shell_pgrp());
+    }
+
+    #[test]
+    fn bash_backend_does_not_persist_settings() {
+        // Bash keeps settings live in the builtin, so the persistence seam is
+        // inert: no path, load yields defaults, persist is a no-op that never writes.
+        assert!(BashBackend.persisted_settings_path().is_none());
+        BashBackend.persist_settings(&crate::settings::Settings::default());
+        assert!(!BashBackend.load_persisted_settings().run_tutorial);
+    }
+
+    #[test]
+    fn zsh_backend_settings_round_trip() {
+        let dir =
+            std::env::temp_dir().join(format!("flyline_settings_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        // SAFETY: no other test reads XDG_CONFIG_HOME; it is restored at the end.
+        unsafe {
+            std::env::set_var("XDG_CONFIG_HOME", &dir);
+        }
+
+        let path = zsh::ZSH_BACKEND
+            .persisted_settings_path()
+            .expect("per-prompt host has a settings path");
+        assert!(path.starts_with(&dir));
+
+        // No file yet -> defaults.
+        assert_eq!(
+            zsh::ZSH_BACKEND
+                .load_persisted_settings()
+                .num_suggestion_rows,
+            crate::settings::Settings::default().num_suggestion_rows
+        );
+
+        let mut s = crate::settings::Settings::default();
+        s.num_suggestion_rows = 33;
+        zsh::ZSH_BACKEND.persist_settings(&s);
+        assert!(path.exists(), "persist_settings should create the snapshot");
+
+        let back = zsh::ZSH_BACKEND.load_persisted_settings();
+        assert_eq!(back.num_suggestion_rows, 33);
+
+        let _ = std::fs::remove_dir_all(&dir);
+        // SAFETY: see above.
+        unsafe {
+            std::env::remove_var("XDG_CONFIG_HOME");
+        }
+    }
+
+    #[test]
+    fn zsh_backend_session_state_round_trip() {
+        // Route the session file into a throwaway XDG_RUNTIME_DIR so the test
+        // is hermetic and never touches a real session.
+        let dir = std::env::temp_dir().join(format!("flyline_session_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        // SAFETY: no other test reads XDG_RUNTIME_DIR; it is restored at the end.
+        unsafe {
+            std::env::set_var("XDG_RUNTIME_DIR", &dir);
+        }
+
+        let path = zsh::ZSH_BACKEND
+            .session_state_path()
+            .expect("per-prompt host has a session-state path");
+        assert!(path.starts_with(&dir));
+
+        // No file yet -> tutorial not running.
+        assert!(!zsh::ZSH_BACKEND.load_session_state().run_tutorial);
+
+        // An active tutorial is persisted and read back.
+        let state = crate::settings::SessionState {
+            run_tutorial: true,
+            tutorial_step: crate::tutorial::TutorialStep::Welcome,
+        };
+        zsh::ZSH_BACKEND.persist_session_state(&state);
+        assert!(path.exists(), "active session state should be written");
+        let back = zsh::ZSH_BACKEND.load_session_state();
+        assert!(back.run_tutorial);
+        assert_eq!(back.tutorial_step, crate::tutorial::TutorialStep::Welcome);
+
+        // A finished tutorial removes the file rather than leaving a stale marker.
+        zsh::ZSH_BACKEND.persist_session_state(&crate::settings::SessionState::default());
+        assert!(!path.exists(), "empty session state should remove the file");
+
+        let _ = std::fs::remove_dir_all(&dir);
+        // SAFETY: see above.
+        unsafe {
+            std::env::remove_var("XDG_RUNTIME_DIR");
+        }
+    }
+
+    #[test]
+    fn bash_backend_does_not_persist_session_state() {
+        // Bash keeps tutorial state live in the builtin; the session seam is inert.
+        assert!(BashBackend.session_state_path().is_none());
+        BashBackend.persist_session_state(&crate::settings::SessionState {
+            run_tutorial: true,
+            ..Default::default()
+        });
+        assert!(!BashBackend.load_session_state().run_tutorial);
     }
 }

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -84,7 +84,17 @@ pub trait ShellBackend: Sync {
     /// Non-zero when the host shell received a terminating signal.
     fn read_terminating_signal(&self) -> libc::c_int;
 
+    /// The completion-script dialect flycomp should synthesize for this host.
+    /// Bash hosts get a `complete -F` script; zsh gets a `#compdef` function.
+    fn flycomp_output_format(&self) -> flycomp::OutputFormat {
+        flycomp::OutputFormat::Bash
+    }
+
     /// Resolve where a synthesized completion script should be written.
+    ///
+    /// The path and on-disk format are backend-specific: Bash writes a
+    /// `complete -F` script named `<cmd>` under a bash-completion dir, while zsh
+    /// writes a `#compdef` function named `_<cmd>` under a dir on its `$fpath`.
     fn resolve_completion_script_path(
         &self,
         command_word: &str,
@@ -98,6 +108,20 @@ pub trait ShellBackend: Sync {
         script: &str,
         flycomp_output: Option<&str>,
     ) -> Result<PathBuf, std::io::Error>;
+
+    /// Make a freshly written completion script active in the running shell so a
+    /// re-triggered Tab uses it immediately. Bash evaluates the script in-process
+    /// (see `evaluate_shell_string`); zsh reloads the function (written at the
+    /// path from `resolve_completion_script_path`) into its completion daemon.
+    /// The default evaluates the script text, matching the original behaviour.
+    fn activate_completion_script(
+        &self,
+        _command_word: &str,
+        script: &str,
+        _flycomp_output: Option<&str>,
+    ) -> anyhow::Result<()> {
+        self.evaluate_shell_string(script)
+    }
 
     /// Read command history from the host shell's in-memory list.
     fn parse_history_from_memory(&self) -> Vec<HistoryRecord>;

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -663,16 +663,33 @@ impl CompDaemon {
 }
 
 /// Parse daemon output between the markers into `(value, description)` pairs.
+///
+/// zsh calls our `compadd` override once per completer/tag, so the same value can
+/// be emitted several times (e.g. `cd` adds each dir under multiple tags). zsh
+/// dedups matches before display; we replicate that here, keeping first-seen order
+/// and the first non-empty description.
 pub fn parse_capture_output(blob: &str) -> Vec<(String, Option<String>)> {
     let mut inside = false;
-    let mut out = Vec::new();
+    let mut out: Vec<(String, Option<String>)> = Vec::new();
+    let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
     for line in blob.lines() {
         let line = line.trim_end_matches('\r');
         if line.contains(FLYEND) {
             break;
         }
         if inside && !line.is_empty() {
-            out.push(parse_capture_line(line));
+            let (value, desc) = parse_capture_line(line);
+            match seen.get(&value) {
+                Some(&idx) => {
+                    if out[idx].1.is_none() && desc.is_some() {
+                        out[idx].1 = desc;
+                    }
+                }
+                None => {
+                    seen.insert(value.clone(), out.len());
+                    out.push((value, desc));
+                }
+            }
         }
         if line.contains(FLYBEGIN) {
             inside = true;
@@ -1032,6 +1049,20 @@ mod tests {
     fn parse_capture_output_skips_empty_lines() {
         let blob = "<<FLYBEGIN>>\n\nfoo\n<<FLYEND>>\n";
         assert_eq!(parse_capture_output(blob), vec![("foo".to_string(), None)],);
+    }
+
+    #[test]
+    fn parse_capture_output_dedups_repeated_values() {
+        // `cd` completion emits each dir under several tags; keep first-seen order
+        // and adopt the first non-empty description that appears for a value.
+        let blob = "<<FLYBEGIN>>\nbin\nsrc\nbin\nsrc -- source\nbin\n<<FLYEND>>\n";
+        assert_eq!(
+            parse_capture_output(blob),
+            vec![
+                ("bin".to_string(), None),
+                ("src".to_string(), Some("source".to_string())),
+            ],
+        );
     }
 
     #[test]

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -1,0 +1,1275 @@
+//! Zsh host backend for the out-of-process `flyline-standalone` editor.
+
+use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant, SystemTime};
+
+use crate::bash_funcs::{
+    CommandWordInfo, CompletionFlags, ProgrammableCompleteReturn, find_quote_type,
+};
+use crate::kill_on_drop_child::KillOnDropChild;
+use crate::shell::{HistoryRecord, ShellBackend};
+use anyhow::Context;
+
+const DAEMON_SCRIPT: &str = include_str!("zsh_comp_daemon.zsh");
+const READY_MARKER: &str = "READY";
+const FLYBEGIN: &str = "<<FLYBEGIN>>";
+const FLYEND: &str = "<<FLYEND>>";
+const FLYCD: &str = "<<FLYCD>>";
+
+/// Read caps so a bad rc/completion can't hang flyline (fail-open on timeout).
+const DAEMON_BOOT_TIMEOUT: Duration = Duration::from_secs(10);
+const CAPTURE_TIMEOUT: Duration = Duration::from_secs(15);
+const DUMP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Socket-path env set when flyline-standalone runs as the broker (run_comp_broker).
+const BROKER_ENV: &str = "FLYLINE_COMP_BROKER";
+const BROKER_IDLE_TIMEOUT: Duration = Duration::from_secs(600);
+const BROKER_SPAWN_WAIT: Duration = Duration::from_secs(4);
+/// Request I/O cap; must exceed a cold daemon boot.
+const BROKER_REQUEST_TIMEOUT: Duration =
+    Duration::from_secs(DAEMON_BOOT_TIMEOUT.as_secs() + CAPTURE_TIMEOUT.as_secs());
+
+/// Cache a dead/absent broker for this process so we don't re-probe every Tab.
+static BROKER_UNAVAILABLE: AtomicBool = AtomicBool::new(false);
+
+/// Dumps the shell's command vocabulary as `FLYT`-prefixed lines (rc loaded).
+const DUMP_SCRIPT: &str = concat!(
+    "zmodload zsh/parameter 2>/dev/null\n",
+    "for k v in \"${(@kv)aliases}\"; do print -r -- \"FLYT\talias\t$k\t$v\"; done\n",
+    "for k in \"${(k)functions[@]}\"; do print -r -- \"FLYT\tfunction\t$k\"; done\n",
+    "for k in \"${(k)builtins[@]}\"; do print -r -- \"FLYT\tbuiltin\t$k\"; done\n",
+    "for k in $reswords; do print -r -- \"FLYT\treserved\t$k\"; done\n",
+    "for k v in \"${(@kv)commands}\"; do print -r -- \"FLYT\tcommand\t$k\t$v\"; done\n",
+);
+
+/// Opt out of loading the user's rc into flyline's zsh helpers.
+fn no_rcs() -> bool {
+    std::env::var_os("FLYLINE_ZSH_NO_RCS").is_some()
+}
+
+/// Opt out of the shared broker (falls back to a per-process in-process daemon).
+fn broker_disabled() -> bool {
+    std::env::var_os("FLYLINE_ZSH_NO_BROKER").is_some()
+}
+
+/// Mark `fd` close-on-exec. Critical: the widget's `$( "$FLYLINE_BIN" 3>&1 )`
+/// only returns once every writer of fd 3 is closed, so a long-lived helper
+/// grandchild (completion daemon, gitstatusd) that inherited it would wedge the
+/// terminal. Only affects `exec`, not our own `read`/`write`.
+pub fn set_cloexec(fd: std::os::fd::RawFd) {
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFD);
+        if flags != -1 {
+            libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC);
+        }
+    }
+}
+
+/// The host shell's command vocabulary (built once with rc loaded). Backs
+/// `find_alias`/`command_info`/`possible_command_words` via map lookups —
+/// injection-safe, since no command word is interpolated into a shell string.
+#[derive(Default)]
+struct CommandTable {
+    aliases: HashMap<String, String>,
+    functions: HashSet<String>,
+    builtins: HashSet<String>,
+    reserved: HashSet<String>,
+    commands: HashMap<String, String>,
+    ordered: Vec<CommandWordInfo>,
+}
+
+fn build_command_table() -> CommandTable {
+    if no_rcs() {
+        // `zsh -fc` (no rc) is effectively instant — no point caching it.
+        return match run_zsh_timeout(&["-fc", DUMP_SCRIPT], DUMP_TIMEOUT) {
+            Some(out) => parse_command_table(&out),
+            None => CommandTable::default(),
+        };
+    }
+    // The rc-loaded dump takes >1s; a fresh process per prompt would pay it every
+    // line. Cache the raw dump on disk, invalidated on ~/.zshrc change or TTL.
+    if let Some(path) = cmd_table_cache_path() {
+        if let Some(cached) = read_cached_dump(&path) {
+            return parse_command_table(&cached);
+        }
+        if let Some(out) = run_zsh_timeout(&["-ic", DUMP_SCRIPT], DUMP_TIMEOUT) {
+            write_cached_dump(&path, &out);
+            return parse_command_table(&out);
+        }
+        return CommandTable::default();
+    }
+    match run_zsh_timeout(&["-ic", DUMP_SCRIPT], DUMP_TIMEOUT) {
+        Some(out) => parse_command_table(&out),
+        None => CommandTable::default(),
+    }
+}
+
+/// Command-table cache TTL: catches PATH changes that don't touch ~/.zshrc.
+const CMD_TABLE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+fn cmd_table_cache_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))?;
+    Some(base.join("flyline").join("zsh-cmdtable"))
+}
+
+fn zshrc_mtime() -> Option<SystemTime> {
+    let home = std::env::var_os("HOME")?;
+    std::fs::metadata(PathBuf::from(home).join(".zshrc"))
+        .ok()?
+        .modified()
+        .ok()
+}
+
+/// Cached dump if present, within TTL, and newer than ~/.zshrc; else `None`.
+fn read_cached_dump(path: &Path) -> Option<String> {
+    let modified = std::fs::metadata(path).ok()?.modified().ok()?;
+    if modified
+        .elapsed()
+        .map(|e| e > CMD_TABLE_TTL)
+        .unwrap_or(true)
+    {
+        return None;
+    }
+    if let Some(rc) = zshrc_mtime() {
+        if rc > modified {
+            return None;
+        }
+    }
+    std::fs::read_to_string(path).ok()
+}
+
+/// Write the dump atomically (temp + rename) so concurrent shells don't read a
+/// half-written cache. Best-effort.
+fn write_cached_dump(path: &Path, dump: &str) {
+    let Some(dir) = path.parent() else { return };
+    if std::fs::create_dir_all(dir).is_err() {
+        return;
+    }
+    let tmp = dir.join(format!("zsh-cmdtable.{}.tmp", std::process::id()));
+    if std::fs::write(&tmp, dump).is_ok() && std::fs::rename(&tmp, path).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+}
+
+/// Parse `FLYT`-prefixed dump lines into a `CommandTable`, ignoring rc noise.
+fn parse_command_table(out: &str) -> CommandTable {
+    let mut table = CommandTable::default();
+    for line in out.lines() {
+        let Some(rest) = line.strip_prefix("FLYT\t") else {
+            continue;
+        };
+        let mut parts = rest.splitn(3, '\t');
+        let kind = parts.next().unwrap_or("");
+        let name = match parts.next() {
+            Some(n) if !n.is_empty() => n.to_string(),
+            _ => continue,
+        };
+        let extra = parts.next().unwrap_or("");
+        match kind {
+            "alias" => {
+                table.aliases.insert(name.clone(), extra.to_string());
+                table.ordered.push(CommandWordInfo::Alias {
+                    command: name,
+                    expansion: extra.to_string(),
+                });
+            }
+            "function" => {
+                table.functions.insert(name.clone());
+                table.ordered.push(CommandWordInfo::Function {
+                    command: name,
+                    source_file: None,
+                    line: None,
+                });
+            }
+            "builtin" => {
+                table.builtins.insert(name.clone());
+                table.ordered.push(CommandWordInfo::Builtin {
+                    command: name,
+                    usage: None,
+                });
+            }
+            "reserved" => {
+                table.reserved.insert(name.clone());
+                table.ordered.push(CommandWordInfo::Keyword {
+                    command: name,
+                    usage: None,
+                });
+            }
+            "command" => {
+                table.commands.insert(name.clone(), extra.to_string());
+                table.ordered.push(CommandWordInfo::File {
+                    command: name,
+                    path: extra.to_string(),
+                });
+            }
+            _ => {}
+        }
+    }
+    table
+}
+
+/// Run `zsh <args>`, capturing stdout; `None` on failure/timeout (fail-open).
+fn run_zsh_timeout(args: &[&str], timeout: Duration) -> Option<String> {
+    let mut child = Command::new("zsh")
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    let mut stdout = child.stdout.take()?;
+    let (tx, rx) = std::sync::mpsc::channel();
+    // Ephemeral I/O reader, not a tracked bash-func thread; lint opt-out is local.
+    #[allow(clippy::disallowed_methods)]
+    std::thread::spawn(move || {
+        let mut s = String::new();
+        let _ = stdout.read_to_string(&mut s);
+        let _ = tx.send(s);
+    });
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let out = rx.recv().unwrap_or_default();
+                return status.success().then_some(out);
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+/// The zsh host backend. Select with `shell::set_backend(&ZSH_BACKEND)` at
+/// standalone startup before any `shell::backend()` call.
+pub struct ZshBackend {
+    comp_daemon: Mutex<Option<CompDaemon>>,
+    daemon_script_path: OnceLock<PathBuf>,
+    // command vocabulary built once per process
+    command_table: OnceLock<CommandTable>,
+}
+
+pub static ZSH_BACKEND: ZshBackend = ZshBackend {
+    comp_daemon: Mutex::new(None),
+    daemon_script_path: OnceLock::new(),
+    command_table: OnceLock::new(),
+};
+
+struct CompDaemon {
+    _child: KillOnDropChild,
+    master: std::fs::File,
+}
+
+fn zsh_eval(script: &str) -> Option<String> {
+    let output = Command::new("zsh").args(["-fc", script]).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    Some(text.trim_end_matches(&['\n', '\r'][..]).to_string())
+}
+
+fn zsh_expand(s: &str) -> String {
+    if s.is_empty() {
+        return String::new();
+    }
+    // ponytail: one subprocess per expansion; fine for standalone startup paths.
+    unsafe {
+        std::env::set_var("_FLYLINE_EXPAND", s);
+    }
+    let expanded = zsh_eval("emulate -L zsh; print -rn -- ${~_FLYLINE_EXPAND}")
+        .unwrap_or_else(|| s.to_string());
+    unsafe {
+        std::env::remove_var("_FLYLINE_EXPAND");
+    }
+    expanded
+}
+
+fn hostname_from_uname() -> String {
+    let mut buf = [0u8; 256];
+    let rc = unsafe { libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
+    if rc == 0 {
+        let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+        String::from_utf8_lossy(&buf[..end]).into_owned()
+    } else {
+        String::new()
+    }
+}
+
+fn shell_var_name(name: &str) -> Option<&str> {
+    if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+impl ZshBackend {
+    fn table(&self) -> &CommandTable {
+        self.command_table.get_or_init(build_command_table)
+    }
+
+    fn daemon_script_path(&self) -> &Path {
+        self.daemon_script_path
+            .get_or_init(|| {
+                let path = std::env::temp_dir().join("flyline_zsh_comp_daemon.zsh");
+                let _ = std::fs::write(&path, DAEMON_SCRIPT);
+                path
+            })
+            .as_path()
+    }
+
+    fn ensure_comp_daemon(&self) -> anyhow::Result<()> {
+        let mut guard = self.comp_daemon.lock().unwrap();
+        if guard.is_none() {
+            *guard = Some(spawn_comp_daemon(self.daemon_script_path())?);
+        }
+        Ok(())
+    }
+
+    fn capture_completions(
+        &self,
+        full_command: &str,
+        cursor_byte_pos: usize,
+    ) -> anyhow::Result<Vec<(String, Option<String>)>> {
+        let buffer_at_cursor = full_command
+            .get(..cursor_byte_pos.min(full_command.len()))
+            .unwrap_or(full_command);
+        // Fast path: the shared broker (daemon booted once, reused across prompts).
+        if let Some(pairs) = broker_capture(&self.cwd(), buffer_at_cursor) {
+            return Ok(pairs);
+        }
+        // Fail-open: per-process in-process daemon (original behaviour).
+        self.ensure_comp_daemon()?;
+        let mut guard = self.comp_daemon.lock().unwrap();
+        let daemon = guard
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("completion daemon not initialized"))?;
+        let output = daemon.capture(buffer_at_cursor)?;
+        Ok(parse_capture_output(&output))
+    }
+}
+
+impl ShellBackend for ZshBackend {
+    fn is_bash(&self) -> bool {
+        false
+    }
+
+    fn cwd(&self) -> String {
+        std::env::var("PWD")
+            .ok()
+            .or_else(|| {
+                std::env::current_dir()
+                    .ok()
+                    .map(|p| p.to_string_lossy().into_owned())
+            })
+            .unwrap_or_default()
+    }
+
+    fn env_var(&self, name: &str) -> Option<String> {
+        if let Ok(v) = std::env::var(name) {
+            return Some(v);
+        }
+        let safe = shell_var_name(name)?;
+        let script = format!(r#"(( ${{{safe}+1}} )) && print -r -- "${{(P){safe}}}" "#);
+        zsh_eval(&script).filter(|s| !s.is_empty())
+    }
+
+    fn hostname(&self) -> String {
+        std::env::var("HOST")
+            .ok()
+            .filter(|h| !h.is_empty())
+            .or_else(|| zsh_eval(r#"print -r -- "${HOST:-$(hostname 2>/dev/null)}""#))
+            .filter(|h| !h.is_empty())
+            .unwrap_or_else(hostname_from_uname)
+    }
+
+    fn format_var(&self, name: &str) -> String {
+        let Some(safe) = shell_var_name(name) else {
+            return String::new();
+        };
+        zsh_eval(&format!(
+            r#"typeset -p {safe} 2>/dev/null || print -r -- "${safe}="" "#
+        ))
+        .unwrap_or_else(|| match self.env_var(name) {
+            Some(value) => format!("${name}={value}"),
+            None => format!("${name}="),
+        })
+    }
+
+    fn vars_with_prefix(&self, prefix: &str) -> Vec<String> {
+        let bare = prefix.strip_prefix('$').unwrap_or(prefix);
+        if bare.is_empty() {
+            return Vec::new();
+        }
+        let script = format!(
+            r#"emulate -L zsh; prefix={bare}; for v in ${{(ok)parameters[(I)${{prefix}}*]}}; do print -r -- "${{v}}"; done"#
+        );
+        zsh_eval(&script)
+            .map(|output| {
+                let mut vars: Vec<String> = output
+                    .lines()
+                    .filter(|l| !l.is_empty())
+                    .map(|l| format!("${l}"))
+                    .collect();
+                if vars.is_empty() {
+                    vars = std::env::vars()
+                        .map(|(name, _)| name)
+                        .filter(|name| name.starts_with(bare))
+                        .map(|name| format!("${name}"))
+                        .collect();
+                }
+                vars.sort();
+                vars.dedup();
+                vars
+            })
+            .unwrap_or_default()
+    }
+
+    fn expand_path(&self, path: &str) -> String {
+        let expanded = self.expand_filename(path);
+        if expanded.is_empty() {
+            return std::env::current_dir()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default();
+        }
+        if Path::new(&expanded).is_absolute() {
+            expanded
+        } else {
+            match std::env::current_dir() {
+                Ok(cwd) => format!("{}/{}", cwd.display(), expanded),
+                Err(_) => expanded,
+            }
+        }
+    }
+
+    fn expand_filename(&self, filename: &str) -> String {
+        zsh_expand(filename)
+    }
+
+    fn decode_prompt(&self, raw: &str, _is_prompt: bool) -> Option<String> {
+        if raw.is_empty() {
+            return Some(String::new());
+        }
+        unsafe {
+            std::env::set_var("_FLYLINE_PROMPT", raw);
+        }
+        let decoded = zsh_eval("emulate -L zsh; print -Pn -- \"$_FLYLINE_PROMPT\"");
+        unsafe {
+            std::env::remove_var("_FLYLINE_PROMPT");
+        }
+        Some(decoded.unwrap_or_else(|| raw.to_string()))
+    }
+
+    fn find_alias(&self, cmd: &str) -> Option<String> {
+        self.table()
+            .aliases
+            .get(cmd)
+            .filter(|e| !e.is_empty())
+            .cloned()
+    }
+
+    fn command_info(&self, cmd: &str) -> CommandWordInfo {
+        let table = self.table();
+        if let Some(expansion) = table.aliases.get(cmd) {
+            return CommandWordInfo::Alias {
+                command: cmd.to_string(),
+                expansion: expansion.clone(),
+            };
+        }
+        if table.functions.contains(cmd) {
+            return CommandWordInfo::Function {
+                command: cmd.to_string(),
+                source_file: None,
+                line: None,
+            };
+        }
+        if table.builtins.contains(cmd) {
+            return CommandWordInfo::Builtin {
+                command: cmd.to_string(),
+                usage: None,
+            };
+        }
+        if table.reserved.contains(cmd) {
+            return CommandWordInfo::Keyword {
+                command: cmd.to_string(),
+                usage: None,
+            };
+        }
+        if let Some(path) = table.commands.get(cmd) {
+            return CommandWordInfo::File {
+                command: cmd.to_string(),
+                path: path.clone(),
+            };
+        }
+        CommandWordInfo::Unknown {
+            command: cmd.to_string(),
+        }
+    }
+
+    fn run_programmable_completions(
+        &self,
+        full_command: &str,
+        _command_word: &str,
+        word_under_cursor: &str,
+        cursor_byte_pos: usize,
+        _word_under_cursor_byte_end: usize,
+    ) -> anyhow::Result<ProgrammableCompleteReturn> {
+        let pairs = self.capture_completions(full_command, cursor_byte_pos)?;
+        let completions = pairs_to_completion_strings(&pairs);
+        let mut flags = CompletionFlags::default();
+        flags.quote_type = find_quote_type(word_under_cursor);
+        flags.some_dont_end_in_equal_sign = completions.iter().any(|s| !s.ends_with('='));
+        let compspec_was_useful = !completions.is_empty();
+        Ok(ProgrammableCompleteReturn::new(
+            completions,
+            flags,
+            compspec_was_useful,
+        ))
+    }
+
+    fn possible_command_words(&self) -> Vec<CommandWordInfo> {
+        self.table().ordered.clone()
+    }
+
+    fn evaluate_shell_string(&self, script: &str) -> anyhow::Result<()> {
+        let status = Command::new("zsh").args(["-fc", script]).status()?;
+        if status.success() {
+            Ok(())
+        } else {
+            anyhow::bail!("zsh -fc exited with {status}")
+        }
+    }
+
+    fn reset_caches(&self) {}
+
+    fn warm_completion_caches(&self) {
+        // Boot the daemon (broker or in-process) and table off the hot path.
+        if broker_disabled() {
+            let _ = self.ensure_comp_daemon();
+        } else if let Some(path) = broker_socket_path() {
+            let _ = connect_or_spawn_broker(&path);
+        }
+        let _ = self.table();
+    }
+
+    fn read_terminating_signal(&self) -> libc::c_int {
+        0
+    }
+
+    fn resolve_completion_script_path(
+        &self,
+        command_word: &str,
+        flycomp_output: Option<&str>,
+    ) -> PathBuf {
+        let poss_alias = self.find_alias(command_word);
+        let alias_def = poss_alias
+            .as_deref()
+            .filter(|alias| !alias.is_empty())
+            .unwrap_or(command_word);
+        let cmd_word = alias_def.split_whitespace().next().unwrap_or(alias_def);
+        let file_name = Path::new(cmd_word)
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or(cmd_word);
+        let output_dir = flycomp_output.unwrap_or("~/.local/share/bash-completion/completions/");
+        Path::new(&self.expand_path(output_dir)).join(file_name)
+    }
+
+    fn resolve_and_write_completion_script(
+        &self,
+        command_word: &str,
+        script: &str,
+        flycomp_output: Option<&str>,
+    ) -> Result<PathBuf, std::io::Error> {
+        let write_path = self.resolve_completion_script_path(command_word, flycomp_output);
+        if let Some(parent) = write_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(&write_path, script)?;
+        Ok(write_path)
+    }
+
+    fn parse_history_from_memory(&self) -> Vec<HistoryRecord> {
+        // ponytail: standalone child cannot read the parent zsh's in-memory history.
+        vec![]
+    }
+
+    fn last_command_exit_status(&self) -> i32 {
+        std::env::var("FLYLINE_LAST_EXIT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .or_else(|| std::env::var("_").ok().and_then(|s| s.parse().ok()))
+            .unwrap_or(0)
+    }
+
+    fn multiline_command_count(&self) -> i32 {
+        0
+    }
+
+    fn shell_pgrp(&self) -> libc::pid_t {
+        unsafe { libc::getpgrp() }
+    }
+}
+
+impl CompDaemon {
+    /// `cd` the long-lived daemon to `cwd` (so path/git completions match the
+    /// caller) then capture. For the broker; one daemon serves many directories.
+    fn cd_and_capture(&mut self, cwd: &str, buffer_at_cursor: &str) -> anyhow::Result<String> {
+        if !cwd.is_empty() && !cwd.contains('\n') {
+            self.master.write_all(cwd.as_bytes()).context("write cwd")?;
+            // ^F -> fly-cd widget (see zsh_comp_daemon.zsh): cd + clear buffer.
+            self.master.write_all(b"\x06").context("write ^F")?;
+            self.master.flush().context("flush cwd")?;
+            read_until_marker_timeout(&self.master, FLYCD, CAPTURE_TIMEOUT)
+                .context("wait for daemon cd")?;
+        }
+        self.capture(buffer_at_cursor)
+    }
+
+    fn capture(&mut self, buffer_at_cursor: &str) -> anyhow::Result<String> {
+        if buffer_at_cursor.contains('\n') {
+            anyhow::bail!("completion buffer must not contain newlines");
+        }
+        self.master
+            .write_all(buffer_at_cursor.as_bytes())
+            .context("write buffer to zsh daemon")?;
+        self.master
+            .write_all(b"\t")
+            .context("write tab to trigger completion")?;
+        self.master.flush().context("flush daemon stdin")?;
+        let output = read_until_marker_timeout(&self.master, FLYEND, CAPTURE_TIMEOUT)?;
+        // Reset line for next round (Ctrl-U).
+        self.master
+            .write_all(b"\x15")
+            .context("reset daemon line")?;
+        self.master.flush().context("flush after reset")?;
+        Ok(output)
+    }
+}
+
+/// Parse daemon output between the markers into `(value, description)` pairs.
+pub fn parse_capture_output(blob: &str) -> Vec<(String, Option<String>)> {
+    let mut inside = false;
+    let mut out = Vec::new();
+    for line in blob.lines() {
+        let line = line.trim_end_matches('\r');
+        if line.contains(FLYEND) {
+            break;
+        }
+        if inside && !line.is_empty() {
+            out.push(parse_capture_line(line));
+        }
+        if line.contains(FLYBEGIN) {
+            inside = true;
+        }
+    }
+    out
+}
+
+/// Parse one compadd-capture line (`value` or `value -- description`).
+pub fn parse_capture_line(line: &str) -> (String, Option<String>) {
+    if let Some(pos) = line.find(" -- ") {
+        let value = line[..pos].to_string();
+        let desc = line[pos + 4..].trim();
+        (
+            value,
+            if desc.is_empty() {
+                None
+            } else {
+                Some(desc.to_string())
+            },
+        )
+    } else {
+        (line.to_string(), None)
+    }
+}
+
+/// Convert parsed pairs to flyline completion strings (`value\\tdescription`).
+pub fn pairs_to_completion_strings(pairs: &[(String, Option<String>)]) -> Vec<String> {
+    pairs
+        .iter()
+        .map(|(value, desc)| match desc {
+            Some(d) => format!("{value}\t{d}"),
+            None => value.clone(),
+        })
+        .collect()
+}
+
+fn read_until_marker(reader: &mut std::fs::File, marker: &str) -> anyhow::Result<String> {
+    let mut buf = String::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        let n = reader.read(&mut chunk).context("read from zsh daemon")?;
+        if n == 0 {
+            break;
+        }
+        buf.push_str(&String::from_utf8_lossy(&chunk[..n]));
+        if buf.contains(marker) {
+            break;
+        }
+    }
+    Ok(buf)
+}
+
+/// `read_until_marker` bounded by `timeout`, on a worker thread so a stuck shell
+/// can't hang flyline; on timeout the caller drops the daemon, unblocking it.
+fn read_until_marker_timeout(
+    master: &std::fs::File,
+    marker: &str,
+    timeout: Duration,
+) -> anyhow::Result<String> {
+    let mut reader = master.try_clone().context("clone pty master for read")?;
+    let marker_owned = marker.to_string();
+    let (tx, rx) = std::sync::mpsc::channel();
+    // Ephemeral I/O reader, not a tracked bash-func thread; lint opt-out is local.
+    #[allow(clippy::disallowed_methods)]
+    std::thread::spawn(move || {
+        let _ = tx.send(read_until_marker(&mut reader, &marker_owned));
+    });
+    match rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(_) => anyhow::bail!("timed out waiting for {marker} from zsh daemon"),
+    }
+}
+
+// ponytail: libc openpty — plain pipes cannot drive ZLE `complete-word`; no extra crate.
+fn spawn_comp_daemon(script_path: &Path) -> anyhow::Result<CompDaemon> {
+    use std::os::unix::io::FromRawFd;
+
+    let mut master: libc::c_int = 0;
+    let mut slave: libc::c_int = 0;
+    unsafe {
+        if libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        ) != 0
+        {
+            anyhow::bail!("openpty failed: {}", std::io::Error::last_os_error());
+        }
+    }
+    // Pty ends close-on-exec so no helper inherits the master (which would keep
+    // the pty from hanging up on exit, orphaning the daemon). Stdio dup2 below is
+    // unaffected by FD_CLOEXEC.
+    set_cloexec(master);
+    set_cloexec(slave);
+
+    let slave_file = unsafe { std::fs::File::from_raw_fd(slave) };
+    let slave_in = slave_file.try_clone().context("clone pty slave")?;
+
+    // Load the user's rc by default (for their fpath completions); NO_RCS uses -f.
+    let args: &[&str] = if no_rcs() { &["-f", "-i"] } else { &["-i"] };
+    let child = Command::new("zsh")
+        .args(args)
+        .stdin(Stdio::from(slave_in))
+        .stdout(Stdio::from(slave_file))
+        .stderr(Stdio::null())
+        .spawn()
+        .context("spawn zsh completion daemon")?;
+
+    // Guard the child now so any early return (e.g. boot timeout) kills it.
+    let daemon = CompDaemon {
+        _child: KillOnDropChild::new(child),
+        master: unsafe { std::fs::File::from_raw_fd(master) },
+    };
+
+    // Startup-file arg makes `zsh -i` exit after the script; source over pty instead.
+    let source_cmd = format!("source {}\n", script_path.display());
+    (&daemon.master)
+        .write_all(source_cmd.as_bytes())
+        .context("source daemon script")?;
+    (&daemon.master).flush().context("flush source command")?;
+
+    let boot = read_until_marker_timeout(&daemon.master, READY_MARKER, DAEMON_BOOT_TIMEOUT)
+        .context("wait for zsh daemon READY")?;
+    if !boot.contains(READY_MARKER) {
+        anyhow::bail!("zsh daemon did not emit READY");
+    }
+
+    Ok(daemon)
+}
+
+// Persistent completion broker: boots one daemon and serves completions over a
+// Unix socket, shared across prompts/terminals, instead of paying the ~1.3s
+// rc-loaded boot per prompt. Strictly fail-open — any failure falls back to the
+// in-process daemon, so the broker can never wedge the shell.
+
+/// Per-rc broker socket, keyed by ~/.zshrc mtime + no-rcs so an rc edit routes to
+/// a fresh daemon. `$XDG_RUNTIME_DIR` preferred, else the temp dir.
+fn broker_socket_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(std::env::temp_dir);
+    let dir = base.join("flyline");
+    let _ = std::fs::create_dir_all(&dir);
+    let key = zshrc_mtime()
+        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let norc = u8::from(no_rcs());
+    Some(dir.join(format!("zcompd-{key}-{norc}.sock")))
+}
+
+/// Complete `buffer_at_cursor` in `cwd` via the broker. `None` (→ in-process
+/// fallback) when disabled, unreachable, or the reply is malformed; a valid empty
+/// result is `Some(vec![])` so we don't redundantly re-capture in-process.
+fn broker_capture(cwd: &str, buffer_at_cursor: &str) -> Option<Vec<(String, Option<String>)>> {
+    // Under `cargo test` current_exe() is the harness, so a spawn would re-exec
+    // the whole suite. Tests drive `run_comp_broker` directly.
+    if cfg!(test) {
+        return None;
+    }
+    if broker_disabled()
+        || BROKER_UNAVAILABLE.load(Ordering::Relaxed)
+        || buffer_at_cursor.contains('\n')
+    {
+        return None;
+    }
+    match broker_request(cwd, buffer_at_cursor) {
+        Some(blob) if blob.contains(FLYEND) => Some(parse_capture_output(&blob)),
+        _ => {
+            BROKER_UNAVAILABLE.store(true, Ordering::Relaxed);
+            None
+        }
+    }
+}
+
+/// Send one request to the broker (spawning it if needed) and read the reply.
+fn broker_request(cwd: &str, buffer_at_cursor: &str) -> Option<String> {
+    let path = broker_socket_path()?;
+    let mut stream = connect_or_spawn_broker(&path)?;
+    stream.set_read_timeout(Some(BROKER_REQUEST_TIMEOUT)).ok()?;
+    stream
+        .set_write_timeout(Some(BROKER_REQUEST_TIMEOUT))
+        .ok()?;
+    let req = format!("{cwd}\n{buffer_at_cursor}\n");
+    stream.write_all(req.as_bytes()).ok()?;
+    stream.flush().ok()?;
+    let _ = stream.shutdown(std::net::Shutdown::Write);
+    let mut resp = String::new();
+    stream.read_to_string(&mut resp).ok()?;
+    Some(resp)
+}
+
+/// Connect to the broker, spawning a detached one and polling for its socket if
+/// none is listening yet.
+fn connect_or_spawn_broker(path: &Path) -> Option<UnixStream> {
+    if let Ok(s) = UnixStream::connect(path) {
+        return Some(s);
+    }
+    spawn_broker(path)?;
+    let deadline = Instant::now() + BROKER_SPAWN_WAIT;
+    loop {
+        if let Ok(s) = UnixStream::connect(path) {
+            return Some(s);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Spawn `flyline-standalone` in broker mode, detached (setsid) so a closing
+/// terminal's SIGHUP can't kill the shared daemon.
+fn spawn_broker(path: &Path) -> Option<()> {
+    // Safety boundary: never re-exec the test harness (current_exe under tests).
+    if cfg!(test) {
+        return None;
+    }
+    use std::os::unix::process::CommandExt;
+    let exe = std::env::current_exe().ok()?;
+    let mut cmd = Command::new(exe);
+    cmd.env(BROKER_ENV, path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    // fd 3 is already close-on-exec, so the detached broker can't hold the
+    // parent's `$( ... 3>&1 )` open.
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+    cmd.spawn().ok()?;
+    Some(())
+}
+
+/// Broker entry point: boot one daemon and serve completions until idle. Returns
+/// only on setup failure; the idle watchdog exits the process otherwise.
+pub fn run_comp_broker(socket_path: &Path) -> i32 {
+    // Singleton: if a broker is already listening here, let it own the socket.
+    if UnixStream::connect(socket_path).is_ok() {
+        return 0;
+    }
+    if let Some(dir) = socket_path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    // Clear a stale socket left by a crashed broker, then claim the path.
+    let _ = std::fs::remove_file(socket_path);
+    let listener = match UnixListener::bind(socket_path) {
+        Ok(l) => l,
+        Err(_) => return 0, // lost the bind race; the winner serves
+    };
+    // Fail-open: on boot failure, tear down so clients revert to in-process.
+    let mut daemon = match spawn_comp_daemon(ZSH_BACKEND.daemon_script_path()) {
+        Ok(d) => d,
+        Err(_) => {
+            let _ = std::fs::remove_file(socket_path);
+            return 1;
+        }
+    };
+
+    let last_activity = Arc::new(Mutex::new(Instant::now()));
+    spawn_idle_watchdog(last_activity.clone(), socket_path.to_path_buf());
+
+    for stream in listener.incoming() {
+        let Ok(mut stream) = stream else { continue };
+        if let Ok(mut act) = last_activity.lock() {
+            *act = Instant::now();
+        }
+        if let Some((cwd, buffer)) = read_broker_request(&stream) {
+            let blob = daemon.cd_and_capture(&cwd, &buffer).unwrap_or_default();
+            let _ = stream.write_all(blob.as_bytes());
+        }
+        // Dropping the stream closes it: EOF frames the response for the client.
+    }
+    0
+}
+
+/// Read a `<cwd>\n<buffer>\n` request. A missing second line yields an empty
+/// buffer (harmless empty completion).
+fn read_broker_request(stream: &UnixStream) -> Option<(String, String)> {
+    let clone = stream.try_clone().ok()?;
+    let _ = clone.set_read_timeout(Some(BROKER_REQUEST_TIMEOUT));
+    let mut reader = BufReader::new(clone);
+    let mut cwd = String::new();
+    let mut buffer = String::new();
+    reader.read_line(&mut cwd).ok()?;
+    reader.read_line(&mut buffer).ok()?;
+    Some((
+        cwd.trim_end_matches('\n').to_string(),
+        buffer.trim_end_matches('\n').to_string(),
+    ))
+}
+
+/// Exit the broker process once it has been idle past `BROKER_IDLE_TIMEOUT`.
+fn spawn_idle_watchdog(last_activity: Arc<Mutex<Instant>>, socket_path: PathBuf) {
+    // Ephemeral watchdog, not a tracked bash-func thread; lint opt-out is local.
+    #[allow(clippy::disallowed_methods)]
+    std::thread::spawn(move || {
+        loop {
+            std::thread::sleep(Duration::from_secs(30));
+            let idle = last_activity
+                .lock()
+                .map(|t| t.elapsed())
+                .unwrap_or_default();
+            if idle >= BROKER_IDLE_TIMEOUT {
+                let _ = std::fs::remove_file(&socket_path);
+                std::process::exit(0);
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+fn zsh_available() -> bool {
+    Command::new("which")
+        .arg("zsh")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_capture_line_value_only() {
+        assert_eq!(parse_capture_line("main"), ("main".to_string(), None));
+    }
+
+    #[test]
+    fn parse_capture_line_with_description() {
+        assert_eq!(
+            parse_capture_line("get -- Display a resource"),
+            ("get".to_string(), Some("Display a resource".to_string()),),
+        );
+    }
+
+    #[test]
+    fn parse_capture_output_between_markers() {
+        let blob = "noise\n<<FLYBEGIN>>\nmain\nget -- Display a resource\n<<FLYEND>>\ntrailer\n";
+        assert_eq!(
+            parse_capture_output(blob),
+            vec![
+                ("main".to_string(), None),
+                ("get".to_string(), Some("Display a resource".to_string())),
+            ],
+        );
+    }
+
+    #[test]
+    fn parse_capture_output_skips_empty_lines() {
+        let blob = "<<FLYBEGIN>>\n\nfoo\n<<FLYEND>>\n";
+        assert_eq!(parse_capture_output(blob), vec![("foo".to_string(), None)],);
+    }
+
+    #[test]
+    fn set_cloexec_marks_and_blocks_inheritance() {
+        // pipe(2) fds start without FD_CLOEXEC.
+        let mut fds = [0 as libc::c_int; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let (r, w) = (fds[0], fds[1]);
+        assert_eq!(
+            unsafe { libc::fcntl(w, libc::F_GETFD) } & libc::FD_CLOEXEC,
+            0
+        );
+
+        set_cloexec(w);
+        assert_ne!(
+            unsafe { libc::fcntl(w, libc::F_GETFD) } & libc::FD_CLOEXEC,
+            0,
+            "set_cloexec did not set FD_CLOEXEC"
+        );
+
+        // A child that execs must NOT inherit `w`; after we close our own copy
+        // the reader hangs up. If `w` leaked into the child, POLLHUP never fires
+        // and the poll times out — exactly the bug that wedged the zsh widget.
+        let mut child = Command::new("sleep").arg("2").spawn().unwrap();
+        unsafe { libc::close(w) };
+        let mut pfd = libc::pollfd {
+            fd: r,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let ready = unsafe { libc::poll(&raw mut pfd, 1, 1000) };
+        let _ = child.kill();
+        let _ = child.wait();
+        unsafe { libc::close(r) };
+        assert!(ready > 0, "reader never hung up: child inherited the fd");
+    }
+
+    #[test]
+    fn parse_command_table_classifies_kinds_and_ignores_noise() {
+        // Includes rc stdout noise (lines without the FLYT sentinel) that must
+        // be skipped, plus one entry of each kind.
+        let dump = "p10k instant prompt noise\n\
+            FLYT\talias\tgst\tgit status\n\
+            FLYT\tfunction\tmy_fn\n\
+            FLYT\tbuiltin\tprint\n\
+            FLYT\treserved\tif\n\
+            FLYT\tcommand\tgit\t/usr/bin/git\n\
+            more noise\n";
+        let table = parse_command_table(dump);
+
+        assert_eq!(
+            table.aliases.get("gst").map(String::as_str),
+            Some("git status")
+        );
+        assert!(table.functions.contains("my_fn"));
+        assert!(table.builtins.contains("print"));
+        assert!(table.reserved.contains("if"));
+        assert_eq!(
+            table.commands.get("git").map(String::as_str),
+            Some("/usr/bin/git")
+        );
+        // One CommandWordInfo per real entry; noise lines dropped.
+        assert_eq!(table.ordered.len(), 5);
+    }
+
+    #[test]
+    fn parse_command_table_skips_entries_without_a_name() {
+        let table = parse_command_table("FLYT\talias\t\nFLYT\tbuiltin\tvalid\n");
+        assert!(table.aliases.is_empty());
+        assert!(table.builtins.contains("valid"));
+        assert_eq!(table.ordered.len(), 1);
+    }
+
+    #[test]
+    fn command_table_cache_round_trips_and_expires() {
+        let dir = std::env::temp_dir().join(format!(
+            "flyline_cmdtable_test_{}_{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let path = dir.join("zsh-cmdtable");
+        let dump = "FLYT\talias\tgd\tgit diff\nFLYT\tcommand\tls\t/bin/ls\n";
+
+        // Missing cache -> None (caller must rebuild).
+        assert!(read_cached_dump(&path).is_none());
+
+        // Fresh write -> read returns identical content that parses correctly.
+        write_cached_dump(&path, dump);
+        let cached = read_cached_dump(&path).expect("fresh cache should be readable");
+        assert_eq!(cached, dump);
+        assert_eq!(
+            parse_command_table(&cached)
+                .aliases
+                .get("gd")
+                .map(String::as_str),
+            Some("git diff")
+        );
+
+        // Backdate past the TTL -> None (stale cache is rejected).
+        let old = SystemTime::now() - CMD_TABLE_TTL - Duration::from_secs(60);
+        let secs = old
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as libc::time_t;
+        let tv = libc::timeval {
+            tv_sec: secs,
+            tv_usec: 0,
+        };
+        let times = [tv, tv];
+        let c_path = std::ffi::CString::new(path.to_str().unwrap()).unwrap();
+        assert_eq!(unsafe { libc::utimes(c_path.as_ptr(), times.as_ptr()) }, 0);
+        assert!(
+            read_cached_dump(&path).is_none(),
+            "expired cache should be rejected"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pairs_to_completion_strings_formats_tab_descriptions() {
+        let pairs = vec![
+            ("a".to_string(), None),
+            ("b".to_string(), Some("desc".to_string())),
+        ];
+        assert_eq!(
+            pairs_to_completion_strings(&pairs),
+            vec!["a".to_string(), "b\tdesc".to_string()],
+        );
+    }
+
+    #[test]
+    fn zsh_env_var_reads_home() {
+        if !zsh_available() {
+            return;
+        }
+        let backend = &ZSH_BACKEND;
+        assert_eq!(backend.env_var("HOME"), std::env::var("HOME").ok());
+    }
+
+    #[test]
+    fn zsh_run_programmable_completions_git() {
+        if !zsh_available() {
+            return;
+        }
+        // ponytail: pty daemon can hang in CI/WSL; cap wait so `cargo test --lib` stays bounded.
+        let backend = &ZSH_BACKEND;
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = backend.run_programmable_completions("git ", "git", "", 4, 4);
+            let _ = tx.send(result);
+        });
+        let result = rx
+            .recv_timeout(std::time::Duration::from_secs(15))
+            .expect("git completion capture timed out after 15s")
+            .expect("git completion capture");
+        assert!(
+            !result.completions.is_empty(),
+            "expected git completions, got empty",
+        );
+        assert!(
+            result
+                .completions
+                .iter()
+                .any(|s| s.starts_with("add") || s.starts_with("checkout")),
+            "expected git subcommand in {:?}",
+            result.completions.iter().take(5).collect::<Vec<_>>(),
+        );
+    }
+
+    /// Serve two requests over the socket and confirm the second reuses the warm
+    /// daemon (no per-line reboot). Drives `run_comp_broker` directly.
+    #[test]
+    fn broker_serves_and_reuses_daemon() {
+        if !zsh_available() {
+            eprintln!("skipping broker round-trip: zsh not available");
+            return;
+        }
+        let sock = std::env::temp_dir().join(format!(
+            "flyline-test-broker-{}-{}.sock",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let broker_sock = sock.clone();
+        // Broker never returns during the test; it dies with the test process.
+        #[allow(clippy::disallowed_methods)]
+        std::thread::spawn(move || {
+            run_comp_broker(&broker_sock);
+        });
+
+        let cwd = std::env::temp_dir();
+        let cwd = cwd.to_str().unwrap();
+        let request = |buffer: &str| -> Option<Vec<(String, Option<String>)>> {
+            let deadline = Instant::now() + Duration::from_secs(20);
+            let mut stream = loop {
+                if let Ok(s) = UnixStream::connect(&sock) {
+                    break s;
+                }
+                if Instant::now() >= deadline {
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            };
+            stream.set_read_timeout(Some(BROKER_REQUEST_TIMEOUT)).ok()?;
+            stream
+                .write_all(format!("{cwd}\n{buffer}\n").as_bytes())
+                .ok()?;
+            stream.flush().ok()?;
+            let _ = stream.shutdown(std::net::Shutdown::Write);
+            let mut resp = String::new();
+            stream.read_to_string(&mut resp).ok()?;
+            resp.contains(FLYEND).then(|| parse_capture_output(&resp))
+        };
+
+        // First request boots the daemon (rc load) and returns git subcommands.
+        let first = request("git ").expect("broker should serve git completions");
+        assert!(
+            first.len() > 10,
+            "expected >10 git completions, got {}",
+            first.len()
+        );
+
+        // Second request must reuse the warm daemon: still correct, and fast.
+        let started = Instant::now();
+        let second = request("git ").expect("broker should serve a warm request");
+        assert!(second.len() > 10);
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "warm request took {:?} — daemon not reused?",
+            started.elapsed()
+        );
+
+        let _ = std::fs::remove_file(&sock);
+    }
+}

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -923,6 +923,21 @@ fn read_until_marker_timeout(
 
 // ponytail: libc openpty — plain pipes cannot drive ZLE `complete-word`; no extra crate.
 fn spawn_comp_daemon(script_path: &Path) -> anyhow::Result<CompDaemon> {
+    spawn_comp_daemon_with_env(script_path, &[])
+}
+
+/// Boot the headless completion daemon. `extra_env` is layered onto the child
+/// `zsh` (used by tests to point at a scratch rc); production callers pass `&[]`.
+///
+/// `FLYLINE_ZSH_DAEMON=1` is always set here — the single choke point every
+/// daemon (in-process and broker) flows through. `scripts/flyline.zsh` reads it
+/// to skip installing its interactive `line-init` editor hook, which the
+/// completion-only daemon never needs and which could otherwise re-enter the
+/// editor against the user's controlling tty.
+fn spawn_comp_daemon_with_env(
+    script_path: &Path,
+    extra_env: &[(&str, &str)],
+) -> anyhow::Result<CompDaemon> {
     use std::os::unix::io::FromRawFd;
 
     let mut master: libc::c_int = 0;
@@ -950,13 +965,16 @@ fn spawn_comp_daemon(script_path: &Path) -> anyhow::Result<CompDaemon> {
 
     // Load the user's rc by default (for their fpath completions); NO_RCS uses -f.
     let args: &[&str] = if no_rcs() { &["-f", "-i"] } else { &["-i"] };
-    let child = Command::new("zsh")
-        .args(args)
+    let mut cmd = Command::new("zsh");
+    cmd.args(args)
+        .env("FLYLINE_ZSH_DAEMON", "1")
         .stdin(Stdio::from(slave_in))
         .stdout(Stdio::from(slave_file))
-        .stderr(Stdio::null())
-        .spawn()
-        .context("spawn zsh completion daemon")?;
+        .stderr(Stdio::null());
+    for (key, value) in extra_env {
+        cmd.env(key, value);
+    }
+    let child = cmd.spawn().context("spawn zsh completion daemon")?;
 
     // Guard the child now so any early return (e.g. boot timeout) kills it.
     let daemon = CompDaemon {
@@ -1479,6 +1497,83 @@ mod tests {
                 .any(|s| s.starts_with("add") || s.starts_with("checkout")),
             "expected git subcommand in {:?}",
             result.completions.iter().take(5).collect::<Vec<_>>(),
+        );
+    }
+
+    /// When the daemon loads a user rc that sources
+    /// `scripts/flyline.zsh`, the `FLYLINE_ZSH_DAEMON` guard must stop the rc
+    /// from installing flyline's interactive editor hook inside the daemon. We
+    /// assert the effect directly — the `_flyline_edit` widget is absent — which
+    /// is deterministic and doesn't depend on the recursive editor's tty
+    /// behaviour. The daemon must still reach READY with the rc loaded.
+    ///
+    /// The rc writes two markers so a broken test can't pass silently: one
+    /// proves the rc was actually sourced (else ZDOTDIR wasn't honored and the
+    /// test is a no-op), the other is written only if `_flyline_edit` got
+    /// registered — i.e. the guard failed.
+    #[test]
+    fn daemon_rc_does_not_install_editor_hook() {
+        if !zsh_available() {
+            eprintln!("skipping flyline-rc daemon boot: zsh not available");
+            return;
+        }
+        // `-f` (no_rcs) skips the rc entirely, so the guard would never be
+        // exercised; this test only means something when the rc is loaded.
+        if no_rcs() {
+            eprintln!("skipping flyline-rc daemon boot: FLYLINE_ZSH_NO_RCS set");
+            return;
+        }
+
+        let zdotdir = std::env::temp_dir().join(format!(
+            "flyline-test-zdotdir-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&zdotdir).expect("create scratch ZDOTDIR");
+
+        let flyline_script = concat!(env!("CARGO_MANIFEST_DIR"), "/scripts/flyline.zsh");
+        let rc_marker = zdotdir.join("rc_sourced");
+        let hook_marker = zdotdir.join("editor_hook_installed");
+        let zshrc = zdotdir.join(".zshrc");
+        std::fs::write(
+            &zshrc,
+            format!(
+                "print -r -- sourced > {rc_marker:?}\n\
+                 source {flyline_script}\n\
+                 (( ${{+widgets[_flyline_edit]}} )) && print -r -- hooked > {hook_marker:?}\n",
+            ),
+        )
+        .expect("write scratch .zshrc");
+
+        let script_path = ZSH_BACKEND.daemon_script_path().to_path_buf();
+        let zdotdir_str = zdotdir.to_str().unwrap().to_string();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result =
+                spawn_comp_daemon_with_env(&script_path, &[("ZDOTDIR", zdotdir_str.as_str())])
+                    .map(|_daemon| ());
+            let _ = tx.send(result);
+        });
+
+        let booted = rx.recv_timeout(DAEMON_BOOT_TIMEOUT + Duration::from_secs(5));
+        let rc_was_sourced = rc_marker.exists();
+        let editor_hook_installed = hook_marker.exists();
+        let _ = std::fs::remove_dir_all(&zdotdir);
+
+        assert!(
+            rc_was_sourced,
+            "scratch rc was not sourced — ZDOTDIR not honored, test is a no-op",
+        );
+        booted
+            .expect("daemon boot did not resolve in time")
+            .expect("daemon should reach READY with a flyline-enabled rc");
+        assert!(
+            !editor_hook_installed,
+            "FLYLINE_ZSH_DAEMON guard failed: the daemon's rc installed the \
+             _flyline_edit line-init hook",
         );
     }
 

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -22,6 +22,9 @@ const FLYBEGIN: &str = "<<FLYBEGIN>>";
 const FLYEND: &str = "<<FLYEND>>";
 const FLYCD: &str = "<<FLYCD>>";
 const FLYRELOAD: &str = "<<FLYRELOAD>>";
+/// Marker whose payload is `$_comps[<cmd>]`: non-empty means a native completion
+/// function is registered for the command word (even if it produced no matches).
+const FLYCOMPDEF: &str = "<<FLYCOMPDEF>>";
 
 /// First line of a broker request that asks the daemon to (re)load a completion
 /// function instead of capturing completions. A real cwd never starts with this.
@@ -368,17 +371,21 @@ impl ZshBackend {
         Ok(())
     }
 
+    /// Capture completions plus whether a native completer is registered for the
+    /// command word (`has_completer`), used to keep flyline from offering to
+    /// synthesize a completion when one already exists but simply had nothing to
+    /// add (e.g. `kubectl get` with no reachable cluster).
     fn capture_completions(
         &self,
         full_command: &str,
         cursor_byte_pos: usize,
-    ) -> anyhow::Result<Vec<(String, Option<String>)>> {
+    ) -> anyhow::Result<(Vec<(String, Option<String>)>, bool)> {
         let buffer_at_cursor = full_command
             .get(..cursor_byte_pos.min(full_command.len()))
             .unwrap_or(full_command);
         // Fast path: the shared broker (daemon booted once, reused across prompts).
-        if let Some(pairs) = broker_capture(&self.cwd(), buffer_at_cursor) {
-            return Ok(pairs);
+        if let Some(blob) = broker_capture(&self.cwd(), buffer_at_cursor) {
+            return Ok((parse_capture_output(&blob), capture_has_completer(&blob)));
         }
         // Fail-open: per-process in-process daemon (original behaviour).
         self.ensure_comp_daemon()?;
@@ -387,7 +394,7 @@ impl ZshBackend {
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("completion daemon not initialized"))?;
         let output = daemon.capture(buffer_at_cursor)?;
-        Ok(parse_capture_output(&output))
+        Ok((parse_capture_output(&output), capture_has_completer(&output)))
     }
 }
 
@@ -556,12 +563,17 @@ impl ShellBackend for ZshBackend {
         cursor_byte_pos: usize,
         _word_under_cursor_byte_end: usize,
     ) -> anyhow::Result<ProgrammableCompleteReturn> {
-        let pairs = self.capture_completions(full_command, cursor_byte_pos)?;
+        let (pairs, has_completer) = self.capture_completions(full_command, cursor_byte_pos)?;
         let completions = pairs_to_completion_strings(&pairs);
         let mut flags = CompletionFlags::default();
         flags.quote_type = find_quote_type(word_under_cursor);
         flags.some_dont_end_in_equal_sign = completions.iter().any(|s| !s.ends_with('='));
-        let compspec_was_useful = !completions.is_empty();
+        // A registered completer that ran but produced nothing (e.g. `kubectl get`
+        // with no reachable cluster) still counts as "useful": flyline should fall
+        // silent like cobra/fig/carapace rather than offering to synthesize a
+        // completion (which can't know cluster state anyway). Only a command with
+        // no completer at all is treated as useless, which triggers the flycomp prompt.
+        let compspec_was_useful = !completions.is_empty() || has_completer;
         Ok(ProgrammableCompleteReturn::new(
             completions,
             flags,
@@ -770,6 +782,10 @@ pub fn parse_capture_output(blob: &str) -> Vec<(String, Option<String>)> {
         if line.contains(FLYEND) {
             break;
         }
+        // The completer-registration marker is metadata, not a completion value.
+        if line.contains(FLYCOMPDEF) {
+            continue;
+        }
         if inside && !line.is_empty() {
             let (value, desc) = parse_capture_line(line);
             match seen.get(&value) {
@@ -789,6 +805,18 @@ pub fn parse_capture_output(blob: &str) -> Vec<(String, Option<String>)> {
         }
     }
     out
+}
+
+/// Whether the daemon reported a native completion function for the command word
+/// (the `<<FLYCOMPDEF>>` marker carries `$_comps[cmd]`; a non-empty payload means
+/// a completer is registered). Lets the backend distinguish "a completer ran but
+/// had nothing to add" (stay silent) from "no completer exists" (offer flycomp).
+pub fn capture_has_completer(blob: &str) -> bool {
+    blob.lines().any(|line| {
+        line.trim_end_matches('\r')
+            .strip_prefix(FLYCOMPDEF)
+            .is_some_and(|rest| !rest.trim().is_empty())
+    })
 }
 
 /// Parse one compadd-capture line (`value` or `value -- description`).
@@ -921,26 +949,56 @@ fn spawn_comp_daemon(script_path: &Path) -> anyhow::Result<CompDaemon> {
 // rc-loaded boot per prompt. Strictly fail-open — any failure falls back to the
 // in-process daemon, so the broker can never wedge the shell.
 
-/// Per-rc broker socket, keyed by ~/.zshrc mtime + no-rcs so an rc edit routes to
-/// a fresh daemon. `$XDG_RUNTIME_DIR` preferred, else the temp dir.
+/// Binary identity for the broker key: the running executable's mtime + size.
+/// Any rebuild, upgrade, or reinstall rewrites the file, so this changes and
+/// clients route to a fresh broker (the previous one idles out) — no manual
+/// restart needed. `current_exe` resolves symlinks, so this works for the dev
+/// `~/.local/lib -> target/...` symlink, `cargo install`, and package-manager
+/// installs alike (not just local/standalone layouts). Size is folded in so
+/// version bumps are still distinguished under reproducible builds that pin
+/// mtime. Falls back to "0" (version-agnostic) if the path is unreadable.
+fn binary_version_key() -> String {
+    std::env::current_exe()
+        .and_then(std::fs::metadata)
+        .map(|m| {
+            let mtime = m
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            format!("{mtime}.{}", m.len())
+        })
+        .unwrap_or_else(|_| "0".to_string())
+}
+
+/// Broker socket filename, keyed by ~/.zshrc mtime, binary identity, and no-rcs
+/// so an rc edit *or* a new binary routes to a fresh daemon.
+fn broker_socket_name(rc_key: u64, bin_key: &str, norc: u8) -> String {
+    format!("zcompd-{rc_key}-{bin_key}-{norc}.sock")
+}
+
+/// Per-rc, per-binary broker socket. `$XDG_RUNTIME_DIR` preferred, else temp dir.
 fn broker_socket_path() -> Option<PathBuf> {
     let base = std::env::var_os("XDG_RUNTIME_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(std::env::temp_dir);
     let dir = base.join("flyline");
     let _ = std::fs::create_dir_all(&dir);
-    let key = zshrc_mtime()
+    let rc_key = zshrc_mtime()
         .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
         .map(|d| d.as_secs())
         .unwrap_or(0);
     let norc = u8::from(no_rcs());
-    Some(dir.join(format!("zcompd-{key}-{norc}.sock")))
+    Some(dir.join(broker_socket_name(rc_key, &binary_version_key(), norc)))
 }
 
-/// Complete `buffer_at_cursor` in `cwd` via the broker. `None` (→ in-process
-/// fallback) when disabled, unreachable, or the reply is malformed; a valid empty
-/// result is `Some(vec![])` so we don't redundantly re-capture in-process.
-fn broker_capture(cwd: &str, buffer_at_cursor: &str) -> Option<Vec<(String, Option<String>)>> {
+/// Capture `buffer_at_cursor` in `cwd` via the broker, returning the raw daemon
+/// blob (parsed by the caller so it can also read the `<<FLYCOMPDEF>>` marker).
+/// `None` (→ in-process fallback) when disabled, unreachable, or the reply is
+/// malformed; a valid empty capture still returns `Some(blob)` so we don't
+/// redundantly re-capture in-process.
+fn broker_capture(cwd: &str, buffer_at_cursor: &str) -> Option<String> {
     // Under `cargo test` current_exe() is the harness, so a spawn would re-exec
     // the whole suite. Tests drive `run_comp_broker` directly.
     if cfg!(test) {
@@ -953,7 +1011,7 @@ fn broker_capture(cwd: &str, buffer_at_cursor: &str) -> Option<Vec<(String, Opti
         return None;
     }
     match broker_request(cwd, buffer_at_cursor) {
-        Some(blob) if blob.contains(FLYEND) => Some(parse_capture_output(&blob)),
+        Some(blob) if blob.contains(FLYEND) => Some(blob),
         _ => {
             BROKER_UNAVAILABLE.store(true, Ordering::Relaxed);
             None
@@ -1470,6 +1528,65 @@ mod tests {
     }
 
     #[test]
+    fn broker_socket_name_varies_with_rc_and_binary() {
+        assert_eq!(
+            broker_socket_name(100, "200.4096", 0),
+            "zcompd-100-200.4096-0.sock"
+        );
+        // A rebuild/upgrade (new binary mtime) routes clients to a fresh broker.
+        assert_ne!(
+            broker_socket_name(100, "200.4096", 0),
+            broker_socket_name(100, "201.4096", 0)
+        );
+        // A size change alone (e.g. reproducible build, same pinned mtime) too.
+        assert_ne!(
+            broker_socket_name(100, "200.4096", 0),
+            broker_socket_name(100, "200.8192", 0)
+        );
+        // An rc edit does too, as before.
+        assert_ne!(
+            broker_socket_name(100, "200.4096", 0),
+            broker_socket_name(101, "200.4096", 0)
+        );
+        // no-rcs remains part of the key.
+        assert_ne!(
+            broker_socket_name(100, "200.4096", 0),
+            broker_socket_name(100, "200.4096", 1)
+        );
+    }
+
+    #[test]
+    fn binary_version_key_is_stable() {
+        // Must not flap within a process, or clients and broker would disagree.
+        assert_eq!(binary_version_key(), binary_version_key());
+        // mtime.size shape (or the "0" fallback for an unreadable path).
+        let key = binary_version_key();
+        assert!(
+            key == "0" || key.split('.').count() == 2,
+            "unexpected binary key shape: {key}"
+        );
+    }
+
+    #[test]
+    fn capture_has_completer_detects_registration() {
+        let registered = "<<FLYBEGIN>>\nget -- Display\n<<FLYCOMPDEF>>_kubectl\n<<FLYEND>>\n";
+        assert!(capture_has_completer(registered));
+        let empty_payload = "<<FLYBEGIN>>\n<<FLYCOMPDEF>>\n<<FLYEND>>\n";
+        assert!(!capture_has_completer(empty_payload));
+        let no_marker = "<<FLYBEGIN>>\nfoo\n<<FLYEND>>\n";
+        assert!(!capture_has_completer(no_marker));
+    }
+
+    #[test]
+    fn parse_capture_output_ignores_compdef_marker() {
+        let blob = "<<FLYBEGIN>>\nget -- Display a resource\n<<FLYCOMPDEF>>_kubectl\n<<FLYEND>>\n";
+        assert_eq!(
+            parse_capture_output(blob),
+            vec![("get".to_string(), Some("Display a resource".to_string()))],
+        );
+    }
+
+    #[test]
     fn zsh_backend_synthesizes_zsh_completions() {
         assert!(matches!(
             ZSH_BACKEND.flycomp_output_format(),
@@ -1578,6 +1695,26 @@ mod tests {
         assert!(
             values.contains(&"alpha") && values.contains(&"beta"),
             "expected synthesized subcommands, got {values:?}"
+        );
+        assert!(
+            capture_has_completer(&resp),
+            "registered _flytest should be reported as a completer, got: {resp:?}"
+        );
+
+        // A command with no registered completer must not report one — that's the
+        // signal that keeps flyline from offering flycomp only when nothing exists.
+        let mut stream = connect().expect("connect for unknown-cmd capture");
+        stream.set_read_timeout(Some(BROKER_REQUEST_TIMEOUT)).unwrap();
+        stream
+            .write_all(format!("{}\nzzznosuchcmd_flytest \n", cwd.display()).as_bytes())
+            .unwrap();
+        stream.flush().unwrap();
+        let _ = stream.shutdown(std::net::Shutdown::Write);
+        let mut resp2 = String::new();
+        stream.read_to_string(&mut resp2).unwrap();
+        assert!(
+            !capture_has_completer(&resp2),
+            "unregistered command should not report a completer, got: {resp2:?}"
         );
 
         let _ = std::fs::remove_file(&sock);

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -394,7 +394,10 @@ impl ZshBackend {
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("completion daemon not initialized"))?;
         let output = daemon.capture(buffer_at_cursor)?;
-        Ok((parse_capture_output(&output), capture_has_completer(&output)))
+        Ok((
+            parse_capture_output(&output),
+            capture_has_completer(&output),
+        ))
     }
 }
 
@@ -706,6 +709,39 @@ impl ShellBackend for ZshBackend {
 
     fn shell_pgrp(&self) -> libc::pid_t {
         unsafe { libc::getpgrp() }
+    }
+
+    /// This host spawns a fresh process per prompt, so settings changed via
+    /// `flyline <subcommand>` are persisted to a config file rather than kept in
+    /// a live builtin. Uses `$XDG_CONFIG_HOME/flyline/settings.json`, falling back
+    /// to `~/.config/flyline/settings.json`.
+    fn persisted_settings_path(&self) -> Option<std::path::PathBuf> {
+        let base = std::env::var_os("XDG_CONFIG_HOME")
+            .filter(|v| !v.is_empty())
+            .map(std::path::PathBuf::from)
+            .or_else(|| {
+                std::env::var_os("HOME").map(|h| std::path::PathBuf::from(h).join(".config"))
+            })?;
+        Some(base.join("flyline").join("settings.json"))
+    }
+
+    /// Transient tutorial state is scoped to the terminal session so it never
+    /// leaks into other terminals or outlives this one, matching how the Bash
+    /// builtin keeps it live in its per-terminal process. The session is keyed
+    /// by the POSIX session id (stable across this terminal's per-prompt
+    /// processes, distinct per terminal window). Stored under
+    /// `$XDG_RUNTIME_DIR/flyline/` (falling back to the system temp dir).
+    fn session_state_path(&self) -> Option<std::path::PathBuf> {
+        // SAFETY: getsid is a simple, thread-safe syscall with no preconditions.
+        let sid = unsafe { libc::getsid(0) };
+        if sid <= 0 {
+            return None;
+        }
+        let base = std::env::var_os("XDG_RUNTIME_DIR")
+            .filter(|v| !v.is_empty())
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir);
+        Some(base.join("flyline").join(format!("session-{sid}.json")))
     }
 }
 
@@ -1704,7 +1740,9 @@ mod tests {
         // A command with no registered completer must not report one — that's the
         // signal that keeps flyline from offering flycomp only when nothing exists.
         let mut stream = connect().expect("connect for unknown-cmd capture");
-        stream.set_read_timeout(Some(BROKER_REQUEST_TIMEOUT)).unwrap();
+        stream
+            .set_read_timeout(Some(BROKER_REQUEST_TIMEOUT))
+            .unwrap();
         stream
             .write_all(format!("{}\nzzznosuchcmd_flytest \n", cwd.display()).as_bytes())
             .unwrap();

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -21,6 +21,15 @@ const READY_MARKER: &str = "READY";
 const FLYBEGIN: &str = "<<FLYBEGIN>>";
 const FLYEND: &str = "<<FLYEND>>";
 const FLYCD: &str = "<<FLYCD>>";
+const FLYRELOAD: &str = "<<FLYRELOAD>>";
+
+/// First line of a broker request that asks the daemon to (re)load a completion
+/// function instead of capturing completions. A real cwd never starts with this.
+const RELOAD_SENTINEL: &str = "\x01RELOAD";
+
+/// Default dir for flyline-synthesized zsh completions. Must stay in sync with
+/// the `fpath` prepend in `zsh_comp_daemon.zsh` so the `_<cmd>` files are found.
+const ZSH_COMPLETIONS_DIR: &str = "~/.local/share/flyline/zsh/completions/";
 
 /// Read caps so a bad rc/completion can't hang flyline (fail-open on timeout).
 const DAEMON_BOOT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -251,6 +260,24 @@ fn run_zsh_timeout(args: &[&str], timeout: Duration) -> Option<String> {
             }
             Err(_) => return None,
         }
+    }
+}
+
+/// The on-disk name for a synthesized zsh completion of `cmd_word`.
+///
+/// zsh autoloadable completion functions must be named `_<cmd>` and live on
+/// `$fpath` (the daemon prepends `ZSH_COMPLETIONS_DIR`); bash's `<cmd>` name in
+/// the bash-completion dir would never be picked up here. A path-like command
+/// word (alias expansion, absolute path) is reduced to its file name first.
+fn zsh_completion_file_name(cmd_word: &str) -> String {
+    let base = Path::new(cmd_word)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or(cmd_word);
+    if base.starts_with('_') {
+        base.to_string()
+    } else {
+        format!("_{base}")
     }
 }
 
@@ -555,6 +582,53 @@ impl ShellBackend for ZshBackend {
         }
     }
 
+    fn flycomp_output_format(&self) -> flycomp::OutputFormat {
+        // zsh consumes native `#compdef` functions, not bash `complete -F` scripts.
+        flycomp::OutputFormat::Zsh
+    }
+
+    fn activate_completion_script(
+        &self,
+        command_word: &str,
+        _script: &str,
+        flycomp_output: Option<&str>,
+    ) -> anyhow::Result<()> {
+        // The script is already on disk (resolve_and_write_completion_script ran);
+        // load that `_<cmd>` file into the completion daemon so the immediate Tab
+        // re-run uses it, mirroring bash's in-process eval.
+        let path = self.resolve_completion_script_path(command_word, flycomp_output);
+        let path_str = path.to_string_lossy().into_owned();
+        if path_str.contains('\n') {
+            anyhow::bail!("completion script path must not contain newlines");
+        }
+
+        let mut activated = false;
+        // Shared broker first, so every session picks up the new completion.
+        if !broker_disabled() && broker_reload(&path_str) {
+            activated = true;
+        }
+        // Also reload this process's in-process daemon if it exists (broker-disabled
+        // path, or broker unreachable), so the local capture below sees it.
+        if let Ok(mut guard) = self.comp_daemon.lock() {
+            if let Some(daemon) = guard.as_mut() {
+                if daemon.reload(&path_str).is_ok() {
+                    activated = true;
+                }
+            }
+        }
+        if activated {
+            return Ok(());
+        }
+        // Fail-open: boot an in-process daemon and reload there.
+        self.ensure_comp_daemon()?;
+        let mut guard = self.comp_daemon.lock().unwrap();
+        let daemon = guard
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("completion daemon not initialized"))?;
+        daemon.reload(&path_str)?;
+        Ok(())
+    }
+
     fn reset_caches(&self) {}
 
     fn warm_completion_caches(&self) {
@@ -582,11 +656,8 @@ impl ShellBackend for ZshBackend {
             .filter(|alias| !alias.is_empty())
             .unwrap_or(command_word);
         let cmd_word = alias_def.split_whitespace().next().unwrap_or(alias_def);
-        let file_name = Path::new(cmd_word)
-            .file_name()
-            .and_then(|f| f.to_str())
-            .unwrap_or(cmd_word);
-        let output_dir = flycomp_output.unwrap_or("~/.local/share/bash-completion/completions/");
+        let file_name = zsh_completion_file_name(cmd_word);
+        let output_dir = flycomp_output.unwrap_or(ZSH_COMPLETIONS_DIR);
         Path::new(&self.expand_path(output_dir)).join(file_name)
     }
 
@@ -658,6 +729,28 @@ impl CompDaemon {
             .write_all(b"\x15")
             .context("reset daemon line")?;
         self.master.flush().context("flush after reset")?;
+        Ok(output)
+    }
+
+    /// Load the `_<cmd>` completion function at `path` into the running daemon so
+    /// subsequent captures use it. Types the path then fires the `fly-reload`
+    /// widget (^G) which autoloads + `compdef`s it (see zsh_comp_daemon.zsh).
+    fn reload(&mut self, path: &str) -> anyhow::Result<String> {
+        if path.contains('\n') {
+            anyhow::bail!("reload path must not contain newlines");
+        }
+        self.master
+            .write_all(path.as_bytes())
+            .context("write reload path")?;
+        // ^G -> fly-reload widget: register the completion + clear buffer.
+        self.master.write_all(b"\x07").context("write ^G")?;
+        self.master.flush().context("flush reload path")?;
+        let output = read_until_marker_timeout(&self.master, FLYRELOAD, CAPTURE_TIMEOUT)?;
+        // Clear the line in case the widget left anything behind (Ctrl-U).
+        self.master
+            .write_all(b"\x15")
+            .context("reset daemon line")?;
+        self.master.flush().context("flush after reload")?;
         Ok(output)
     }
 }
@@ -885,6 +978,44 @@ fn broker_request(cwd: &str, buffer_at_cursor: &str) -> Option<String> {
     Some(resp)
 }
 
+/// Ask the broker (spawning it if needed) to (re)load the completion function at
+/// `script_path`. Returns true when the daemon acknowledged with the reload
+/// marker. Fail-open: any error returns false so activation falls back locally.
+fn broker_reload(script_path: &str) -> bool {
+    // Under `cargo test` current_exe() is the harness; never spawn a broker.
+    if cfg!(test) {
+        return false;
+    }
+    let Some(path) = broker_socket_path() else {
+        return false;
+    };
+    let Some(mut stream) = connect_or_spawn_broker(&path) else {
+        return false;
+    };
+    if stream
+        .set_read_timeout(Some(BROKER_REQUEST_TIMEOUT))
+        .is_err()
+        || stream
+            .set_write_timeout(Some(BROKER_REQUEST_TIMEOUT))
+            .is_err()
+    {
+        return false;
+    }
+    let req = format!("{RELOAD_SENTINEL}\n{script_path}\n");
+    if stream.write_all(req.as_bytes()).is_err() {
+        return false;
+    }
+    if stream.flush().is_err() {
+        return false;
+    }
+    let _ = stream.shutdown(std::net::Shutdown::Write);
+    let mut resp = String::new();
+    if stream.read_to_string(&mut resp).is_err() {
+        return false;
+    }
+    resp.contains(FLYRELOAD)
+}
+
 /// Connect to the broker, spawning a detached one and polling for its socket if
 /// none is listening yet.
 fn connect_or_spawn_broker(path: &Path) -> Option<UnixStream> {
@@ -963,29 +1094,50 @@ pub fn run_comp_broker(socket_path: &Path) -> i32 {
         if let Ok(mut act) = last_activity.lock() {
             *act = Instant::now();
         }
-        if let Some((cwd, buffer)) = read_broker_request(&stream) {
-            let blob = daemon.cd_and_capture(&cwd, &buffer).unwrap_or_default();
-            let _ = stream.write_all(blob.as_bytes());
+        match read_broker_request(&stream) {
+            Some(BrokerRequest::Capture { cwd, buffer }) => {
+                let blob = daemon.cd_and_capture(&cwd, &buffer).unwrap_or_default();
+                let _ = stream.write_all(blob.as_bytes());
+            }
+            Some(BrokerRequest::Reload { path }) => {
+                let blob = daemon.reload(&path).unwrap_or_default();
+                let _ = stream.write_all(blob.as_bytes());
+            }
+            None => {}
         }
         // Dropping the stream closes it: EOF frames the response for the client.
     }
     0
 }
 
-/// Read a `<cwd>\n<buffer>\n` request. A missing second line yields an empty
-/// buffer (harmless empty completion).
-fn read_broker_request(stream: &UnixStream) -> Option<(String, String)> {
+/// A request served by the broker: capture completions, or (re)load a
+/// synthesized completion function into the daemon.
+enum BrokerRequest {
+    Capture { cwd: String, buffer: String },
+    Reload { path: String },
+}
+
+/// Read a broker request. A capture request is `<cwd>\n<buffer>\n`; a reload
+/// request is `<RELOAD_SENTINEL>\n<path>\n`. A missing second line yields an
+/// empty tail (harmless empty completion / no-op reload).
+fn read_broker_request(stream: &UnixStream) -> Option<BrokerRequest> {
     let clone = stream.try_clone().ok()?;
     let _ = clone.set_read_timeout(Some(BROKER_REQUEST_TIMEOUT));
     let mut reader = BufReader::new(clone);
-    let mut cwd = String::new();
-    let mut buffer = String::new();
-    reader.read_line(&mut cwd).ok()?;
-    reader.read_line(&mut buffer).ok()?;
-    Some((
-        cwd.trim_end_matches('\n').to_string(),
-        buffer.trim_end_matches('\n').to_string(),
-    ))
+    let mut first = String::new();
+    reader.read_line(&mut first).ok()?;
+    let first = first.trim_end_matches('\n').to_string();
+    let mut second = String::new();
+    reader.read_line(&mut second).ok()?;
+    let second = second.trim_end_matches('\n').to_string();
+    if first == RELOAD_SENTINEL {
+        Some(BrokerRequest::Reload { path: second })
+    } else {
+        Some(BrokerRequest::Capture {
+            cwd: first,
+            buffer: second,
+        })
+    }
 }
 
 /// Exit the broker process once it has been idle past `BROKER_IDLE_TIMEOUT`.
@@ -1302,5 +1454,133 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(&sock);
+    }
+
+    #[test]
+    fn zsh_completion_file_name_prefixes_underscore() {
+        assert_eq!(zsh_completion_file_name("kubectl"), "_kubectl");
+        // Path-like command words are reduced to their file name.
+        assert_eq!(
+            zsh_completion_file_name("/opt/homebrew/bin/kubectl"),
+            "_kubectl"
+        );
+        assert_eq!(zsh_completion_file_name("~/bin/foo"), "_foo");
+        // An already-underscored name is not doubled.
+        assert_eq!(zsh_completion_file_name("_kubectl"), "_kubectl");
+    }
+
+    #[test]
+    fn zsh_backend_synthesizes_zsh_completions() {
+        assert!(matches!(
+            ZSH_BACKEND.flycomp_output_format(),
+            flycomp::OutputFormat::Zsh
+        ));
+    }
+
+    #[test]
+    fn bash_backend_synthesizes_bash_completions() {
+        assert!(matches!(
+            crate::shell::BashBackend.flycomp_output_format(),
+            flycomp::OutputFormat::Bash
+        ));
+    }
+
+    /// End-to-end: a `_<cmd>` file written outside the daemon's default fpath is
+    /// registered via the broker reload verb (the `fly-reload` widget adds its dir
+    /// to fpath + `compdef`s it), then the next capture returns its completions.
+    #[test]
+    fn broker_reload_registers_synthesized_completion() {
+        if !zsh_available() {
+            eprintln!("skipping broker reload: zsh not available");
+            return;
+        }
+        let stamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let comp_dir =
+            std::env::temp_dir().join(format!("flyline-comp-{}-{}", std::process::id(), stamp));
+        std::fs::create_dir_all(&comp_dir).unwrap();
+        let comp_file = comp_dir.join("_flytest");
+        // Autoload-compatible compdef offering static subcommands (no binary call).
+        std::fs::write(
+            &comp_file,
+            "#compdef flytest\n\
+             _flytest() {\n\
+               local -a subcmds\n\
+               subcmds=(alpha beta gamma)\n\
+               _describe 'command' subcmds\n\
+             }\n\
+             if [ \"$funcstack[1]\" = \"_flytest\" ]; then\n\
+               _flytest \"$@\"\n\
+             else\n\
+               compdef _flytest flytest\n\
+             fi\n",
+        )
+        .unwrap();
+
+        let sock = std::env::temp_dir().join(format!(
+            "flyline-test-reload-{}-{}.sock",
+            std::process::id(),
+            stamp
+        ));
+        let broker_sock = sock.clone();
+        #[allow(clippy::disallowed_methods)]
+        std::thread::spawn(move || {
+            run_comp_broker(&broker_sock);
+        });
+
+        let connect = || -> Option<UnixStream> {
+            let deadline = Instant::now() + Duration::from_secs(20);
+            loop {
+                if let Ok(s) = UnixStream::connect(&sock) {
+                    return Some(s);
+                }
+                if Instant::now() >= deadline {
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        };
+
+        // Reload request.
+        let mut stream = connect().expect("connect for reload");
+        stream
+            .set_read_timeout(Some(BROKER_REQUEST_TIMEOUT))
+            .unwrap();
+        stream
+            .write_all(format!("{RELOAD_SENTINEL}\n{}\n", comp_file.display()).as_bytes())
+            .unwrap();
+        stream.flush().unwrap();
+        let _ = stream.shutdown(std::net::Shutdown::Write);
+        let mut resp = String::new();
+        stream.read_to_string(&mut resp).unwrap();
+        assert!(
+            resp.contains(FLYRELOAD),
+            "reload not acknowledged, got: {resp:?}"
+        );
+
+        // Capture request now sees the freshly registered completion.
+        let mut stream = connect().expect("connect for capture");
+        stream
+            .set_read_timeout(Some(BROKER_REQUEST_TIMEOUT))
+            .unwrap();
+        let cwd = std::env::temp_dir();
+        stream
+            .write_all(format!("{}\nflytest \n", cwd.display()).as_bytes())
+            .unwrap();
+        stream.flush().unwrap();
+        let _ = stream.shutdown(std::net::Shutdown::Write);
+        let mut resp = String::new();
+        stream.read_to_string(&mut resp).unwrap();
+        let hits = parse_capture_output(&resp);
+        let values: Vec<&str> = hits.iter().map(|(v, _)| v.as_str()).collect();
+        assert!(
+            values.contains(&"alpha") && values.contains(&"beta"),
+            "expected synthesized subcommands, got {values:?}"
+        );
+
+        let _ = std::fs::remove_file(&sock);
+        let _ = std::fs::remove_dir_all(&comp_dir);
     }
 }

--- a/src/shell/zsh_comp_daemon.zsh
+++ b/src/shell/zsh_comp_daemon.zsh
@@ -1,0 +1,58 @@
+#!/bin/zsh
+# Headless completion daemon for flyline, sourced after the user's rc. Rust drives
+# it by writing "buffer<TAB>" to the pty and reads back the compadd-captured hits.
+
+# No `emulate -L zsh`: at top level that would clobber the user's completion setup.
+PROMPT=
+RPROMPT=
+# Idempotent compinit (-C skips the security check); required under NO_RCS.
+autoload -Uz compinit
+(( $+functions[compinit] )) && compinit -C -d "${ZDOTDIR:-$HOME}/.zcompdump_flyline"
+
+bindkey '^M' undefined
+bindkey '^J' undefined
+bindkey '^I' complete-word
+
+# Broker cwd change: caller types a path then sends ^F. Only cds — command
+# execution stays disabled (^M/^J are `undefined`) — so completions match the dir.
+fly-cd () { builtin cd -q -- "$BUFFER" 2>/dev/null; BUFFER=''; print -r -- '<<FLYCD>>' }
+zle -N fly-cd
+bindkey '^F' fly-cd
+
+fly-begin () { compprefuncs=( fly-begin ); print -r -- '<<FLYBEGIN>>' }
+fly-end   () { comppostfuncs=( fly-end ); print -r -- '<<FLYEND>>' }
+compprefuncs=( fly-begin )
+comppostfuncs=( fly-end )
+
+zstyle ':completion:*' list-grouped false
+zstyle ':completion:*' insert-tab false
+zstyle ':completion:*' list-separator ''
+
+zmodload zsh/zutil
+compadd () {
+  if [[ ${@[1,(i)(-|--)]} == *-(O|A|D)\ * ]]; then
+    builtin compadd "$@"
+    return $?
+  fi
+  typeset -a __hits __dscr __tmp
+  if (( $@[(I)-d] )); then
+    __tmp=${@[$[${@[(i)-d]}+1]]}
+    if [[ $__tmp == \(* ]]; then
+      eval "__dscr=$__tmp"
+    else
+      __dscr=( "${(@P)__tmp}" )
+    fi
+  fi
+  builtin compadd -A __hits -D __dscr "$@"
+  setopt localoptions norcexpandparam extendedglob
+  typeset -A apre hpre hsuf asuf
+  zparseopts -E P:=apre p:=hpre S:=asuf s:=hsuf
+  [[ -n $__hits ]] || return
+  local dscr
+  for i in {1..$#__hits}; do
+    (( $#__dscr >= $i )) && dscr=" -- ${${__dscr[$i]}##$__hits[$i] #}" || dscr=
+    echo -E - $IPREFIX$apre$hpre$__hits[$i]$hsuf$asuf$dscr
+  done
+}
+
+print -r -- READY

--- a/src/shell/zsh_comp_daemon.zsh
+++ b/src/shell/zsh_comp_daemon.zsh
@@ -67,7 +67,16 @@ zle -N fly-reload
 bindkey '^G' fly-reload
 
 fly-begin () { compprefuncs=( fly-begin ); print -r -- '<<FLYBEGIN>>' }
-fly-end   () { comppostfuncs=( fly-end ); print -r -- '<<FLYEND>>' }
+# fly-end reports whether a completion function is registered for the command
+# word ($_comps[cmd]) so Rust can tell "a completer ran but had nothing to add"
+# (e.g. `kubectl get` with no cluster -> stay silent) apart from "no completer
+# exists" (-> offer to synthesize one). Empty payload means no completer.
+fly-end () {
+  comppostfuncs=( fly-end )
+  local -a __fly_words; __fly_words=( ${(z)BUFFER} )
+  print -r -- "<<FLYCOMPDEF>>${_comps[${__fly_words[1]}]}"
+  print -r -- '<<FLYEND>>'
+}
 compprefuncs=( fly-begin )
 comppostfuncs=( fly-end )
 

--- a/src/shell/zsh_comp_daemon.zsh
+++ b/src/shell/zsh_comp_daemon.zsh
@@ -5,9 +5,37 @@
 # No `emulate -L zsh`: at top level that would clobber the user's completion setup.
 PROMPT=
 RPROMPT=
-# Idempotent compinit (-C skips the security check); required under NO_RCS.
+
+# flyline's own synthesized completions (see ZSH_COMPLETIONS_DIR / the fly-reload
+# widget below and resolve_completion_script_path in zsh.rs); keep this path in
+# sync. Prepended so autoloadable `_<cmd>` functions written here are discovered.
+fpath=( "${HOME}/.local/share/flyline/zsh/completions" $fpath )
+
+# Idempotent compinit. The fast `-C` path skips the security check *and* the
+# rescan of $fpath for new functions, reusing the cached dump. That means a
+# completion installed after the dump was built (e.g. a freshly `brew install`ed
+# `_kubectl`) stays invisible, which makes flyline needlessly offer to synthesize
+# one. So rebuild the dump (`-i` skips the interactive insecure-dir prompt that
+# would otherwise hang the headless daemon) whenever any $fpath dir is newer than
+# the dump; otherwise keep the fast cached path.
 autoload -Uz compinit
-(( $+functions[compinit] )) && compinit -C -d "${ZDOTDIR:-$HOME}/.zcompdump_flyline"
+if (( $+functions[compinit] )); then
+  _fly_dump="${ZDOTDIR:-$HOME}/.zcompdump_flyline"
+  _fly_stale=""
+  if [[ ! -e $_fly_dump ]]; then
+    _fly_stale=1
+  else
+    for _fly_d in $fpath; do
+      [[ -d $_fly_d && $_fly_d -nt $_fly_dump ]] && { _fly_stale=1; break; }
+    done
+  fi
+  if [[ -n $_fly_stale ]]; then
+    compinit -i -d "$_fly_dump"
+  else
+    compinit -C -d "$_fly_dump"
+  fi
+  unset _fly_dump _fly_stale _fly_d
+fi
 
 bindkey '^M' undefined
 bindkey '^J' undefined
@@ -18,6 +46,25 @@ bindkey '^I' complete-word
 fly-cd () { builtin cd -q -- "$BUFFER" 2>/dev/null; BUFFER=''; print -r -- '<<FLYCD>>' }
 zle -N fly-cd
 bindkey '^F' fly-cd
+
+# Register a flyline-synthesized completion: caller types the `_<cmd>` file path
+# then sends ^G. We add its dir to $fpath (covers a custom flycomp_output dir),
+# then autoload + `compdef` it so the very next capture uses it — no rebuild,
+# mirroring bash's in-process eval of the synthesized script.
+fly-reload () {
+  local f=$BUFFER c d
+  BUFFER=''
+  d=${f:h}; c=${${f:t}#_}
+  if [[ -n $c ]]; then
+    [[ -n $d && -d $d ]] && fpath=( $d $fpath )
+    unfunction "_$c" 2>/dev/null
+    autoload -Uz -- "_$c" 2>/dev/null
+    compdef "_$c" "$c" 2>/dev/null
+  fi
+  print -r -- '<<FLYRELOAD>>'
+}
+zle -N fly-reload
+bindkey '^G' fly-reload
 
 fly-begin () { compprefuncs=( fly-begin ); print -r -- '<<FLYBEGIN>>' }
 fly-end   () { comppostfuncs=( fly-end ); print -r -- '<<FLYEND>>' }

--- a/src/shell_integration.rs
+++ b/src/shell_integration.rs
@@ -5,10 +5,8 @@ use crossterm::QueueableCommand;
 use crossterm::cursor::{MoveTo, RestorePosition, SavePosition};
 use ratatui::prelude::Position;
 
-use crate::{bash_funcs, bash_symbols};
-
 static IS_VSCODE: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
-    bash_funcs::get_envvar_value("TERM_PROGRAM").as_deref() == Some("vscode")
+    crate::shell::backend().env_var("TERM_PROGRAM").as_deref() == Some("vscode")
 });
 
 /// https://code.visualstudio.com/docs/terminal/shell-integration#_supported-escape-sequences
@@ -124,7 +122,7 @@ impl EscapeCodes {
 
 impl Command for EscapeCodes {
     fn write_ansi(&self, f: &mut impl core::fmt::Write) -> core::fmt::Result {
-        let bash_pid = unsafe { bash_symbols::shell_pgrp };
+        let bash_pid = crate::shell::backend().shell_pgrp();
 
         match self {
             // OSC 7
@@ -276,7 +274,7 @@ pub fn write_after_rendering_codes(
 
 pub fn write_on_exit_codes(commandline: Option<&str>) -> std::io::Result<()> {
     let codes: Vec<EscapeCodes> = if is_vscode() {
-        let nonce = bash_funcs::get_envvar_value("VSCODE_NONCE");
+        let nonce = crate::shell::backend().env_var("VSCODE_NONCE");
         log::info!("vscode_nonce: {:?}", nonce);
         match commandline {
             Some(cmd) => vec![

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -130,6 +130,9 @@ where
 }
 
 pub(crate) fn join_bash_func_threads() {
+    if !crate::shell::backend().is_bash() {
+        return;
+    }
     let mut to_join = Vec::new();
     if let Ok(mut guard) = BACKGROUND_THREADS.lock() {
         let mut i = 0;

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -7,8 +7,9 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use crate::content_builder::{ClipboardTypes, Tag, TaggedLine, TaggedSpan};
 use crate::content_utils;
 use crate::palette::Palette;
+use crate::settings;
+use crate::shell::backend;
 use crate::shell_integration;
-use crate::{bash_funcs, settings};
 
 /// Large block-art logo displayed on the welcome screen.
 const LOGO_LINES: &[&str] = &[
@@ -136,8 +137,8 @@ impl TutorialStep {
 /// support the protocol.
 /// TODO: https://sw.kovidgoyal.net/kitty/keyboard-protocol/#detection-of-support-for-this-protocol
 fn detect_kitty_keyboard_support() -> bool {
-    let term = bash_funcs::get_envvar_value("TERM").unwrap_or_default();
-    let term_program = bash_funcs::get_envvar_value("TERM_PROGRAM").unwrap_or_default();
+    let term = backend().env_var("TERM").unwrap_or_default();
+    let term_program = backend().env_var("TERM_PROGRAM").unwrap_or_default();
     let lower_term = term.to_lowercase();
     let lower_program = term_program.to_lowercase();
 
@@ -156,19 +157,22 @@ fn is_vscode() -> bool {
 }
 
 fn is_ghostty() -> bool {
-    let term_program = bash_funcs::get_envvar_value("TERM_PROGRAM").unwrap_or_default();
+    let term_program = backend().env_var("TERM_PROGRAM").unwrap_or_default();
     term_program.to_lowercase().contains("ghostty")
 }
 
 /// Path to the user's Zsh history file (`$HOME/.zsh_history`), if `$HOME` is
 /// set. Returns `None` when no home directory can be determined.
 fn zsh_history_path() -> Option<std::path::PathBuf> {
-    bash_funcs::get_envvar_value("HOME").map(|h| std::path::PathBuf::from(h).join(".zsh_history"))
+    backend()
+        .env_var("HOME")
+        .map(|h| std::path::PathBuf::from(h).join(".zsh_history"))
 }
 
 /// Returns true when the user's default shell (`$SHELL`) ends with `zsh`.
 fn default_shell_is_zsh() -> bool {
-    bash_funcs::get_envvar_value("SHELL")
+    backend()
+        .env_var("SHELL")
         .map(|s| {
             std::path::PathBuf::from(&s)
                 .file_name()
@@ -345,8 +349,8 @@ pub fn generate_tutorial_text(
                 ]));
             }
 
-            let rps1_set = bash_funcs::get_envvar_value("RPS1").is_some_and(|v| !v.is_empty())
-                || bash_funcs::get_envvar_value("RPROMPT").is_some_and(|v| !v.is_empty());
+            let rps1_set = backend().env_var("RPS1").is_some_and(|v| !v.is_empty())
+                || backend().env_var("RPROMPT").is_some_and(|v| !v.is_empty());
 
             if !rps1_set {
                 lines.push(TaggedLine::from_line(Line::from(""), Tag::Tutorial));

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -85,7 +85,9 @@ pub fn generate_welcome_action_line(now: std::time::Instant, width: u16) -> (u16
 }
 
 /// Tracks progress through the interactive tutorial.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, VariantArray)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, VariantArray, serde::Serialize, serde::Deserialize,
+)]
 pub enum TutorialStep {
     Welcome,
     TutorialsTutorial,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,15 @@
 use std::env;
 use std::process::{Command, Stdio};
 
+#[allow(dead_code)] // used by zsh_completion_tests; shared with docker tests
+pub fn command_available(name: &str) -> bool {
+    Command::new("sh")
+        .args(["-c", &format!("command -v {name} >/dev/null 2>&1")])
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
 pub fn run_bake_target(target: &str) -> anyhow::Result<()> {
     let stream = env::var("RUST_TEST_NOCAPTURE").is_ok();
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());

--- a/tests/standalone_startup_tests.rs
+++ b/tests/standalone_startup_tests.rs
@@ -1,0 +1,41 @@
+//! Regression guard: `flyline-standalone` must never hang or spin at startup.
+//!
+//! A `#[no_mangle] getenv` stub in `bash_stubs.rs` once interposed libc's
+//! `getenv` and recursed infinitely (100% CPU) the first time `std::env::var`
+//! ran during `Settings::default()`, wedging the host zsh with a blank,
+//! unresponsive terminal. This runs the real binary headless (stdin =
+//! /dev/null) and asserts it exits promptly instead of hanging.
+//!
+//! Skips when the binary isn't built (it needs `--features standalone`).
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+#[test]
+fn standalone_exits_promptly_without_a_terminal() {
+    let Some(bin) = option_env!("CARGO_BIN_EXE_flyline-standalone") else {
+        eprintln!("skipping: flyline-standalone not built (needs --features standalone)");
+        return;
+    };
+
+    let mut child = Command::new(bin)
+        .env("FLYLINE_HOST", "zsh")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn flyline-standalone");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if child.try_wait().expect("try_wait").is_some() {
+            return; // exited on its own — no startup hang/spin
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("flyline-standalone did not exit within 10s (startup hang/spin regression)");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}

--- a/tests/zsh_completion_tests.rs
+++ b/tests/zsh_completion_tests.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+
+fn manifest_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Parser unit tests live in `shell::zsh` (pure Rust). Run them here so
+/// `cargo test --test zsh_completion_tests` covers the parser without linking
+/// the full flyline rlib (cdylib + standalone stubs overflow at link/init).
+#[test]
+fn shell_zsh_parser_unit_tests() {
+    let status = Command::new("cargo")
+        .current_dir(manifest_dir())
+        .args(["test", "--lib", "parse_capture", "--"])
+        .status()
+        .expect("spawn cargo test for shell::zsh parser");
+    assert!(
+        status.success(),
+        "shell::zsh parser unit tests failed (run: cargo test --lib parse_capture)"
+    );
+}

--- a/tests/zsh_integration_tests.rs
+++ b/tests/zsh_integration_tests.rs
@@ -1,0 +1,26 @@
+mod common;
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .args(["info"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn run_zsh_integration_test() {
+    if !docker_available() {
+        eprintln!("skipping zsh integration test: docker not available");
+        return;
+    }
+
+    common::run_bake_target("zsh-integration-test").expect("zsh integration test failed");
+    println!("Successfully tested zsh integration with flyline");
+}
+
+#[test]
+fn zsh_integration_test() {
+    run_zsh_integration_test();
+}


### PR DESCRIPTION
## Summary

Adds first-class zsh support to flyline. In zsh, flyline runs **out-of-process**
as a `flyline-standalone` editor launched from a `zle-line-init` widget: it draws
its TUI on the tty and hands the chosen command line back to zsh over fd 3. This
is introduced behind a new `ShellBackend` seam, so the existing Bash
loadable-builtin path is unchanged (byte-for-byte — `BashBackend` just delegates
to the current `bash_funcs`).

The integration is **fail-open by construction**: if flyline is missing,
cancelled, crashes, or times out, native ZLE handles the line unharmed. It's also
trivially reversible (`sh install.sh --uninstall` / `flyline_disable`), which was a
hard requirement — nothing here can wedge the shell.

## Features

- **Out-of-process zsh editor** via `zle-line-init` + `flyline-standalone`, with
  fd 3 handoff and `FD_CLOEXEC` hardening so long-lived grandchildren (e.g.
  `gitstatusd`) can't hold the widget's `$( … 3>&1 )` open.
- **Native completion reuse**: zsh's own compsys (kubectl, git, oh-my-zsh, user
  fpath, …) is captured out-of-band in a headless `zsh -i` pty daemon via a
  `compadd` override — no reimplementation of zsh completion.
- **Persistent completion broker**: the rc-loaded daemon (~1.3s boot) is booted
  once and reused across prompts and terminals over a Unix socket, instead of per
  line. Keyed by `~/.zshrc` mtime (rc edits route to a fresh daemon),
  cd-per-request so path/git completions match the caller's directory, with an
  idle timeout and singleton bind. Falls back to an in-process daemon on any
  failure.
- **Cached command table**: the rc-loaded command vocabulary (aliases/functions/
  builtins/PATH) used for highlighting/validation is cached on disk (TTL + rc-mtime
  invalidation) so a fresh per-prompt process doesn't re-source the rc each line.
- **Prompt fidelity**: PS1/RPS1 are handed to flyline for rendering; starship is
  rendered via its CLI; heavy templates that can't be resolved out-of-context
  (e.g. powerlevel10k) fall back to a clean minimal prompt.
- **History**: reads `$HISTFILE`; the widget flushes the session's in-memory
  history (`fc -AI`) first so recent entries are visible.
- **Opt-outs**: `FLYLINE_ZSH_NO_BROKER=1` (per-process in-process daemon) and
  `FLYLINE_ZSH_NO_RCS=1` (pristine `zsh -f` helpers).

## Install improvements (local builds)

- `sh install.sh --local [DIST_DIR]` installs from locally-built artifacts instead
  of a release download. It **symlinks** the built `flyline-standalone` (and the
  Bash `libflyline.so`/`.dylib` if present) and the checkout's `scripts/flyline.zsh`
  into the install dir, then adds a guarded block to `~/.zshrc`. Because it
  symlinks, **rebuilds are picked up automatically** — no re-install after
  `cargo build`.
- `DIST_DIR` defaults to `target/release`, falling back to `target/debug`
  (overridable via arg or `FLYLINE_LOCAL_DIST`).
- `sh install.sh --uninstall` removes the zsh integration and the `~/.zshrc` block,
  leaving `libflyline` in place for Bash users.

## Suggested reading order

1. `README.md` — user-facing zsh overview and quickstart.
2. `src/shell/mod.rs` — the `ShellBackend` seam and `BashBackend` delegation (the
   design; start here).
3. `src/shell/zsh.rs` — `ZshBackend`: env/prompt/command-table + completion
   capture and the persistent broker (largest file).
4. `src/shell/zsh_comp_daemon.zsh` — the headless completion daemon sourced into
   the pty `zsh -i`.
5. `src/bin/standalone.rs` + `scripts/flyline.zsh` — the process entry (incl.
   broker mode) and the ZLE widget glue (fd 3 handoff, fail-open, Ctrl-C).
6. `src/lib.rs` + `src/bash_stubs.rs` — standalone exports and the stubbed Bash
   FFI symbols that let the standalone binary link without a Bash host.
7. `install.sh` — packaging, `--local`, `--uninstall`.
8. Existing-file migrations routed through the seam: `src/history.rs`,
   `src/prompt_manager.rs`, `src/app/mod.rs`, `src/app/tab_completion.rs`,
   `src/settings.rs`, `src/shell_integration.rs`, `src/tutorial.rs`, …
9. `tests/*` + `docker/*` — coverage and the multi-version CI harness.

## Testing

- Rust unit/integration tests: capture parser, on-disk command-table cache,
  `FD_CLOEXEC` behavior, the pty completion daemon (git completions), and an
  end-to-end broker round-trip (serves completions and reuses the warm daemon).
- Zsh integration tests + a Docker harness that exercises the widget contract
  (fd 3 handoff, fail-open) across multiple zsh/Bash versions.

## Notes / limitations

- The broker daemon captures its environment/fpath at boot; completions installed
  mid-session aren't seen until `~/.zshrc` changes (re-keys the socket) or the
  broker idles out.
- Completion requests are serialized across terminals (fast once the daemon is
  warm).
