### PR TITLE
fix(agent): reset SIGCHLD before spawning process

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1442,8 +1442,10 @@ impl<'a> App<'a> {
         let flycomp_settings = self.settings.flycomp.clone();
         let shared_handle =
             crate::threads::spawn_thread(crate::threads::ThreadTag::Flycomp, move || {
+                let mut new_action: libc::sigaction = unsafe { std::mem::zeroed() };
+                new_action.sa_sigaction = libc::SIG_DFL as libc::sighandler_t as usize;
                 unsafe {
-                    libc::signal(libc::SIGCHLD, libc::SIG_DFL);
+                    libc::sigaction(libc::SIGCHLD, &new_action, std::ptr::null_mut());
                 }
                 flycomp::generate_completion_output_with_settings(
                     &cmd_word,
@@ -1568,8 +1570,16 @@ impl<'a> App<'a> {
         // Safety: the guard `!ai_command.is_empty()` at the call site ensures
         // cmd_args is non-empty, so split_first() always returns Some.
         let (prog, args) = cmd_args.split_first().expect("ai_command is non-empty");
-        // SIGCHLD was already set to SIG_DFL by `Flyline::get()` before calling
-        // `app::get_command`, so no per-process signal manipulation is needed.
+        // Reset SIGCHLD to SIG_DFL just before spawning the agent.
+        // Command substitution in prompt parsing (e.g. `$(__git_ps1)`) executes
+        // Bash code that reinstalls Bash's SIGCHLD handler, undoing the initial
+        // setup in `Flyline::get()`. Without this, Bash's handler will intercept
+        // the child's exit and reap it, causing try_wait() to fail with ECHILD.
+        let mut new_action: libc::sigaction = unsafe { std::mem::zeroed() };
+        new_action.sa_sigaction = libc::SIG_DFL as libc::sighandler_t as usize;
+        unsafe {
+            libc::sigaction(libc::SIGCHLD, &new_action, std::ptr::null_mut());
+        }
         match std::process::Command::new(prog)
             .args(args)
             .arg(&final_arg)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,13 +181,20 @@ impl Flyline {
             // put the original disposition back once the app exits.
             // SAFETY: signal(2) only modifies the signal disposition; no other
             // thread depends on SIGCHLD disposition at this instant.
-            let prev_sigchld = unsafe { libc::signal(libc::SIGCHLD, libc::SIG_DFL) };
+            let mut prev_sigaction: libc::sigaction = unsafe { std::mem::zeroed() };
+            let mut new_sigaction: libc::sigaction = unsafe { std::mem::zeroed() };
+            new_sigaction.sa_sigaction = libc::SIG_DFL as libc::sighandler_t as usize;
+            unsafe {
+                libc::sigaction(libc::SIGCHLD, &new_sigaction, &mut prev_sigaction);
+            }
 
             let result = app::get_command(&mut self.settings);
 
             self.settings.last_app_closed_at = Some(std::time::Instant::now());
 
-            unsafe { libc::signal(libc::SIGCHLD, prev_sigchld) };
+            unsafe {
+                libc::sigaction(libc::SIGCHLD, &prev_sigaction, std::ptr::null_mut());
+            }
 
             // Join the background cache warming thread before returning control to Bash.
             // This ensures that no background Rust threads are running or calling Bash FFI

--- a/src/prompt_manager.rs
+++ b/src/prompt_manager.rs
@@ -237,6 +237,13 @@ fn expand_prompt_through_bash(raw: String) -> Option<Vec<Line<'static>>> {
         // `decode_prompt_string` returns an allocated buffer.
         bash_symbols::locked_xfree(decoded_prompt_cstr as *mut std::ffi::c_void);
 
+        // Command substitution `$(...)` inside `decode_prompt_string` evaluates
+        // Bash code that reinstalls Bash's SIGCHLD handler. We must reset it
+        // back to SIG_DFL so we don't accidentally leave Bash's handler active.
+        let mut new_action: libc::sigaction = std::mem::zeroed();
+        new_action.sa_sigaction = libc::SIG_DFL as libc::sighandler_t as usize;
+        libc::sigaction(libc::SIGCHLD, &new_action, std::ptr::null_mut());
+
         decoded
     };
 


### PR DESCRIPTION
Bash  executes command substitutions like
 which reinstall Bash's own SIGCHLD handler,
overwriting the SIG_DFL set during initialization. This caused Bash to reap agent processes, failing  with ECHILD.

- Reset SIGCHLD to SIG_DFL immediately before
- Reset SIGCHLD after  returns
- Replace  with  to guarantee SA_NOCLDWAIT is cleared across all platforms

Related to issue #870 