### PR TITLE
Support for third party tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,8 @@ export RPS1='FLYLINE_LEADER_MODE'
 > [!CAUTION]
 > This an experimental feature and might change. Feedback welcome
 
+Flyline completely replaces readline so other TUIs that help you write commands don't work immediately.
+
 Flyline has a special action that will:
 - pause flyline then
 - run a Bash command then

--- a/README.md
+++ b/README.md
@@ -759,6 +759,31 @@ eval "$(fzf --bash)"
 flyline key bind Ctrl+r 'always=runBashCommand(__fzf_history__)' 
 ```
 
+## Custom
+
+```bash
+# 1. Define the function
+my_custom_function() {
+    local line="$READLINE_LINE"
+    local point="${READLINE_POINT:-0}"
+    local mark="${READLINE_MARK:-0}"
+
+    local start=$(( point < mark ? point : mark ))
+    local end=$(( point > mark ? point : mark ))
+    local len=$(( end - start ))
+
+    local selected="${line:start:len}"
+    local prefix="this part was selected: "
+
+    READLINE_LINE="${prefix}${selected}"
+    READLINE_MARK=${#prefix}
+    READLINE_POINT=$(( ${#prefix}  + ${#selected}  ))
+}
+
+# 2. Bind it to a key combination (e.g., Ctrl+b)
+flyline key bind Ctrl+b 'always=runBashCommand(my_custom_function)'
+```
+
 # Licensing
 
 This project is multi-licensed:

--- a/README.md
+++ b/README.md
@@ -741,6 +741,24 @@ flyline create-prompt-widget leader-mode --name FLYLINE_LEADER_MODE 'LEADER' ''
 export RPS1='FLYLINE_LEADER_MODE'
 ```
 
+# Integration with third party apps
+Flyline has a special action that will pause flyline, run a Bash command, then resume and update the buffer based on `READLINE_LINE` and `READLINE_POINT`.
+
+> [!CAUTION]
+> This an experimental feature and might change. Feedback welcome
+
+## Atuin
+```bash
+eval "$(atuin init bash)"
+flyline key bind Ctrl+r 'always=runBashCommand(__atuin_widget_run)' 
+```
+
+## fzf
+```bash
+eval "$(fzf --bash)"
+flyline key bind Ctrl+r 'always=runBashCommand(__fzf_history__)' 
+```
+
 # Licensing
 
 This project is multi-licensed:

--- a/README.md
+++ b/README.md
@@ -754,13 +754,23 @@ Flyline has a special action that will:
 ## Atuin
 ```bash
 eval "$(atuin init bash)"
-flyline key bind Ctrl+r 'always=runBashCommand(__atuin_widget_run)' 
+flyline key bind Ctrl+r 'always=runBashCommand(__atuin_widget_run)+submitOrNewline' 
+flyline key bind Up 'editingBufferMode+cursorOnFirstLine=runBashCommand("__atuin_history --shell-up-key-binding --keymap-mode=emacs")+submitOrNewline'
+flyline key bind Ctrl+b 'editingBufferMode+bufferIsEmpty=runBashCommand(_atuin_ai_question_mark)'
 ```
 
 ## fzf
 ```bash
 eval "$(fzf --bash)"
-flyline key bind Ctrl+r 'always=runBashCommand(__fzf_history__)' 
+
+flyline_fzf_cd() {
+    local cmd
+    cmd=$(__fzf_cd__) && READLINE_LINE="$cmd" READLINE_POINT=${#cmd}
+}
+
+flyline key bind Ctrl+r 'always=runBashCommand(__fzf_history__)' # or runBashCommand(__fzf_history__)+submitOrNewline
+flyline key bind Ctrl+t 'always=runBashCommand(fzf-file-widget)'
+flyline key bind Alt+c  'always=runBashCommand(flyline_fzf_cd)+submitOrNewline'
 ```
 
 ## Custom

--- a/README.md
+++ b/README.md
@@ -742,10 +742,14 @@ export RPS1='FLYLINE_LEADER_MODE'
 ```
 
 # Integration with third party apps
-Flyline has a special action that will pause flyline, run a Bash command, then resume and update the buffer based on `READLINE_LINE` and `READLINE_POINT`.
-
 > [!CAUTION]
 > This an experimental feature and might change. Feedback welcome
+
+Flyline has a special action that will:
+- pause flyline then
+- run a Bash command then
+- wait for it to finish (keyboard / mouse are handled by your program) then
+- flyline resumes and update the buffer based on `READLINE_LINE`, `READLINE_POINT`, and `READLINE_MARK`.
 
 ## Atuin
 ```bash

--- a/README.md
+++ b/README.md
@@ -749,7 +749,7 @@ Flyline completely replaces readline so other TUIs that help you write commands 
 
 Flyline has a special action that will:
 - pause flyline then
-- run a Bash command then
+- run your program then
 - wait for it to finish (keyboard / mouse are handled by your program) then
 - flyline resumes and update the buffer based on `READLINE_LINE`, `READLINE_POINT`, and `READLINE_MARK`.
 

--- a/src/app/actions/keyboard.rs
+++ b/src/app/actions/keyboard.rs
@@ -222,6 +222,8 @@ pub enum KeyEventAction {
     UnsetLeaderKey,
     #[strum(message = "Insert a literal string of characters", disabled)]
     InsertString(String),
+    #[strum(message = "Run a Bash command", disabled)]
+    RunBashCommand(String),
 }
 
 impl KeyEventAction {
@@ -229,6 +231,7 @@ impl KeyEventAction {
     pub fn as_str(&self) -> &'static str {
         match self {
             KeyEventAction::InsertString(_) => "insertString",
+            KeyEventAction::RunBashCommand(_) => "runBashCommand",
             _ => <&'static str>::from(self),
         }
     }
@@ -238,6 +241,7 @@ impl KeyEventAction {
     pub fn description(&self) -> &'static str {
         match self {
             KeyEventAction::InsertString(_) => "Insert a literal string of characters",
+            KeyEventAction::RunBashCommand(_) => "Run a Bash command",
             _ => self.get_message().unwrap_or(""),
         }
     }
@@ -245,6 +249,7 @@ impl KeyEventAction {
     pub fn display_name(&self) -> String {
         match self {
             KeyEventAction::InsertString(s) => format!("insertString('{}')", s.escape_debug()),
+            KeyEventAction::RunBashCommand(s) => format!("runBashCommand('{}')", s.escape_debug()),
             _ => self.as_str().to_string(),
         }
     }
@@ -921,6 +926,9 @@ impl KeyEventAction {
                 app.buffer.delete_selection();
                 app.buffer.insert_str(s);
             }
+            KeyEventAction::RunBashCommand(cmd) => {
+                app.run_bash_command(cmd);
+            }
         }
     }
 }
@@ -1349,6 +1357,27 @@ impl Binding {
                     };
                     let unescaped = unescape_string(inner_trimmed);
                     Ok(KeyEventAction::InsertString(unescaped))
+                } else if let Some(stripped) = s.strip_prefix("runBashCommand(") {
+                    if !stripped.ends_with(')') {
+                        return Err(anyhow::anyhow!(
+                            "Invalid runBashCommand syntax: '{}'. Expected 'runBashCommand(value)'",
+                            s
+                        ));
+                    }
+                    let inner = &stripped[..stripped.len() - 1];
+                    let inner_trimmed = if (inner.starts_with('"') && inner.ends_with('"'))
+                        || (inner.starts_with('\'') && inner.ends_with('\''))
+                    {
+                        if inner.len() >= 2 {
+                            &inner[1..inner.len() - 1]
+                        } else {
+                            inner
+                        }
+                    } else {
+                        inner
+                    };
+                    let unescaped = unescape_string(inner_trimmed);
+                    Ok(KeyEventAction::RunBashCommand(unescaped))
                 } else {
                     KeyEventAction::try_from(s)
                         .map_err(|_| anyhow::anyhow!("Unknown action: '{}'", s))
@@ -1741,6 +1770,15 @@ pub fn possible_context_action_completions(current: &std::ffi::OsStr) -> Vec<Com
                 .help(Some(clap::builder::StyledStr::from(
                     "Insert a literal string of characters",
                 ))),
+            );
+        }
+        if "runbashcommand".contains(&action_lower) {
+            candidates.push(
+                CompletionCandidate::new(format!(
+                    "{}PREFIX_DELIM{}{}NO_SUFFIX",
+                    prefix, action_prefix, "runBashCommand(command)"
+                ))
+                .help(Some(clap::builder::StyledStr::from("Run a Bash command"))),
             );
         }
         return candidates;
@@ -3919,6 +3957,31 @@ mod tests {
         );
 
         assert!(Binding::try_new_from_strs("Ctrl+g", "always=insertString(hello").is_err());
+    }
+
+    #[test]
+    fn test_binding_try_new_from_strs_run_bash_command() {
+        let b =
+            Binding::try_new_from_strs("Ctrl+g", "always=runBashCommand('echo hello')").unwrap();
+        assert_eq!(
+            b.actions,
+            vec![KeyEventAction::RunBashCommand("echo hello".to_string())]
+        );
+
+        let action = KeyEventAction::RunBashCommand("echo hello".to_string());
+        assert_eq!(action.as_str(), "runBashCommand");
+        assert_eq!(action.description(), "Run a Bash command");
+        assert_eq!(action.display_name(), "runBashCommand('echo hello')");
+
+        let b2 =
+            Binding::try_new_from_strs("Ctrl+g", "always=runBashCommand(\"echo \\\"hello\\\"\")")
+                .unwrap();
+        assert_eq!(
+            b2.actions,
+            vec![KeyEventAction::RunBashCommand("echo \"hello\"".to_string())]
+        );
+
+        assert!(Binding::try_new_from_strs("Ctrl+g", "always=runBashCommand(echo hello").is_err());
     }
 
     #[test]

