### PR TITLE
implement nix module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,11 @@
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
     in
     {
+      nixosModules = {
+        flyline = import ./nix/module.nix;
+        default = self.nixosModules.flyline;
+      };
+
       packages = forAllSystems (pkgs: rec {
         flyline = pkgs.callPackage ./nix/package.nix { };
         default = flyline;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.flyline;
+
+  inherit (lib.options) mkEnableOption;
+  inherit (lib.modules) mkIf;
+
+  flyline = pkgs.callPackage ./package.nix { };
+in
+{
+  options.programs.flyline.enable = mkEnableOption "flyline integration into bash shell";
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ flyline ];
+
+    programs.bash.interactiveShellInit = ''
+      enable -f ${flyline}/lib/libflyline.so flyline
+    '';
+  };
+}


### PR DESCRIPTION
Installation of flyline on a NixOS system isn't immediately clear, as "the nix way" tries to avoid any sort of external non declarative setup like calling a script.

This just creates a simple module that will auto install flyline to a users bash shell declaratively.