### PR TITLE
Kitty cursor backend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,13 @@ flyline set-cursor --help
 ```
 
 # Terminal emulator notes
+## Kitty:
+When running inside Kitty, it is highly recommended to use the terminal cursor backend:
+```bash
+flyline set-cursor --backend terminal
+```
+By default, Flyline detects if it is running in Kitty and defaults to the `terminal` backend. Using the custom `flyline` cursor backend inside Kitty hides the terminal's native hardware cursor, which prevents Kitty from detecting shell prompts, causing it to ask for confirmation when closing the terminal window.
+
 ## VS Code:
 Recommended settings
 - [`terminal.integrated.minimumContrastRatio = 1`](vscode://settings/terminal.integrated.minimumContrastRatio) to prevent the cell's foreground colour changing when it's under the cursor.

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -732,7 +732,7 @@ impl<'a> App<'a> {
                 cursor_pos
             };
             let cursor_style = {
-                if self.settings.cursor_config.backend == CursorBackend::Terminal {
+                if self.settings.cursor_config.backend() == CursorBackend::Terminal {
                     None
                 } else {
                     let focused = self.term_has_focus
@@ -1528,7 +1528,7 @@ impl<'a> App<'a> {
         };
 
         if let Some(term_em_cursor) = drawn_content.term_em_cursor_pos()
-            && (self.settings.cursor_config.backend == CursorBackend::Terminal
+            && (self.settings.cursor_config.backend() == CursorBackend::Terminal
                 || !self.mode.is_running())
             && !(self.mouse_state.is_left_button_down()
                 && self.buffer.selection_range().is_some()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1327,7 +1327,7 @@ impl Flyline {
                         // If the user configures flyline-only options without explicitly setting the backend,
                         // and we defaulted to terminal (e.g. on kitty), automatically switch to flyline.
                         if backend.is_none()
-                            && self.settings.cursor_config.backend.is_none()
+                            && self.settings.cursor_config.is_backend_unset()
                             && (style.is_some()
                                 || effect.is_some()
                                 || effect_speed.is_some()
@@ -1336,14 +1336,15 @@ impl Flyline {
                             log::info!(
                                 "Auto-switching cursor backend to Flyline for configured options"
                             );
-                            self.settings.cursor_config.backend =
-                                Some(cursor::CursorBackend::Flyline);
+                            self.settings
+                                .cursor_config
+                                .set_backend(Some(cursor::CursorBackend::Flyline));
                         }
 
                         // set backend first since it affects the validity of other options
                         if let Some(b) = backend {
                             log::info!("Cursor backend set to {:?}", b);
-                            self.settings.cursor_config.backend = Some(b);
+                            self.settings.cursor_config.set_backend(Some(b));
                             if b == cursor::CursorBackend::Terminal
                                 && (style.is_some()
                                     || effect.is_some()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1324,10 +1324,26 @@ impl Flyline {
                         effect_speed,
                         effect_easing,
                     }) => {
+                        // If the user configures flyline-only options without explicitly setting the backend,
+                        // and we defaulted to terminal (e.g. on kitty), automatically switch to flyline.
+                        if backend.is_none()
+                            && self.settings.cursor_config.backend.is_none()
+                            && (style.is_some()
+                                || effect.is_some()
+                                || effect_speed.is_some()
+                                || effect_easing.is_some())
+                        {
+                            log::info!(
+                                "Auto-switching cursor backend to Flyline for configured options"
+                            );
+                            self.settings.cursor_config.backend =
+                                Some(cursor::CursorBackend::Flyline);
+                        }
+
                         // set backend first since it affects the validity of other options
                         if let Some(b) = backend {
                             log::info!("Cursor backend set to {:?}", b);
-                            self.settings.cursor_config.backend = b;
+                            self.settings.cursor_config.backend = Some(b);
                             if b == cursor::CursorBackend::Terminal
                                 && (style.is_some()
                                     || effect.is_some()
@@ -1342,8 +1358,8 @@ impl Flyline {
 
                         // Helper closure: every flyline-only option emits the same error.
                         // Returning a `bool` lets callers chain it with the option-presence check.
-                        let backend_is_terminal =
-                            self.settings.cursor_config.backend == cursor::CursorBackend::Terminal;
+                        let backend_is_terminal = self.settings.cursor_config.backend()
+                            == cursor::CursorBackend::Terminal;
 
                         if let Some(interp_str) = interpolate {
                             if interp_str.eq_ignore_ascii_case("none") {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -190,8 +190,9 @@ pub enum CursorStyleConfig {
 /// Complete cursor configuration set by `flyline set-cursor`.
 #[derive(Debug, Clone)]
 pub struct CursorConfig {
-    /// Which backend renders the cursor.
-    pub backend: CursorBackend,
+    /// Which backend renders the cursor.  If `None`, the default is resolved
+    /// dynamically based on terminal emulator checks.
+    pub backend: Option<CursorBackend>,
     /// Interpolation speed.  `None` disables position
     /// interpolation and the cursor jumps instantly to its target.
     /// Default is `Some(16.0)`.
@@ -208,10 +209,29 @@ pub struct CursorConfig {
     pub effect_easing: CursorEasing,
 }
 
+fn detect_kitty() -> bool {
+    let term = crate::bash_funcs::get_envvar_value("TERM").unwrap_or_default();
+    let term_program = crate::bash_funcs::get_envvar_value("TERM_PROGRAM").unwrap_or_default();
+    term.to_lowercase().contains("xterm-kitty") || term_program.to_lowercase().contains("kitty")
+}
+
+impl CursorConfig {
+    /// Resolves the cursor backend to use, defaulting to `Terminal` on Kitty and `Flyline` otherwise.
+    pub fn backend(&self) -> CursorBackend {
+        self.backend.unwrap_or_else(|| {
+            if detect_kitty() {
+                CursorBackend::Terminal
+            } else {
+                CursorBackend::Flyline
+            }
+        })
+    }
+}
+
 impl Default for CursorConfig {
     fn default() -> Self {
         Self {
-            backend: CursorBackend::Flyline,
+            backend: None,
             interpolate: Some(16.0),
             interpolate_easing: CursorEasing::Linear,
             style: CursorStyleConfig::Default,

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -192,7 +192,7 @@ pub enum CursorStyleConfig {
 pub struct CursorConfig {
     /// Which backend renders the cursor.  If `None`, the default is resolved
     /// dynamically based on terminal emulator checks.
-    pub backend: Option<CursorBackend>,
+    backend: Option<CursorBackend>,
     /// Interpolation speed.  `None` disables position
     /// interpolation and the cursor jumps instantly to its target.
     /// Default is `Some(16.0)`.
@@ -209,10 +209,14 @@ pub struct CursorConfig {
     pub effect_easing: CursorEasing,
 }
 
-fn detect_kitty() -> bool {
+static IS_KITTY: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
     let term = crate::bash_funcs::get_envvar_value("TERM").unwrap_or_default();
     let term_program = crate::bash_funcs::get_envvar_value("TERM_PROGRAM").unwrap_or_default();
     term.to_lowercase().contains("xterm-kitty") || term_program.to_lowercase().contains("kitty")
+});
+
+fn detect_kitty() -> bool {
+    *IS_KITTY
 }
 
 impl CursorConfig {
@@ -225,6 +229,16 @@ impl CursorConfig {
                 CursorBackend::Flyline
             }
         })
+    }
+
+    /// Sets the cursor rendering backend.
+    pub fn set_backend(&mut self, backend: Option<CursorBackend>) {
+        self.backend = backend;
+    }
+
+    /// Returns `true` if no backend has been explicitly configured.
+    pub fn is_backend_unset(&self) -> bool {
+        self.backend.is_none()
     }
 }
 

--- a/src/dparser.rs
+++ b/src/dparser.rs
@@ -1503,13 +1503,22 @@ mod tests {
         // 14: "))", kind: DoubleRParen, matches with 2
 
         assert_eq!(tokens[2].token.kind, TokenKind::ArithSubst);
-        assert_eq!(tokens[2].annotations.opening, Some(OpeningState::Matched(14)));
+        assert_eq!(
+            tokens[2].annotations.opening,
+            Some(OpeningState::Matched(14))
+        );
 
         assert_eq!(tokens[4].token.kind, TokenKind::LParen);
-        assert_eq!(tokens[4].annotations.opening, Some(OpeningState::Matched(12)));
+        assert_eq!(
+            tokens[4].annotations.opening,
+            Some(OpeningState::Matched(12))
+        );
 
         assert_eq!(tokens[5].token.kind, TokenKind::LParen);
-        assert_eq!(tokens[5].annotations.opening, Some(OpeningState::Matched(7)));
+        assert_eq!(
+            tokens[5].annotations.opening,
+            Some(OpeningState::Matched(7))
+        );
 
         assert_eq!(tokens[7].token.kind, TokenKind::RParen);
         assert_eq!(

--- a/src/tutorial.rs
+++ b/src/tutorial.rs
@@ -616,6 +616,13 @@ pub fn generate_tutorial_text(
         TutorialStep::CursorStyleEffects => {
             lines.push(tl(Span::styled("Cursor Style & Effects", heading_style)));
             lines.push(empty());
+            if detect_kitty_keyboard_support() {
+                lines.push(tl(Span::styled(
+                    "⚠ Warning: You are running Kitty. The custom `flyline` cursor backend hides the terminal's native cursor, which stops Kitty from detecting prompt states and prompts you on exit. It is highly recommended to use the `terminal` backend instead.",
+                    ratatui::style::Style::default().fg(ratatui::style::Color::Red),
+                )));
+                lines.push(empty());
+            }
             lines.push(TaggedLine::from(vec![
                 TaggedSpan::new(Span::styled("Use ", text_style), Tag::Tutorial),
                 ts_copiable(


### PR DESCRIPTION
Fixes #767 

Kitty needs to the terminal emulator's cursor to be visible so that it doesnt prompt you when you close the window.

But if you use the flyline cursor backend, we hide the terminal emulator's cursor so that we can draw cool cursors.

Other term ems don't seem to set this.