--- a/src/app/actions/keyboard.rs
+++ b/src/app/actions/keyboard.rs
@@ -1325,7 +1325,7 @@ impl Binding {
     /// Parse a user-provided binding from the CLI form
     /// `<KEY> <CONTEXT_EXPR>=<ACTION>`.
     pub fn try_new_from_strs(key_event: &str, context_and_action: &str) -> Result<Self> {
-        let (context_str, action_str) = context_and_action.rsplit_once('=').ok_or_else(|| {
+        let (context_str, action_str) = context_and_action.split_once('=').ok_or_else(|| {
             anyhow::anyhow!(
                 "Invalid context and action format: '{}'. Expected 'context=action'",
                 context_and_action
@@ -3979,6 +3979,18 @@ mod tests {
         assert_eq!(
             b2.actions,
             vec![KeyEventAction::RunBashCommand("echo \"hello\"".to_string())]
+        );
+
+        let b3 = Binding::try_new_from_strs(
+            "Up",
+            "editingBufferMode+!cursorOnFirstLine=runBashCommand(\"__atuin_history --shell-up-key-binding --keymap-mode=emacs\")",
+        )
+        .unwrap();
+        assert_eq!(
+            b3.actions,
+            vec![KeyEventAction::RunBashCommand(
+                "__atuin_history --shell-up-key-binding --keymap-mode=emacs".to_string()
+            )]
         );
 
         assert!(Binding::try_new_from_strs("Ctrl+g", "always=runBashCommand(echo hello").is_err());

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -89,6 +89,8 @@ fn restore_terminal() {
     });
 }
 
+// Set up terminal features. Mouse capture is handled separately inside
+// MouseState::initialize (called in App::new) based on the configured mode.
 fn configure_terminal(extended_key_codes: bool) {
     let mut stdout = std::io::stdout();
     let _ = std::io::Write::flush(&mut stdout);
@@ -96,6 +98,9 @@ fn configure_terminal(extended_key_codes: bool) {
         log::error!("Failed to enable raw mode: {}", e);
     });
     let flags = if extended_key_codes {
+        // Enabling REPORT_ALL_KEYS_AS_ESCAPE_CODES causes Ctrl+C to not copy to clipboard in VS Code with default settings
+        // because it causes the press of Ctrl to be sent as a key code thus clearing the selection before 'c' is pressed.
+        // https://blog.fsck.com/releases/2026/02/26/terminal-keyboard-protocol/ is a good reference for understanding the terminal key code problem.
         crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
             | crossterm::event::KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
     } else {
@@ -826,7 +831,6 @@ impl<'a> App<'a> {
         // 2. Put terminal back into normal mode
         restore_terminal();
         // move cursor to column 0 (matching Readline's rl_clear_visible_line)
-        // Not sure if this is desireable
         let mut stdout = std::io::stdout();
         let _ = crossterm::execute!(stdout, crossterm::cursor::MoveToColumn(0));
         let _ = std::io::Write::flush(&mut stdout);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -805,11 +805,19 @@ impl<'a> App<'a> {
         let extended_key_codes = self.settings.enable_extended_key_codes;
         let mouse_enabled = self.mouse_state.is_enabled();
 
-        // 1. Set READLINE_LINE and READLINE_POINT env vars before running command
+        // 1. Export READLINE_* variables before running command
         let current_line = self.buffer.buffer().to_string();
-        let current_point = self.buffer.cursor_byte_pos().to_string();
+        let current_point = self.buffer.cursor_char_offset().to_string();
+        let current_mark = self
+            .buffer
+            .selection_char_offset()
+            .unwrap_or_else(|| self.buffer.cursor_char_offset())
+            .to_string();
+
         let _ = crate::bash_funcs::export_env_var("READLINE_LINE", &current_line);
         let _ = crate::bash_funcs::export_env_var("READLINE_POINT", &current_point);
+        let _ = crate::bash_funcs::export_env_var("READLINE_MARK", &current_mark);
+        let _ = crate::bash_funcs::export_env_var("READLINE_ARGUMENT", "1");
 
         // 2. Put terminal back into normal mode
         restore_terminal();
@@ -825,16 +833,30 @@ impl<'a> App<'a> {
             self.mouse_state.enable();
         }
 
-        // 5. Read READLINE_LINE and READLINE_POINT env vars and set text buffer and cursor pos
+        // 5. Read READLINE_* env vars and set text buffer, cursor, and mark positions
         if let Some(new_line) = crate::bash_funcs::get_envvar_value("READLINE_LINE") {
-            self.buffer.replace_buffer(&new_line);
+            let cleaned_line = new_line.trim_end_matches(['\r', '\n']);
+            self.buffer.replace_buffer(cleaned_line);
         }
         if let Some(new_point_str) = crate::bash_funcs::get_envvar_value("READLINE_POINT") {
-            if let Ok(new_point) = new_point_str.parse::<usize>() {
-                self.buffer.try_move_cursor_to_byte_pos(new_point, true);
+            if let Ok(new_point_char_offset) = new_point_str.parse::<usize>() {
+                let byte_pos = self.buffer.char_to_byte_offset(new_point_char_offset);
+                self.buffer.try_move_cursor_to_byte_pos(byte_pos, true);
             }
         }
-        self.on_possible_buffer_change();
+        if let Some(new_mark_str) = crate::bash_funcs::get_envvar_value("READLINE_MARK") {
+            if let Ok(new_mark_char_offset) = new_mark_str.parse::<usize>() {
+                let byte_pos = self.buffer.char_to_byte_offset(new_mark_char_offset);
+                self.buffer.set_selection_anchor(byte_pos);
+            }
+        }
+
+        // 6. Unset READLINE_* variables (matching GNU Readline unbind_readline_variables)
+        let _ = crate::bash_funcs::unset_env_var("READLINE_LINE");
+        let _ = crate::bash_funcs::unset_env_var("READLINE_POINT");
+        let _ = crate::bash_funcs::unset_env_var("READLINE_MARK");
+        let _ = crate::bash_funcs::unset_env_var("READLINE_ARGUMENT");
+
         self.needs_full_redraw = true;
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -68,7 +68,7 @@ const IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 /// Frame rate (fps) used when the user has been idle for longer than [`IDLE_TIMEOUT`].
 const IDLE_FRAME_RATE: f64 = 0.2;
 
-fn restore_terminal(extended_key_codes: bool) {
+fn restore_terminal() {
     crossterm::terminal::disable_raw_mode().unwrap_or_else(|e| {
         // Likely from the master pty fd being closed.
         log::error!("Failed to disable raw mode: {}", e);
@@ -80,19 +80,11 @@ fn restore_terminal(extended_key_codes: bool) {
         crossterm::event::DisableMouseCapture,
         XtShiftEscape::Disable,
         PointerShape::Default,
+        crossterm::event::PopKeyboardEnhancementFlags,
     )
     .unwrap_or_else(|e| {
         log::error!("Failed to restore terminal features: {}", e);
     });
-    if extended_key_codes {
-        crossterm::execute!(
-            std::io::stdout(),
-            crossterm::event::PopKeyboardEnhancementFlags
-        )
-        .unwrap_or_else(|e| {
-            log::error!("Failed to pop keyboard enhancement flags: {}", e);
-        });
-    }
 }
 
 fn configure_terminal(extended_key_codes: bool) {
@@ -101,32 +93,27 @@ fn configure_terminal(extended_key_codes: bool) {
     crossterm::terminal::enable_raw_mode().unwrap_or_else(|e| {
         log::error!("Failed to enable raw mode: {}", e);
     });
+    let flags = if extended_key_codes {
+        crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+            | crossterm::event::KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
+    } else {
+        crossterm::event::KeyboardEnhancementFlags::empty()
+    };
     crossterm::execute!(
         std::io::stdout(),
         crossterm::event::EnableBracketedPaste,
         crossterm::event::EnableFocusChange,
+        crossterm::event::PushKeyboardEnhancementFlags(flags),
     )
     .unwrap_or_else(|e| {
         log::error!("Failed to set terminal features: {}", e);
     });
-    if extended_key_codes {
-        crossterm::execute!(
-            std::io::stdout(),
-            crossterm::event::PushKeyboardEnhancementFlags(
-                crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                    | crossterm::event::KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
-            )
-        )
-        .unwrap_or_else(|e| {
-            log::error!("Failed to push keyboard enhancement flags: {}", e);
-        });
-    }
 }
 
-fn set_panic_hook(extended_key_codes: bool) {
+fn set_panic_hook() {
     let hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-        restore_terminal(extended_key_codes);
+        restore_terminal();
         log::error!("Panic: {}", info);
         hook(info);
     }));
@@ -236,44 +223,14 @@ pub fn get_command(settings: &mut Settings) -> ExitState {
         return ExitState::EOF;
     }
 
-    let extended_key_codes = settings.enable_extended_key_codes;
-    set_panic_hook(extended_key_codes);
-
-    let mut stdout = std::io::stdout();
-    std::io::Write::flush(&mut stdout).unwrap();
-    crossterm::terminal::enable_raw_mode().unwrap();
-
-    // Set up terminal features. Mouse capture is handled separately inside
-    // MouseState::initialize (called in App::new) based on the configured mode.
-    crossterm::execute!(
-        std::io::stdout(),
-        crossterm::event::EnableBracketedPaste,
-        crossterm::event::EnableFocusChange,
-    )
-    .unwrap_or_else(|e| {
-        log::error!("Failed to set terminal features: {}", e);
-    });
-    if extended_key_codes {
-        // Enabling REPORT_ALL_KEYS_AS_ESCAPE_CODES causes Ctrl+C to not copy to clipboard in VS Code with default settings
-        // because it causes the press of Ctrl to be sent as a key code thus clearing the selection before 'c' is pressed.
-        // https://blog.fsck.com/releases/2026/02/26/terminal-keyboard-protocol/ is a good reference for understanding the terminal key code problem.
-        crossterm::execute!(
-            std::io::stdout(),
-            crossterm::event::PushKeyboardEnhancementFlags(
-                crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                    | crossterm::event::KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
-            )
-        )
-        .unwrap_or_else(|e| {
-            log::error!("Failed to push keyboard enhancement flags: {}", e);
-        });
-    }
+    set_panic_hook();
+    configure_terminal(settings.enable_extended_key_codes);
 
     let app = time_it!("startup: app creation", App::new(settings));
 
     let end_state = app.run();
 
-    restore_terminal(extended_key_codes);
+    restore_terminal();
 
     log::debug!("Final state: {:?}", end_state);
     end_state
@@ -855,7 +812,7 @@ impl<'a> App<'a> {
         let _ = crate::bash_funcs::export_env_var("READLINE_POINT", &current_point);
 
         // 2. Put terminal back into normal mode
-        restore_terminal(extended_key_codes);
+        restore_terminal();
 
         // 3. Execute command using bash FFI function
         if let Err(e) = crate::bash_funcs::evaluate_shell_string(cmd) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -827,9 +827,9 @@ impl<'a> App<'a> {
         restore_terminal();
         // move cursor to column 0 (matching Readline's rl_clear_visible_line)
         // Not sure if this is desireable
-        // let mut stdout = std::io::stdout();
-        // let _ = crossterm::execute!(stdout, crossterm::cursor::MoveToColumn(0));
-        // let _ = std::io::Write::flush(&mut stdout);
+        let mut stdout = std::io::stdout();
+        let _ = crossterm::execute!(stdout, crossterm::cursor::MoveToColumn(0));
+        let _ = std::io::Write::flush(&mut stdout);
 
         // 3. Execute command using bash FFI function
         if let Err(e) = crate::bash_funcs::evaluate_shell_string(cmd) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -807,15 +807,21 @@ impl<'a> App<'a> {
         let extended_key_codes = self.settings.enable_extended_key_codes;
         let mouse_enabled = self.mouse_state.is_enabled();
 
-        // 1. Put terminal back into normal mode
+        // 1. Set READLINE_LINE and READLINE_POINT env vars before running command
+        let current_line = self.buffer.buffer().to_string();
+        let current_point = self.buffer.cursor_byte_pos().to_string();
+        let _ = crate::bash_funcs::export_env_var("READLINE_LINE", &current_line);
+        let _ = crate::bash_funcs::export_env_var("READLINE_POINT", &current_point);
+
+        // 2. Put terminal back into normal mode
         restore_terminal(extended_key_codes);
 
-        // 2. Execute command using bash FFI function
+        // 3. Execute command using bash FFI function
         if let Err(e) = crate::bash_funcs::evaluate_shell_string(cmd) {
             log::error!("Failed to execute bash command '{}': {}", cmd, e);
         }
 
-        // 3. Restore terminal back to the mode it was already in
+        // 4. Restore terminal back to the mode it was already in
         let mut stdout = std::io::stdout();
         let _ = std::io::Write::flush(&mut stdout);
         crossterm::terminal::enable_raw_mode().unwrap_or_else(|e| {
@@ -845,7 +851,18 @@ impl<'a> App<'a> {
             self.mouse_state.enable();
         }
 
-        // 4. Every cell should then get skip = false in the ratatui buffer
+        // 5. Read READLINE_LINE and READLINE_POINT env vars and set text buffer and cursor pos
+        if let Some(new_line) = crate::bash_funcs::get_envvar_value("READLINE_LINE") {
+            self.buffer.replace_buffer(&new_line);
+        }
+        if let Some(new_point_str) = crate::bash_funcs::get_envvar_value("READLINE_POINT") {
+            if let Ok(new_point) = new_point_str.parse::<usize>() {
+                self.buffer.set_cursor_byte_pos(new_point);
+            }
+        }
+        self.on_possible_buffer_change();
+
+        // 6. Every cell should then get skip = false in the ratatui buffer
         if let Some(ref mut drawn) = self.last_contents {
             for row in &mut drawn.contents.buf {
                 for tagged_cell in row {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -825,6 +825,11 @@ impl<'a> App<'a> {
 
         // 2. Put terminal back into normal mode
         restore_terminal();
+        // move cursor to column 0 (matching Readline's rl_clear_visible_line)
+        // Not sure if this is desireable
+        // let mut stdout = std::io::stdout();
+        // let _ = crossterm::execute!(stdout, crossterm::cursor::MoveToColumn(0));
+        // let _ = std::io::Write::flush(&mut stdout);
 
         // 3. Execute command using bash FFI function
         if let Err(e) = crate::bash_funcs::evaluate_shell_string(cmd) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -69,10 +69,6 @@ const IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 const IDLE_FRAME_RATE: f64 = 0.2;
 
 fn restore_terminal() {
-    crossterm::terminal::disable_raw_mode().unwrap_or_else(|e| {
-        // Likely from the master pty fd being closed.
-        log::error!("Failed to disable raw mode: {}", e);
-    });
     crossterm::execute!(
         std::io::stdout(),
         crossterm::event::DisableBracketedPaste,
@@ -84,6 +80,12 @@ fn restore_terminal() {
     )
     .unwrap_or_else(|e| {
         log::error!("Failed to restore terminal features: {}", e);
+    });
+    let mut stdout = std::io::stdout();
+    let _ = std::io::Write::flush(&mut stdout);
+    crossterm::terminal::disable_raw_mode().unwrap_or_else(|e| {
+        // Likely from the master pty fd being closed.
+        log::error!("Failed to disable raw mode: {}", e);
     });
 }
 
@@ -224,7 +226,6 @@ pub fn get_command(settings: &mut Settings) -> ExitState {
     }
 
     set_panic_hook();
-    configure_terminal(settings.enable_extended_key_codes);
 
     let app = time_it!("startup: app creation", App::new(settings));
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -390,6 +390,7 @@ pub(crate) struct App<'a> {
     /// Timestamp of the last draw operation.
     pub(super) last_draw_time: std::time::Instant,
     pub(super) needs_screen_cleared: bool,
+    pub(super) needs_full_redraw: bool,
     /// Last key event, context expression, and action dispatched.
     pub(super) last_key: Option<LastKeyPress>,
     /// Last mouse event received.
@@ -474,6 +475,7 @@ impl<'a> App<'a> {
             settings,
             last_draw_time: std::time::Instant::now(),
             needs_screen_cleared: false,
+            needs_full_redraw: false,
             last_key: None,
             last_mouse: None,
             last_processed_key_sequence: 0,
@@ -614,6 +616,12 @@ impl<'a> App<'a> {
             }
 
             if redraw {
+                if self.needs_full_redraw {
+                    if let Err(e) = terminal.resize(last_terminal_size.into()) {
+                        log::error!("Failed to resync inline viewport after bash command: {}", e);
+                    }
+                }
+
                 let frame_area = terminal.get_frame().area();
 
                 let content =
@@ -622,6 +630,11 @@ impl<'a> App<'a> {
                 let desired_height = if self.needs_screen_cleared {
                     self.needs_screen_cleared = false;
                     last_terminal_size.height
+                } else if self.needs_full_redraw {
+                    last_terminal_size
+                        .height
+                        .saturating_sub(frame_area.y)
+                        .max(content.height())
                 } else {
                     content.height().min(last_terminal_size.height)
                 };
@@ -861,15 +874,7 @@ impl<'a> App<'a> {
             }
         }
         self.on_possible_buffer_change();
-
-        // 6. Every cell should then get skip = false in the ratatui buffer
-        if let Some(ref mut drawn) = self.last_contents {
-            for row in &mut drawn.contents.buf {
-                for tagged_cell in row {
-                    tagged_cell.cell.set_skip(false);
-                }
-            }
-        }
+        self.needs_full_redraw = true;
     }
 
     /// Compute the [`ButtonState`] of an interactive cell with the given `tag`,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -95,6 +95,34 @@ fn restore_terminal(extended_key_codes: bool) {
     }
 }
 
+fn configure_terminal(extended_key_codes: bool) {
+    let mut stdout = std::io::stdout();
+    let _ = std::io::Write::flush(&mut stdout);
+    crossterm::terminal::enable_raw_mode().unwrap_or_else(|e| {
+        log::error!("Failed to enable raw mode: {}", e);
+    });
+    crossterm::execute!(
+        std::io::stdout(),
+        crossterm::event::EnableBracketedPaste,
+        crossterm::event::EnableFocusChange,
+    )
+    .unwrap_or_else(|e| {
+        log::error!("Failed to set terminal features: {}", e);
+    });
+    if extended_key_codes {
+        crossterm::execute!(
+            std::io::stdout(),
+            crossterm::event::PushKeyboardEnhancementFlags(
+                crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                    | crossterm::event::KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
+            )
+        )
+        .unwrap_or_else(|e| {
+            log::error!("Failed to push keyboard enhancement flags: {}", e);
+        });
+    }
+}
+
 fn set_panic_hook(extended_key_codes: bool) {
     let hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -548,7 +576,7 @@ impl<'a> App<'a> {
         });
 
         let mut terminal = time_it!("startup: terminal setup", {
-            crossterm::terminal::enable_raw_mode().unwrap();
+            configure_terminal(self.settings.enable_extended_key_codes);
 
             let terminal = match ratatui::Terminal::with_options(
                 ratatui::backend::CrosstermBackend::new(std::io::stdout()),
@@ -835,31 +863,7 @@ impl<'a> App<'a> {
         }
 
         // 4. Restore terminal back to the mode it was already in
-        let mut stdout = std::io::stdout();
-        let _ = std::io::Write::flush(&mut stdout);
-        crossterm::terminal::enable_raw_mode().unwrap_or_else(|e| {
-            log::error!("Failed to re-enable raw mode: {}", e);
-        });
-        crossterm::execute!(
-            std::io::stdout(),
-            crossterm::event::EnableBracketedPaste,
-            crossterm::event::EnableFocusChange,
-        )
-        .unwrap_or_else(|e| {
-            log::error!("Failed to set terminal features: {}", e);
-        });
-        if extended_key_codes {
-            crossterm::execute!(
-                std::io::stdout(),
-                crossterm::event::PushKeyboardEnhancementFlags(
-                    crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                        | crossterm::event::KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
-                )
-            )
-            .unwrap_or_else(|e| {
-                log::error!("Failed to push keyboard enhancement flags: {}", e);
-            });
-        }
+        configure_terminal(extended_key_codes);
         if mouse_enabled {
             self.mouse_state.enable();
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -803,6 +803,58 @@ impl<'a> App<'a> {
         }
     }
 
+    pub(crate) fn run_bash_command(&mut self, cmd: &str) {
+        let extended_key_codes = self.settings.enable_extended_key_codes;
+        let mouse_enabled = self.mouse_state.is_enabled();
+
+        // 1. Put terminal back into normal mode
+        restore_terminal(extended_key_codes);
+
+        // 2. Execute command using bash FFI function
+        if let Err(e) = crate::bash_funcs::evaluate_shell_string(cmd) {
+            log::error!("Failed to execute bash command '{}': {}", cmd, e);
+        }
+
+        // 3. Restore terminal back to the mode it was already in
+        let mut stdout = std::io::stdout();
+        let _ = std::io::Write::flush(&mut stdout);
+        crossterm::terminal::enable_raw_mode().unwrap_or_else(|e| {
+            log::error!("Failed to re-enable raw mode: {}", e);
+        });
+        crossterm::execute!(
+            std::io::stdout(),
+            crossterm::event::EnableBracketedPaste,
+            crossterm::event::EnableFocusChange,
+        )
+        .unwrap_or_else(|e| {
+            log::error!("Failed to set terminal features: {}", e);
+        });
+        if extended_key_codes {
+            crossterm::execute!(
+                std::io::stdout(),
+                crossterm::event::PushKeyboardEnhancementFlags(
+                    crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                        | crossterm::event::KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
+                )
+            )
+            .unwrap_or_else(|e| {
+                log::error!("Failed to push keyboard enhancement flags: {}", e);
+            });
+        }
+        if mouse_enabled {
+            self.mouse_state.enable();
+        }
+
+        // 4. Every cell should then get skip = false in the ratatui buffer
+        if let Some(ref mut drawn) = self.last_contents {
+            for row in &mut drawn.contents.buf {
+                for tagged_cell in row {
+                    tagged_cell.cell.set_skip(false);
+                }
+            }
+        }
+    }
+
     /// Compute the [`ButtonState`] of an interactive cell with the given `tag`,
     /// based on whether the mouse is hovering it and whether the left mouse
     /// button is currently held down.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -801,18 +801,21 @@ impl<'a> App<'a> {
         }
     }
 
+    /// This is meant to mimic bash_execute_unix_command from bashline.c
     pub(crate) fn run_bash_command(&mut self, cmd: &str) {
         let extended_key_codes = self.settings.enable_extended_key_codes;
         let mouse_enabled = self.mouse_state.is_enabled();
 
         // 1. Export READLINE_* variables before running command
-        let current_line = self.buffer.buffer().to_string();
-        let current_point = self.buffer.cursor_char_offset().to_string();
-        let current_mark = self
+        let selection_was_active = self.buffer.selection_byte().is_some();
+        let initial_mark_char_offset = self
             .buffer
             .selection_char_offset()
-            .unwrap_or_else(|| self.buffer.cursor_char_offset())
-            .to_string();
+            .unwrap_or_else(|| self.buffer.cursor_char_offset());
+
+        let current_line = self.buffer.buffer().to_string();
+        let current_point = self.buffer.cursor_char_offset().to_string();
+        let current_mark = initial_mark_char_offset.to_string();
 
         let _ = crate::bash_funcs::export_env_var("READLINE_LINE", &current_line);
         let _ = crate::bash_funcs::export_env_var("READLINE_POINT", &current_point);
@@ -838,17 +841,35 @@ impl<'a> App<'a> {
             let cleaned_line = new_line.trim_end_matches(['\r', '\n']);
             self.buffer.replace_buffer(cleaned_line);
         }
-        if let Some(new_point_str) = crate::bash_funcs::get_envvar_value("READLINE_POINT") {
-            if let Ok(new_point_char_offset) = new_point_str.parse::<usize>() {
-                let byte_pos = self.buffer.char_to_byte_offset(new_point_char_offset);
-                self.buffer.try_move_cursor_to_byte_pos(byte_pos, true);
-            }
-        }
+
+        let new_point_char_offset =
+            if let Some(new_point_str) = crate::bash_funcs::get_envvar_value("READLINE_POINT") {
+                if let Ok(new_point) = new_point_str.parse::<usize>() {
+                    let byte_pos = self.buffer.char_to_byte_offset(new_point);
+                    self.buffer.try_move_cursor_to_byte_pos(byte_pos, true);
+                    new_point
+                } else {
+                    self.buffer.cursor_char_offset()
+                }
+            } else {
+                self.buffer.cursor_char_offset()
+            };
+
         if let Some(new_mark_str) = crate::bash_funcs::get_envvar_value("READLINE_MARK") {
             if let Ok(new_mark_char_offset) = new_mark_str.parse::<usize>() {
-                let byte_pos = self.buffer.char_to_byte_offset(new_mark_char_offset);
-                self.buffer.set_selection_anchor(byte_pos);
+                if new_mark_char_offset != new_point_char_offset
+                    && (selection_was_active || new_mark_char_offset != initial_mark_char_offset)
+                {
+                    let byte_pos = self.buffer.char_to_byte_offset(new_mark_char_offset);
+                    self.buffer.set_selection_anchor(byte_pos);
+                } else {
+                    self.buffer.clear_selection();
+                }
+            } else {
+                self.buffer.clear_selection();
             }
+        } else {
+            self.buffer.clear_selection();
         }
 
         // 6. Unset READLINE_* variables (matching GNU Readline unbind_readline_variables)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -831,7 +831,7 @@ impl<'a> App<'a> {
         }
         if let Some(new_point_str) = crate::bash_funcs::get_envvar_value("READLINE_POINT") {
             if let Ok(new_point) = new_point_str.parse::<usize>() {
-                self.buffer.set_cursor_byte_pos(new_point);
+                self.buffer.try_move_cursor_to_byte_pos(new_point, true);
             }
         }
         self.on_possible_buffer_change();

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -1515,14 +1515,21 @@ impl<'a> App<'a> {
                 Some(row) => {
                     for (x, tagged_cell) in row.iter().enumerate() {
                         if x < frame_area.width as usize {
+                            let mut cell = tagged_cell.cell.clone();
+                            if self.needs_full_redraw {
+                                cell.set_diff_option(ratatui::buffer::CellDiffOption::AlwaysUpdate);
+                            }
                             frame.buffer_mut().content
-                                [row_idx as usize * frame_area.width as usize + x] =
-                                tagged_cell.cell.clone();
+                                [row_idx as usize * frame_area.width as usize + x] = cell;
                         }
                     }
                 }
                 None => break,
             };
+        }
+
+        if self.needs_full_redraw {
+            self.needs_full_redraw = false;
         }
 
         let drawn_content = DrawnContent {

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -476,8 +476,7 @@ impl<'a> App<'a> {
             }
         }
 
-        if self.mode.is_running()
-            && self.settings.key_debug
+        if self.settings.key_debug
             && let Some(last_key) = &self.last_key
         {
             let actions_str = last_key

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -916,12 +916,14 @@ pub fn evaluate_shell_string(script: &str) -> Result<()> {
     unsafe {
         let script_cstr = std::ffi::CString::new(script)?;
         let allocated_ptr = bash_symbols::locked_xmalloc_cstr(&script_cstr);
-        let from_file_cstr = std::ffi::CString::new("flycomp")?;
+        let from_file_cstr = std::ffi::CString::new("flyline")?;
 
         #[cfg(not(feature = "pre_bash_4_4"))]
-        let flags = bash_symbols::SEVAL_NOHIST | bash_symbols::SEVAL_NOOPTIMIZE;
+        let flags = bash_symbols::SEVAL_NOHIST
+            | bash_symbols::SEVAL_NOOPTIMIZE
+            | bash_symbols::SEVAL_NOTIFY;
         #[cfg(feature = "pre_bash_4_4")]
-        let flags = bash_symbols::SEVAL_NOHIST;
+        let flags = bash_symbols::SEVAL_NOHIST | bash_symbols::SEVAL_NOTIFY;
 
         #[cfg(not(feature = "pre_bash_4_4"))]
         bash_symbols::evalstring(allocated_ptr, from_file_cstr.as_ptr(), flags);

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -925,10 +925,19 @@ pub fn evaluate_shell_string(script: &str) -> Result<()> {
         #[cfg(feature = "pre_bash_4_4")]
         let flags = bash_symbols::SEVAL_NOHIST | bash_symbols::SEVAL_NOTIFY;
 
+        // Save parser state (Bash's save_parser_state(NULL) uses xmalloc to allocate exact sizeof(sh_parser_state_t))
+        let ps_ptr = bash_symbols::save_parser_state(std::ptr::null_mut());
+
         #[cfg(not(feature = "pre_bash_4_4"))]
         bash_symbols::evalstring(allocated_ptr, from_file_cstr.as_ptr(), flags);
         #[cfg(feature = "pre_bash_4_4")]
         bash_symbols::parse_and_execute(allocated_ptr, from_file_cstr.as_ptr(), flags);
+
+        // Restore parser state so expand_aliases and parser_state are preserved
+        if !ps_ptr.is_null() {
+            bash_symbols::restore_parser_state(ps_ptr);
+            libc::free(ps_ptr);
+        }
         Ok(())
     }
 }

--- a/src/bash_symbols.rs
+++ b/src/bash_symbols.rs
@@ -163,6 +163,8 @@ unsafe extern "C" {
     // from shell.h
     pub static interactive: c_int;
     pub static interactive_shell: c_int;
+    pub fn save_parser_state(ps: *mut libc::c_void) -> *mut libc::c_void;
+    pub fn restore_parser_state(ps: *mut libc::c_void);
 
     // from shell.h
     pub static no_line_editing: c_int;

--- a/src/bash_symbols.rs
+++ b/src/bash_symbols.rs
@@ -7,6 +7,7 @@ pub const BUILTIN_ENABLED: c_int = 0x01;
 
 pub const SEVAL_NOHIST: c_int = 0x004;
 pub const SEVAL_NOOPTIMIZE: c_int = 0x400;
+pub const SEVAL_NOTIFY: c_int = 0x800;
 
 /* A structure which represents a word. */
 // typedef struct word_desc {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,12 +226,6 @@ impl Flyline {
 
         if let Some(byte) = self.content.get(self.position) {
             self.position += 1;
-            log::info!(
-                "Returning byte {} (char '{}') at position {}",
-                *byte,
-                *byte as char,
-                self.position - 1
-            );
             *byte as c_int
         } else {
             log::info!("End of input stream reached, returning EOF");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,7 @@ impl Flyline {
                             self.settings.run_tutorial = false;
                         }
                     }
+
                     cmd.into_bytes()
                 }
                 app::ExitState::EOF => {
@@ -225,6 +226,12 @@ impl Flyline {
 
         if let Some(byte) = self.content.get(self.position) {
             self.position += 1;
+            log::info!(
+                "Returning byte {} (char '{}') at position {}",
+                *byte,
+                *byte as char,
+                self.position - 1
+            );
             *byte as c_int
         } else {
             log::info!("End of input stream reached, returning EOF");

--- a/src/prompt_manager.rs
+++ b/src/prompt_manager.rs
@@ -1332,14 +1332,13 @@ impl PromptManager {
         widgets: &[PromptWidget],
         last_app_closed_at: Option<std::time::Instant>,
     ) -> Self {
-
         let dim_style = Style::default().add_modifier(ratatui::style::Modifier::DIM);
         let default_ps2 = vec![
             PromptSegment::WidgetBufferLineNumber {
                 base_style: dim_style,
             },
             PromptSegment::Static(Span::styled("∙", dim_style)),
-        ];  
+        ];
         if unfinished_from_prev_command {
             // If the previous command was unfinished, use a simple prompt to avoid confusion
 
@@ -1440,7 +1439,6 @@ impl PromptManager {
                     log::warn!("Failed to parse PS1, defaulting to '{}'", PS1_DEFAULT);
                     vec![vec![PromptSegment::Static(Span::raw(PS1_DEFAULT))]]
                 });
-
 
             let ps2 = bash_funcs::get_envvar_value("PS2")
                 .filter(|raw| raw != "> ")

--- a/src/text_buffer.rs
+++ b/src/text_buffer.rs
@@ -613,14 +613,11 @@ impl TextBuffer {
             return;
         }
 
-        if byte_pos <= self.buf.len() {
-            // Round up to next char boundary if not already on one
-            let mut pos = byte_pos;
-            while pos <= self.buf.len() && !self.buf.is_char_boundary(pos) {
-                pos += 1;
-            }
-            self.cursor_byte = pos;
+        let mut pos = byte_pos.min(self.buf.len());
+        while pos > 0 && !self.buf.is_char_boundary(pos) {
+            pos -= 1;
         }
+        self.cursor_byte = pos;
     }
 }
 
@@ -1809,15 +1806,6 @@ impl TextBuffer {
 
     pub fn cursor_byte_pos(&self) -> usize {
         self.cursor_byte
-    }
-
-    pub fn set_cursor_byte_pos(&mut self, pos: usize) {
-        let clamped = pos.min(self.buf.len());
-        let mut valid_pos = clamped;
-        while valid_pos > 0 && !self.buf.is_char_boundary(valid_pos) {
-            valid_pos -= 1;
-        }
-        self.cursor_byte = valid_pos;
     }
 }
 

--- a/src/text_buffer.rs
+++ b/src/text_buffer.rs
@@ -117,6 +117,16 @@ impl TextBuffer {
         self.selection_byte
     }
 
+    /// Set the selection anchor byte position (bounded to UTF-8 character boundary).
+    pub fn set_selection_anchor(&mut self, pos: usize) {
+        let clamped = pos.min(self.buf.len());
+        let mut valid_pos = clamped;
+        while valid_pos > 0 && !self.buf.is_char_boundary(valid_pos) {
+            valid_pos -= 1;
+        }
+        self.selection_byte = Some(valid_pos);
+    }
+
     /// Returns the byte range of the current selection, sorted so that
     /// `start <= end`. Returns `None` when no selection is active or when the
     /// selection is empty (anchor equal to cursor).
@@ -1806,6 +1816,31 @@ impl TextBuffer {
 
     pub fn cursor_byte_pos(&self) -> usize {
         self.cursor_byte
+    }
+
+    /// Convert a byte offset in `buf` to a character count (matching Readline's `readline_get_char_offset`).
+    pub fn byte_to_char_offset(&self, byte_offset: usize) -> usize {
+        let clamped = byte_offset.min(self.buf.len());
+        self.buf[..clamped].chars().count()
+    }
+
+    /// Convert a character count into a byte index in `buf` (matching Readline's `readline_set_char_offset`).
+    pub fn char_to_byte_offset(&self, char_offset: usize) -> usize {
+        self.buf
+            .char_indices()
+            .nth(char_offset)
+            .map(|(byte_idx, _)| byte_idx)
+            .unwrap_or(self.buf.len())
+    }
+
+    /// Returns the current cursor position as a character offset.
+    pub fn cursor_char_offset(&self) -> usize {
+        self.byte_to_char_offset(self.cursor_byte)
+    }
+
+    /// Returns the current selection anchor position as a character offset.
+    pub fn selection_char_offset(&self) -> Option<usize> {
+        self.selection_byte.map(|b| self.byte_to_char_offset(b))
     }
 }
 

--- a/src/text_buffer.rs
+++ b/src/text_buffer.rs
@@ -1810,6 +1810,15 @@ impl TextBuffer {
     pub fn cursor_byte_pos(&self) -> usize {
         self.cursor_byte
     }
+
+    pub fn set_cursor_byte_pos(&mut self, pos: usize) {
+        let clamped = pos.min(self.buf.len());
+        let mut valid_pos = clamped;
+        while valid_pos > 0 && !self.buf.is_char_boundary(valid_pos) {
+            valid_pos -= 1;
+        }
+        self.cursor_byte = valid_pos;
+    }
 }
 
 mod test_accessors {


### PR DESCRIPTION
This adds the `runBashCommand` actions so that users can run fzf, atuin, etc to help them write commands.
See the readme for more details on how to use it.