### PR TITLE
Don't hold lock during PATH scan

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -420,10 +420,18 @@ impl<'a> App<'a> {
         crate::threads::join_bash_func_threads();
 
         let _ = crate::threads::spawn_thread(crate::threads::ThreadTag::Warming, || {
-            let _timer = crate::perf::PerfTimer::start("warming_thread");
+            let _timer = crate::perf::PerfTimer::start("warming_thread_bash");
             let start = std::time::Instant::now();
-            crate::bash_funcs::warm_completion_caches();
-            log::info!("Warming thread finished in {:?}", start.elapsed());
+            crate::bash_funcs::warm_bash_caches();
+            log::info!("Warming bash caches finished in {:?}", start.elapsed());
+        });
+
+        let path_env = bash_funcs::get_envvar_value("PATH");
+        let _ = crate::threads::spawn_thread(crate::threads::ThreadTag::PathWarming, move || {
+            let _timer = crate::perf::PerfTimer::start("warming_thread_path");
+            let start = std::time::Instant::now();
+            crate::bash_funcs::warm_path_cache(path_env);
+            log::info!("Warming path cache finished in {:?}", start.elapsed());
         });
 
         let mut app = App {

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -1641,7 +1641,7 @@ pub fn find_quote_type(s: &str) -> Option<QuoteType> {
 }
 
 // ---------------------------------------------------------------------------
-// Cached environment lookups (moved from BashEnvManager)
+// Cached environment lookups
 // ---------------------------------------------------------------------------
 
 static DEFINED_ALIASES: Mutex<Option<Vec<CommandWordInfo>>> = Mutex::new(None);
@@ -1775,9 +1775,9 @@ impl ExecutablesOnPath {
 
     /// Update the cache in-place: evict removed PATH dirs, add new ones, and
     /// re-scan any directory whose mtime has changed.
-    fn update_cache() {
+    fn update_cache(path_env: Option<String>) {
         let _timer = crate::perf::PerfTimer::start_and_log_on_drop("update_path_cache");
-        let current_dirs: Vec<PathBuf> = get_envvar_value("PATH")
+        let current_dirs: Vec<PathBuf> = path_env
             .map(|p| p.split(':').map(PathBuf::from).collect())
             .unwrap_or_default();
 
@@ -1792,6 +1792,7 @@ impl ExecutablesOnPath {
 
         // Refresh (or populate) each directory that is currently on PATH.
         for dir in current_dirs {
+            std::thread::sleep(Duration::from_millis(300));
             let current_mtime = dir.metadata().ok().and_then(|m| m.modified().ok());
 
             let needs_update = {
@@ -1902,19 +1903,24 @@ pub fn get_possible_command_words() -> impl Iterator<Item = CommandWordInfo> {
 }
 
 #[cfg(not(test))]
-pub fn warm_completion_caches() {
-    {
-        let _guard = crate::bash_symbols::BASH_LOCK.lock();
-        let _ = get_cached_aliases();
-        let _ = get_cached_reserved_words();
-        let _ = get_cached_shell_functions();
-        let _ = get_cached_builtins();
-    }
-    ExecutablesOnPath::update_cache();
+pub fn warm_bash_caches() {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
+    let _ = get_cached_aliases();
+    let _ = get_cached_reserved_words();
+    let _ = get_cached_shell_functions();
+    let _ = get_cached_builtins();
 }
 
 #[cfg(test)]
-pub fn warm_completion_caches() {}
+pub fn warm_bash_caches() {}
+
+#[cfg(not(test))]
+pub fn warm_path_cache(path_env: Option<String>) {
+    ExecutablesOnPath::update_cache(path_env);
+}
+
+#[cfg(test)]
+pub fn warm_path_cache(_path_env: Option<String>) {}
 
 #[cfg(not(test))]
 pub fn read_terminating_signal() -> c_int {

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -11,8 +11,6 @@ use libc::c_int;
 use lscolors::LsColors;
 use std::collections::HashMap;
 #[cfg(not(test))]
-use std::collections::HashSet;
-#[cfg(not(test))]
 use std::io::Read;
 #[cfg(not(test))]
 use std::os::unix::fs::PermissionsExt;
@@ -24,6 +22,8 @@ use std::path::PathBuf;
 use std::sync::{LazyLock, Mutex};
 #[cfg(not(test))]
 use std::time::SystemTime;
+#[cfg(not(test))]
+use std::{collections::HashSet, time::Duration};
 
 #[cfg(not(test))]
 fn with_redirected_stdout<F, R>(func: F) -> (R, String)
@@ -1869,10 +1869,11 @@ pub fn get_possible_command_words() -> impl Iterator<Item = CommandWordInfo> {
     let reserved_words = get_cached_reserved_words();
     let shell_functions = get_cached_shell_functions();
     let builtins = get_cached_builtins();
-    ExecutablesOnPath::update_cache();
-    let exe_guard = EXECUTABLES_ON_PATH.lock().unwrap();
-    let executables: Vec<CommandWordInfo> = exe_guard.iter_info().collect();
-    drop(exe_guard);
+    // This should be pre warmed by warm_completion_caches
+    // We don't update the executables cache here to avoid hitting the filesystem
+    // when we are just tab completing
+    let executables: Vec<CommandWordInfo> =
+        EXECUTABLES_ON_PATH.lock().unwrap().iter_info().collect();
 
     aliases
         .into_iter()

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -1775,7 +1775,7 @@ impl ExecutablesOnPath {
 
     /// Update the cache in-place: evict removed PATH dirs, add new ones, and
     /// re-scan any directory whose mtime has changed.
-    fn update_cache(&mut self) {
+    fn update_cache() {
         let _timer = crate::perf::PerfTimer::start_and_log_on_drop("update_path_cache");
         let current_dirs: Vec<PathBuf> = get_envvar_value("PATH")
             .map(|p| p.split(':').map(PathBuf::from).collect())
@@ -1784,24 +1784,33 @@ impl ExecutablesOnPath {
         let current_dir_set: HashSet<&PathBuf> = current_dirs.iter().collect();
 
         // Evict directories that are no longer on PATH.
-        self.cache.retain(|dir, _| current_dir_set.contains(dir));
+        if let Ok(mut guard) = EXECUTABLES_ON_PATH.lock() {
+            guard.cache.retain(|dir, _| current_dir_set.contains(dir));
+        }
 
         // Refresh (or populate) each directory that is currently on PATH.
-        for dir in &current_dirs {
+        for dir in current_dirs {
             let current_mtime = dir.metadata().ok().and_then(|m| m.modified().ok());
 
-            match self.cache.get(dir) {
-                Some(entry) if entry.mtime == current_mtime => {
-                    continue;
+            let needs_update = if let Ok(guard) = EXECUTABLES_ON_PATH.lock() {
+                match guard.cache.get(&dir) {
+                    Some(entry) if entry.mtime == current_mtime => false,
+                    _ => true,
                 }
-                _ => {
-                    let names = if current_mtime.is_some() {
-                        Self::scan_dir(dir)
-                    } else {
-                        Vec::new()
-                    };
-                    self.cache.insert(
-                        dir.clone(),
+            } else {
+                false
+            };
+
+            if needs_update {
+                let names = if current_mtime.is_some() {
+                    Self::scan_dir(&dir)
+                } else {
+                    Vec::new()
+                };
+
+                if let Ok(mut guard) = EXECUTABLES_ON_PATH.lock() {
+                    guard.cache.insert(
+                        dir,
                         DirExecutables {
                             mtime: current_mtime,
                             names,
@@ -1860,8 +1869,8 @@ pub fn get_possible_command_words() -> impl Iterator<Item = CommandWordInfo> {
     let reserved_words = get_cached_reserved_words();
     let shell_functions = get_cached_shell_functions();
     let builtins = get_cached_builtins();
-    let mut exe_guard = EXECUTABLES_ON_PATH.lock().unwrap();
-    exe_guard.update_cache();
+    ExecutablesOnPath::update_cache();
+    let exe_guard = EXECUTABLES_ON_PATH.lock().unwrap();
     let executables: Vec<CommandWordInfo> = exe_guard.iter_info().collect();
     drop(exe_guard);
 
@@ -1885,14 +1894,14 @@ pub fn get_possible_command_words() -> impl Iterator<Item = CommandWordInfo> {
 
 #[cfg(not(test))]
 pub fn warm_completion_caches() {
-    let _guard = crate::bash_symbols::BASH_LOCK.lock();
-    let _ = get_cached_aliases();
-    let _ = get_cached_reserved_words();
-    let _ = get_cached_shell_functions();
-    let _ = get_cached_builtins();
-    if let Ok(mut exe_guard) = EXECUTABLES_ON_PATH.lock() {
-        exe_guard.update_cache();
+    {
+        let _guard = crate::bash_symbols::BASH_LOCK.lock();
+        let _ = get_cached_aliases();
+        let _ = get_cached_reserved_words();
+        let _ = get_cached_shell_functions();
+        let _ = get_cached_builtins();
     }
+    ExecutablesOnPath::update_cache();
 }
 
 #[cfg(test)]

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -1784,21 +1784,24 @@ impl ExecutablesOnPath {
         let current_dir_set: HashSet<&PathBuf> = current_dirs.iter().collect();
 
         // Evict directories that are no longer on PATH.
-        if let Ok(mut guard) = EXECUTABLES_ON_PATH.lock() {
-            guard.cache.retain(|dir, _| current_dir_set.contains(dir));
-        }
+        EXECUTABLES_ON_PATH
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .cache
+            .retain(|dir, _| current_dir_set.contains(dir));
 
         // Refresh (or populate) each directory that is currently on PATH.
         for dir in current_dirs {
             let current_mtime = dir.metadata().ok().and_then(|m| m.modified().ok());
 
-            let needs_update = if let Ok(guard) = EXECUTABLES_ON_PATH.lock() {
+            let needs_update = {
+                let guard = EXECUTABLES_ON_PATH
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
                 match guard.cache.get(&dir) {
                     Some(entry) if entry.mtime == current_mtime => false,
                     _ => true,
                 }
-            } else {
-                false
             };
 
             if needs_update {
@@ -1808,15 +1811,17 @@ impl ExecutablesOnPath {
                     Vec::new()
                 };
 
-                if let Ok(mut guard) = EXECUTABLES_ON_PATH.lock() {
-                    guard.cache.insert(
+                EXECUTABLES_ON_PATH
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .cache
+                    .insert(
                         dir,
                         DirExecutables {
                             mtime: current_mtime,
                             names,
                         },
                     );
-                }
             }
         }
     }
@@ -1872,8 +1877,11 @@ pub fn get_possible_command_words() -> impl Iterator<Item = CommandWordInfo> {
     // This should be pre warmed by warm_completion_caches
     // We don't update the executables cache here to avoid hitting the filesystem
     // when we are just tab completing
-    let executables: Vec<CommandWordInfo> =
-        EXECUTABLES_ON_PATH.lock().unwrap().iter_info().collect();
+    let executables: Vec<CommandWordInfo> = EXECUTABLES_ON_PATH
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .iter_info()
+        .collect();
 
     aliases
         .into_iter()

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -23,7 +23,7 @@ use std::sync::{LazyLock, Mutex};
 #[cfg(not(test))]
 use std::time::SystemTime;
 #[cfg(not(test))]
-use std::{collections::HashSet, time::Duration};
+use std::collections::HashSet;
 
 #[cfg(not(test))]
 fn with_redirected_stdout<F, R>(func: F) -> (R, String)

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -1775,7 +1775,7 @@ impl ExecutablesOnPath {
 
     /// Update the cache in-place: evict removed PATH dirs, add new ones, and
     /// re-scan any directory whose mtime has changed.
-    /// 
+    ///
     /// This is pure file system stuff and should never require BASH_LOCK.
     fn update_cache(path_env: Option<String>) {
         let _timer = crate::perf::PerfTimer::start_and_log_on_drop("update_path_cache");

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -1775,6 +1775,8 @@ impl ExecutablesOnPath {
 
     /// Update the cache in-place: evict removed PATH dirs, add new ones, and
     /// re-scan any directory whose mtime has changed.
+    /// 
+    /// This is pure file system stuff and should never require BASH_LOCK.
     fn update_cache(path_env: Option<String>) {
         let _timer = crate::perf::PerfTimer::start_and_log_on_drop("update_path_cache");
         let current_dirs: Vec<PathBuf> = path_env
@@ -1792,7 +1794,6 @@ impl ExecutablesOnPath {
 
         // Refresh (or populate) each directory that is currently on PATH.
         for dir in current_dirs {
-            std::thread::sleep(Duration::from_millis(300));
             let current_mtime = dir.metadata().ok().and_then(|m| m.modified().ok());
 
             let needs_update = {

--- a/src/threads.rs
+++ b/src/threads.rs
@@ -6,6 +6,7 @@ use std::thread::JoinHandle;
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum ThreadTag {
     Warming,
+    PathWarming,
     Flycomp,
     TabCompletion,
 }
@@ -14,6 +15,7 @@ impl ThreadTag {
     pub(crate) fn uses_bash_funcs(&self) -> bool {
         match self {
             ThreadTag::Warming => true,
+            ThreadTag::PathWarming => false,
             ThreadTag::Flycomp => false,
             ThreadTag::TabCompletion => false,
         }
@@ -22,6 +24,7 @@ impl ThreadTag {
     pub(crate) fn thread_name(&self) -> &'static str {
         match self {
             ThreadTag::Warming => "flyline-warming",
+            ThreadTag::PathWarming => "flyline-path-warming",
             ThreadTag::Flycomp => "flyline-flycomp",
             ThreadTag::TabCompletion => "flyline-completions",
         }


### PR DESCRIPTION
New thread that populates EXECUTABLES_ON_PATH. This thread does not require BASH_LOCK at all so we can exit flyline app and don't have to wait for it.