### PR TITLE
Possible background thread crash fix

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -393,6 +393,7 @@ impl<'a> App<'a> {
         // Join any previous warming thread to prevent multiple active warming threads
         crate::threads::join_bash_func_threads();
 
+        let path_env = bash_funcs::get_envvar_value("PATH");
         let _ = crate::threads::spawn_thread(crate::threads::ThreadTag::Warming, || {
             let _timer = crate::perf::PerfTimer::start("warming_thread_bash");
             let start = std::time::Instant::now();
@@ -400,7 +401,6 @@ impl<'a> App<'a> {
             log::info!("Warming bash caches finished in {:?}", start.elapsed());
         });
 
-        let path_env = bash_funcs::get_envvar_value("PATH");
         let _ = crate::threads::spawn_thread(crate::threads::ThreadTag::PathWarming, move || {
             let _timer = crate::perf::PerfTimer::start("warming_thread_path");
             let start = std::time::Instant::now();

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -512,30 +512,30 @@ pub fn get_all_shell_functions() -> Vec<String> {
     let mut functions = Vec::new();
 
     unsafe {
-        let func_ptr = bash_symbols::all_shell_functions();
-        if func_ptr.is_null() {
+        let table_ptr = bash_symbols::shell_functions;
+        if table_ptr.is_null() {
             return functions;
         }
 
-        let mut offset = 0;
-        loop {
-            let ptr = *func_ptr.add(offset);
-            if ptr.is_null() {
-                break;
-            }
-            let shell_var = &*ptr;
-            if !shell_var.name.is_null() {
-                let c_str = std::ffi::CStr::from_ptr(shell_var.name);
-                if let Ok(str_slice) = c_str.to_str() {
-                    functions.push(str_slice.to_string());
-                }
-            }
-            offset += 1;
+        let table = &*table_ptr;
+        if table.bucket_array.is_null() || table.nbuckets <= 0 {
+            return functions;
         }
-        bash_symbols::locked_xfree(func_ptr as *mut libc::c_void);
+
+        for i in 0..table.nbuckets as isize {
+            let mut bucket_ptr = *table.bucket_array.offset(i);
+            while !bucket_ptr.is_null() {
+                let item = &*bucket_ptr;
+                if !item.key.is_null() {
+                    if let Ok(name) = std::ffi::CStr::from_ptr(item.key).to_str() {
+                        functions.push(name.to_string());
+                    }
+                }
+                bucket_ptr = item.next;
+            }
+        }
     }
 
-    // log::debug!("Found shell functions: {:?}", functions);
     functions
 }
 

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -430,6 +430,7 @@ pub fn get_all_aliases() -> Vec<String> {
             }
             offset += 1;
         }
+        bash_symbols::locked_xfree(alias_ptr as *mut libc::c_void);
     }
 
     aliases
@@ -468,6 +469,7 @@ pub fn get_all_variables_with_prefix(prefix: &str) -> Vec<String> {
         }
 
         let mut offset = 0;
+        let mut ptrs_to_free = Vec::new();
         loop {
             let ptr = *var_ptr.add(offset);
             if ptr.is_null() {
@@ -477,8 +479,13 @@ pub fn get_all_variables_with_prefix(prefix: &str) -> Vec<String> {
             if let Ok(str_slice) = c_str.to_str() {
                 variables.push(format!("${}", str_slice));
             }
+            ptrs_to_free.push(ptr);
             offset += 1;
         }
+        for str_ptr in ptrs_to_free {
+            bash_symbols::locked_xfree(str_ptr as *mut libc::c_void);
+        }
+        bash_symbols::locked_xfree(var_ptr as *mut libc::c_void);
     }
 
     log::debug!("Found variables with prefix '{}': {:?}", prefix, variables);
@@ -525,6 +532,7 @@ pub fn get_all_shell_functions() -> Vec<String> {
             }
             offset += 1;
         }
+        bash_symbols::locked_xfree(func_ptr as *mut libc::c_void);
     }
 
     // log::debug!("Found shell functions: {:?}", functions);

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -2021,6 +2021,7 @@ pub fn export_env_var(name: &str, value: &str) -> Result<()> {
 
 #[cfg(not(test))]
 pub fn unset_env_var(name: &str) -> Result<()> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     unsafe {
         let name_cstr = std::ffi::CString::new(name)?;
         let res = bash_symbols::unbind_variable(name_cstr.as_ptr());

--- a/src/bash_funcs.rs
+++ b/src/bash_funcs.rs
@@ -1263,6 +1263,7 @@ pub fn get_shell_var(var_name: &str) -> Option<ShellVar> {
 
 #[cfg(not(test))]
 pub fn get_envvar_value(var_name: &str) -> Option<String> {
+    let _guard = crate::bash_symbols::BASH_LOCK.lock();
     get_shell_var(var_name).and_then(|var| var.get_value())
 }
 

--- a/src/bash_symbols.rs
+++ b/src/bash_symbols.rs
@@ -124,6 +124,26 @@ pub struct StreamSaver {
     pub bstream: *mut BufferedStream,
 }
 
+// hashlib.h BUCKET_CONTENTS
+#[repr(C)]
+#[allow(dead_code)]
+pub struct BucketContents {
+    pub next: *mut BucketContents,
+    pub key: *const c_char,
+    pub data: *mut libc::c_void,
+    pub khash: c_uint,
+    pub times_found: c_int,
+}
+
+// hashlib.h HASH_TABLE
+#[repr(C)]
+#[allow(dead_code)]
+pub struct HashTable {
+    pub bucket_array: *mut *mut BucketContents,
+    pub nbuckets: c_int,
+    pub nentries: c_int,
+}
+
 // builtins/common.h
 // /* Flags for describe_command, shared between type.def and command.def */
 #[allow(dead_code)]
@@ -321,6 +341,9 @@ unsafe extern "C" {
 
     // extern SHELL_VAR **all_shell_functions (void);
     pub fn all_shell_functions() -> *mut *mut ShellVar;
+
+    #[link_name = "shell_functions"]
+    pub static mut shell_functions: *mut HashTable;
 
     // extern struct builtin *shell_builtins;
     #[link_name = "shell_builtins"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,11 +368,7 @@ fn flyline_load_common() -> c_int {
         );
 
         let load_dir_var = "FLYLINE_LOAD_DIR";
-        let is_load_dir_set = unsafe {
-            let name_cstr = std::ffi::CString::new(load_dir_var).unwrap();
-            let var = bash_symbols::find_variable(name_cstr.as_ptr());
-            !var.is_null()
-        };
+        let is_load_dir_set = bash_funcs::get_envvar_value(load_dir_var).is_some();
 
         if !is_load_dir_set {
             if let Some(path) = get_library_directory() {


### PR DESCRIPTION
The crash might occur inside bash's `vlist_add()` during `all_shell_functions()`, when `STREQ(var->name, ...)` dereferences an uninitialized or NULL function name pointer.

I wasnt able to reproduce the bug locally. But I have implemented a manual walk of the shell functions hash table. This allows us to bypass bash's code. Hopefully this fixes it.

`get_envvar_value` didnt hold the bash lock. So this could cause a problem.