### PR TITLE
Respect WUC identification under : and =

### DIFF
--- a/src/app/tab_completion.rs
+++ b/src/app/tab_completion.rs
@@ -2071,5 +2071,30 @@ mod tab_completion_tests {
             items.sort();
             assert_eq!(items, vec!["foo1/", "foo2/", "foo3/"]);
         }
+
+        #[test]
+        fn test_getsub_completions() {
+            cd_to_example_fs();
+
+            // 1. Completing the options
+            let actual = run_completion("getsub --");
+            let names: Vec<&str> = actual.iter().map(|s| s.s.as_str()).collect();
+            assert_eq!(names, vec![
+                "--alternative=",
+                "--fix-audio=",
+                "--subtitle-type=",
+                "--translate-from="
+            ]);
+
+            // 2. Completing the value after `=` (empty input)
+            let actual = run_completion("getsub --subtitle-type=");
+            let names: Vec<&str> = actual.iter().map(|s| s.s.as_str()).collect();
+            assert_eq!(names, vec!["json", "srt", "tsv", "txt", "vtt"]);
+
+            // 3. Completing the value after `=` with a prefix `t`
+            let actual = run_completion("getsub --subtitle-type=t");
+            let names: Vec<&str> = actual.iter().map(|s| s.s.as_str()).collect();
+            assert_eq!(names, vec!["tsv", "txt"]);
+        }
     }
 }

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -1082,6 +1082,40 @@ pub fn run_programmable_completions(
             .collect();
         let flags = CompletionFlags::from_alt(word_under_cursor, &filtered);
         Ok(ProgrammableCompleteReturn::new(filtered, flags, true))
+    } else if command_word == "getsub" {
+        let completions = if full_command.contains("--subtitle-type=") {
+            vec![
+                "json".to_string(),
+                "txt".to_string(),
+                "srt".to_string(),
+                "tsv".to_string(),
+                "vtt".to_string(),
+            ]
+        } else if full_command.contains("--fix-audio=") {
+            vec![
+                "backgroundNoise".to_string(),
+                "echoNoise".to_string(),
+                "windNoise".to_string(),
+                "lowVolume".to_string(),
+                "minimal".to_string(),
+            ]
+        } else {
+            vec![
+                "--alternative=".to_string(),
+                "--fix-audio=".to_string(),
+                "--subtitle-type=".to_string(),
+                "--translate-from=".to_string(),
+            ]
+        };
+        let filtered: Vec<String> = completions
+            .into_iter()
+            .filter(|s| s.starts_with(word_under_cursor))
+            .collect();
+        let mut flags = CompletionFlags::from_alt(word_under_cursor, &filtered);
+        if filtered.iter().all(|s| s.ends_with('=')) {
+            flags.no_suffix_desired = true;
+        }
+        Ok(ProgrammableCompleteReturn::new(filtered, flags, true))
     } else if command_word == "cat" {
         // do a naive filessytem glob.
         // bash sometimes does this if nothing is returned by the prog comp spec.

--- a/src/tab_completion_context.rs
+++ b/src/tab_completion_context.rs
@@ -351,7 +351,7 @@ pub fn get_completion_context<'a>(
         }),
     };
 
-    let word_under_cursor_range = match opt_cursor_node {
+    let mut word_under_cursor_range = match opt_cursor_node {
         Some((_, cursor_node))
             if cursor_node.token.kind.is_whitespace()
                 || cursor_node.token.kind == TokenKind::Newline =>
@@ -430,6 +430,35 @@ pub fn get_completion_context<'a>(
             return CompletionContext::dummy(buffer, cursor_byte_pos);
         }
     };
+
+    if !word_under_cursor_range.is_empty() {
+        let start = word_under_cursor_range.start;
+        let end = word_under_cursor_range.end;
+
+        let mut split_indices = Vec::new();
+        split_indices.push(start);
+        for (offset, c) in buffer[start..end].char_indices() {
+            if c == '=' || c == ':' {
+                split_indices.push(start + offset);
+            }
+        }
+        split_indices.push(end);
+
+        for i in 0..split_indices.len() - 1 {
+            let mut seg_start = if i == 0 {
+                split_indices[0]
+            } else {
+                split_indices[i] + 1
+            };
+            let seg_end = split_indices[i + 1];
+            seg_start = seg_start.min(seg_end);
+
+            if (seg_start..=seg_end).contains(&cursor_byte_pos) {
+                word_under_cursor_range = seg_start..seg_end;
+                break;
+            }
+        }
+    }
 
     if !word_under_cursor_range
         .to_inclusive()
@@ -1818,5 +1847,48 @@ mod tests {
     fn test_tilde_dot() {
         let ctx = run_inline("ll ~/.█");
         assert_eq!(ctx.word_under_cursor.as_ref(), "~/.");
+    }
+
+    #[test]
+    fn test_wuc_splitting() {
+        // --fo[CURSOR]o=qwe
+        let ctx = run_inline("getsub --fo█o=qwe");
+        assert_eq!(ctx.word_under_cursor.as_ref(), "--foo");
+
+        // --foo[CURSOR]=qwe
+        let ctx = run_inline("getsub --foo█=qwe");
+        assert_eq!(ctx.word_under_cursor.as_ref(), "--foo");
+
+        // --foo=[CURSOR]
+        let ctx = run_inline("getsub --foo=█");
+        assert_eq!(ctx.word_under_cursor.as_ref(), "");
+
+        // --foo=q[CURSOR]
+        let ctx = run_inline("getsub --foo=q█");
+        assert_eq!(ctx.word_under_cursor.as_ref(), "q");
+
+        // /asd/qwe:/foo/ba[cursor]r:/abc/def
+        let ctx = run_inline("/asd/qwe:/foo/ba█r:/abc/def");
+        assert_eq!(ctx.word_under_cursor.as_ref(), "/foo/bar");
+
+        // [cursor]/asd/qwe:/foo/bar:/abc/def
+        let ctx = run_inline("█/asd/qwe:/foo/bar:/abc/def");
+        assert_eq!(ctx.word_under_cursor.as_ref(), "/asd/qwe");
+
+        // /asd/qwe:/foo/bar:/abc/def[cursor]
+        let ctx = run_inline("/asd/qwe:/foo/bar:/abc/def█");
+        assert_eq!(ctx.word_under_cursor.as_ref(), "/abc/def");
+
+        // /asd/qwe[cursor]:/foo/bar:/abc/def
+        let ctx = run_inline("/asd/qwe█:/foo/bar:/abc/def");
+        assert_eq!(ctx.word_under_cursor.as_ref(), "/asd/qwe");
+
+        // /asd/qwe:[cursor]/foo/bar:/abc/def
+        let ctx = run_inline("/asd/qwe:█/foo/bar:/abc/def");
+        assert_eq!(ctx.word_under_cursor.as_ref(), "/foo/bar");
+
+        // /asd/qwe::/foo/ba[cursor]r
+        let ctx = run_inline("/asd/qwe::/foo/ba█r");
+        assert_eq!(ctx.word_under_cursor.as_ref(), "/foo/bar");
     }
 }


### PR DESCRIPTION
#772 showed that flyline wasn't handling WUC identification when = and : were present.

I reviewed the bash manual, and it looks like flyline is already handling (and I'd say better than readline) the other COMP_WORD_BREAK chars. : and = were two that I needed to split wuc on.

Fixes #772 