### PR TITLE
Upgrade lexer to better handle LParen vs Arith and add test cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 [[package]]
 name = "flash"
 version = "0.0.6"
-source = "git+https://github.com/HalFrgrd/flash.git?rev=dfceaffd316fcc357ce4604fb9971112a7c1de62#dfceaffd316fcc357ce4604fb9971112a7c1de62"
+source = "git+https://github.com/HalFrgrd/flash.git?rev=7f37b29befc07aba742d71e7d9164d4ed75eaf50#7f37b29befc07aba742d71e7d9164d4ed75eaf50"
 dependencies = [
  "atty",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ unicode-width = { version = "0.2.0", default-features = false }
 unicode-segmentation = "1.13.2"
 itertools = "0.14.0"
 glob = "0.3.3"
-flash = { git = "https://github.com/HalFrgrd/flash.git", rev = "dfceaffd316fcc357ce4604fb9971112a7c1de62" }
+flash = { git = "https://github.com/HalFrgrd/flash.git", rev = "7f37b29befc07aba742d71e7d9164d4ed75eaf50" }
 skim = { git = "https://github.com/HalFrgrd/skim", rev = "7908ee85a5f6cd49575925fcc0bdef3999409d26", default-features =  false, features = ["algos_only"]}
 lscolors = "0.21.0"
 serde_json = "1.0"
@@ -75,3 +75,4 @@ image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main-centos"
 # This prevents Cargo from compiling both the registry and git versions of crossterm, which would duplicate
 # the static event reader and cause stdin inputs typed during active commands (e.g. `sleep 1`) to be lost.
 crossterm = { git = "https://github.com/HalFrgrd/crossterm.git", rev = "78def95567c26a463d9f7554d48c3940d797a254" }
+

--- a/src/command_acceptance.rs
+++ b/src/command_acceptance.rs
@@ -64,6 +64,9 @@ mod tests {
         assert_eq!(will_bash_accept_buffer("echo $((1 + 2"), false);
         assert_eq!(will_bash_accept_buffer("echo $((1 + 2)"), false);
         assert_eq!(will_bash_accept_buffer("echo $((1 + 2))"), true);
+        assert_eq!(will_bash_accept_buffer("echo $(( ((2) + 2) ))"), true);
+        assert_eq!(will_bash_accept_buffer("(( ((2) + 2) ))"), true);
+        assert_eq!(will_bash_accept_buffer("case $x in (1) echo ;; esac"), true);
         assert_eq!(will_bash_accept_buffer("echo ${VAR}"), true);
         assert_eq!(will_bash_accept_buffer("echo ${VAR"), false);
         // test backticks

--- a/src/dparser.rs
+++ b/src/dparser.rs
@@ -213,6 +213,12 @@ impl DParser {
                     true
                 }
             }
+            TokenKind::LParen => {
+                matches!(
+                    current_nesting,
+                    Some(TokenKind::ArithSubst | TokenKind::ArithCommand | TokenKind::LParen)
+                )
+            }
             _ => true,
         }
     }
@@ -473,6 +479,7 @@ impl DParser {
                 | TokenKind::CmdSubst
                 | TokenKind::ArithSubst
                 | TokenKind::ArithCommand
+                | TokenKind::LParen
                 | TokenKind::ParamExpansion
                 | TokenKind::ProcessSubstIn
                 | TokenKind::ProcessSubstOut
@@ -1459,6 +1466,72 @@ mod tests {
         assert_eq!(tokens[6].token.value, "))");
         assert_eq!(
             tokens[6].annotations.closing,
+            Some(ClosingAnnotation {
+                opening_idx: 2,
+                is_auto_inserted: false
+            })
+        );
+    }
+
+    #[test]
+    fn test_arithmetic_nested_bracket_annotations() {
+        let input = "echo $(( ((2) + 2) ))";
+        let mut parser = DParser::from(input);
+        parser.walk_to_end();
+
+        let tokens = parser.tokens();
+
+        for t in tokens {
+            dbg!("{:?} - {:?}", &t.token, &t.annotations);
+        }
+
+        // Expected tokens:
+        // 0: "echo"
+        // 1: " "
+        // 2: "$((", kind: ArithSubst, opening matching with the final "))"
+        // 3: " "
+        // 4: "(", kind: LParen, matches with 12: ")"
+        // 5: "(", kind: LParen, matches with 7: ")"
+        // 6: "2"
+        // 7: ")", kind: RParen, matches with 5
+        // 8: " "
+        // 9: "+"
+        // 10: " "
+        // 11: "2"
+        // 12: ")", kind: RParen, matches with 4
+        // 13: " "
+        // 14: "))", kind: DoubleRParen, matches with 2
+
+        assert_eq!(tokens[2].token.kind, TokenKind::ArithSubst);
+        assert_eq!(tokens[2].annotations.opening, Some(OpeningState::Matched(14)));
+
+        assert_eq!(tokens[4].token.kind, TokenKind::LParen);
+        assert_eq!(tokens[4].annotations.opening, Some(OpeningState::Matched(12)));
+
+        assert_eq!(tokens[5].token.kind, TokenKind::LParen);
+        assert_eq!(tokens[5].annotations.opening, Some(OpeningState::Matched(7)));
+
+        assert_eq!(tokens[7].token.kind, TokenKind::RParen);
+        assert_eq!(
+            tokens[7].annotations.closing,
+            Some(ClosingAnnotation {
+                opening_idx: 5,
+                is_auto_inserted: false
+            })
+        );
+
+        assert_eq!(tokens[12].token.kind, TokenKind::RParen);
+        assert_eq!(
+            tokens[12].annotations.closing,
+            Some(ClosingAnnotation {
+                opening_idx: 4,
+                is_auto_inserted: false
+            })
+        );
+
+        assert_eq!(tokens[14].token.kind, TokenKind::DoubleRParen);
+        assert_eq!(
+            tokens[14].annotations.closing,
             Some(ClosingAnnotation {
                 opening_idx: 2,
                 is_auto_inserted: false


### PR DESCRIPTION
Fixes #774

### Problem
Inside arithmetic blocks (e.g., `$((...))`), the `flash` lexer greedily tokenized inner double parentheses `((` and `))` as compound operators (`ArithCommand`/`DoubleRParen`) instead of individual math grouping tokens. This broke bracket balancing for nested arithmetic like `echo $(( ((2) + 2) ))`.

### Solution
* **Stateful Lexer (`flash`)**: Added context tracking to the lexer so that inner `((` and `))` are split into separate `LParen`/`RParen` tokens when inside an active arithmetic block.
* **Context-Aware Parser (`flyline`)**: Updated `dparser` to treat `LParen` as a nesting opener only when inside an active arithmetic block, preventing false-positive nesting on standard syntax like case patterns (`(pattern)`).
* **Testing**: Added unit and acceptance tests validating bracket-matching annotations and parser acceptance.