### PR TITLE
Add Nix flake packaging

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783522502,
+        "narHash": "sha256-iffAls3iaNTyJC2faYcUXSI+Gp02cDjYl+MygxKl2GI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0bb7ec54c8483066ec9d7720e780a5caa71f8612",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "Bash plugin to replace readline for a modern line editing experience";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: rec {
+        flyline = pkgs.callPackage ./nix/package.nix { };
+        default = flyline;
+      });
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage {
+  __structuredAttrs = true;
+
+  pname = "flyline";
+  version = (lib.importTOML ../Cargo.toml).package.version;
+
+  src = lib.cleanSource ../.;
+
+  # Some deps come from git forks; fetchCargoVendor bundles them under one hash.
+  cargoHash = "sha256-PS2whyXd5O1yGDM7Yqzo0TOQFDje+b84/79eJjEBU8k=";
+
+  # Reproducible builds on macOS (Linux needs nothing extra). Timestamps come
+  # from SOURCE_DATE_EPOCH (set by Nix, honored by build.rs); these flags fix
+  # Mach-O leaks:
+  #   --remap-path-prefix  strip the randomised build dir from rustc paths
+  #   -install_name        pin LC_ID_DYLIB (else it's the absolute build path)
+  #   -reproducible        normalize LC_UUID / ad-hoc signature
+  # Exporting RUSTFLAGS overrides .cargo/config.toml, so re-add -undefined
+  # dynamic_lookup (flyline resolves Bash symbols at load time).
+  preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export RUSTFLAGS="--remap-path-prefix=$NIX_BUILD_TOP=/build -C link-arg=-undefined -C link-arg=dynamic_lookup -C link-arg=-Wl,-install_name,@rpath/libflyline.dylib -C link-arg=-Wl,-reproducible''${RUSTFLAGS:+ $RUSTFLAGS}"
+  '';
+
+  # The docker_integration_tests need Docker, which the sandbox lacks; skip them.
+  checkFlags = [
+    "--skip=test_bash_3_2_57"
+    "--skip=test_bash_4_4_18"
+    "--skip=test_bash_4_4_rc1"
+    "--skip=test_bash_5_0"
+    "--skip=test_bash_5_3"
+  ];
+
+  meta = {
+    description = "Bash plugin to replace readline for a modern line editing experience";
+    longDescription = ''
+      Flyline is a Bash loadable builtin (a dynamic library dlopen()ed by Bash)
+      that adds a rich line editor: inline suggestions, fuzzy tab completion,
+      configurable keybindings and prompts. Enable it in an interactive shell
+      with `enable -f ${placeholder "out"}/lib/libflyline.<ext> flyline`.
+    '';
+    homepage = "https://github.com/HalFrgrd/flyline";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Package flyline as a Nix flake.

  - flake.nix: packages.{default,flyline} for the four unix systems, plus a Home-Manager module output.
  - nix/package.nix: rustPlatform.buildRustPackage building from source. Runs the library unit tests. the Docker integration tests can't run in the sandbox.

see also https://github.com/NixOS/nixpkgs/pull/538842 for the nixpkgs side of things