### PR TITLE
Move mouse state to global static and clean up enable/disable / restore

### DIFF
--- a/src/app/actions/keyboard.rs
+++ b/src/app/actions/keyboard.rs
@@ -3246,10 +3246,10 @@ impl<'a> App<'a> {
             .as_ref()
             .is_some_and(|(actions, _)| !actions.contains(&KeyEventAction::ToggleMouse))
             && self.settings.mouse_mode == MouseMode::Smart
-            && self.mouse_state.is_disabled()
+            && crate::mouse_state::mouse_state(|m| m.is_disabled())
         {
             log::debug!("Reenabling mouse due to key event");
-            self.mouse_state.enable();
+            crate::mouse_state::mouse_state(|m| m.enable());
         }
 
         // If the leader key was active before this key event, and was not refreshed or updated

--- a/src/app/actions/mouse.rs
+++ b/src/app/actions/mouse.rs
@@ -1,7 +1,7 @@
 use crate::app::actions::{ContextExpr, ContextLiteral, KeyEventAction};
 use crate::app::{App, AppRunningState, ContentMode, ExitState, FlycompPromptSelection};
 use crate::content_builder::Tag;
-use crate::mouse_state::{ClickCount, PointerShape};
+use crate::mouse_state::{ClickCount, MouseState, PointerShape, mouse_state};
 use crate::settings::MouseMode;
 use std::sync::LazyLock;
 use termina::event::{
@@ -174,8 +174,8 @@ pub enum MouseContextVar {
 impl super::ContextVar for MouseContextVar {
     fn evaluate(&self, app: &App) -> bool {
         let last_mouse = app.last_mouse.as_ref().map(|lm| lm.mouse);
-        let clicked_tag = app.mouse_state.last_mouse_over_cell_semantic;
-        let direct_tag = app.mouse_state.last_mouse_over_cell_direct;
+        let clicked_tag = mouse_state(|m| m.last_mouse_over_cell_semantic);
+        let direct_tag = mouse_state(|m| m.last_mouse_over_cell_direct);
 
         match self {
             MouseContextVar::Always => true,
@@ -203,8 +203,8 @@ impl super::ContextVar for MouseContextVar {
             MouseContextVar::LeftButtonClickedUp => {
                 last_mouse.is_some_and(|m| matches!(m.kind, MouseEventKind::Up(MouseButton::Left)))
             }
-            MouseContextVar::LeftButtonIsDown => app.mouse_state.is_left_button_down(),
-            MouseContextVar::LeftButtonIsUp => !app.mouse_state.is_left_button_down(),
+            MouseContextVar::LeftButtonIsDown => mouse_state(|m| m.is_left_button_down()),
+            MouseContextVar::LeftButtonIsUp => !mouse_state(|m| m.is_left_button_down()),
             MouseContextVar::RightButtonClickedDown => last_mouse
                 .is_some_and(|m| matches!(m.kind, MouseEventKind::Down(MouseButton::Right))),
             MouseContextVar::RightButtonClickedUp => {
@@ -262,39 +262,45 @@ impl super::ContextVar for MouseContextVar {
                 clicked_tag,
                 Some(Tag::HistoryResult(_)) | Some(Tag::FuzzySearch)
             ),
-            MouseContextVar::ScrollBarDrag => {
-                matches!(
-                    app.mouse_state.drag_start_tag,
-                    Some(Tag::TabCompletionScrollBar { .. })
-                ) && (app.mouse_state.is_left_button_down()
-                    || last_mouse
-                        .is_some_and(|m| matches!(m.kind, MouseEventKind::Drag(MouseButton::Left))))
-            }
+            MouseContextVar::ScrollBarDrag => mouse_state(|m| {
+                matches!(m.drag_start_tag, Some(Tag::TabCompletionScrollBar { .. }))
+                    && (m.is_left_button_down()
+                        || last_mouse.is_some_and(|m| {
+                            matches!(m.kind, MouseEventKind::Drag(MouseButton::Left))
+                        }))
+            }),
             MouseContextVar::RightClickPopupActive => app.right_click_popup_pos.is_some(),
-            MouseContextVar::RightReleaseDismiss => {
-                last_mouse.is_some_and(|m| {
-                    matches!(m.kind, MouseEventKind::Up(MouseButton::Right))
-                        && app.mouse_state.right_click_down_pos.is_some_and(
-                            |(start_row, start_col)| (m.row, m.column) != (start_row, start_col),
-                        )
-                })
+            MouseContextVar::RightReleaseDismiss => last_mouse.is_some_and(|m| {
+                matches!(m.kind, MouseEventKind::Up(MouseButton::Right))
+                    && mouse_state(|m_st| {
+                        m_st.right_click_down_pos
+                            .is_some_and(|(start_row, start_col)| {
+                                (m.row, m.column) != (start_row, start_col)
+                            })
+                    })
+            }),
+            MouseContextVar::SingleClick => {
+                mouse_state(|m| m.get_click_count()) == ClickCount::Single
             }
-            MouseContextVar::SingleClick => app.mouse_state.get_click_count() == ClickCount::Single,
-            MouseContextVar::DoubleClick => app.mouse_state.get_click_count() == ClickCount::Double,
-            MouseContextVar::TripleClick => app.mouse_state.get_click_count() == ClickCount::Triple,
-            MouseContextVar::QuadClick => app.mouse_state.get_click_count() == ClickCount::Quad,
+            MouseContextVar::DoubleClick => {
+                mouse_state(|m| m.get_click_count()) == ClickCount::Double
+            }
+            MouseContextVar::TripleClick => {
+                mouse_state(|m| m.get_click_count()) == ClickCount::Triple
+            }
+            MouseContextVar::QuadClick => mouse_state(|m| m.get_click_count()) == ClickCount::Quad,
             MouseContextVar::DragStartCommand => {
-                matches!(app.mouse_state.drag_start_tag, Some(Tag::Command(_)))
+                mouse_state(|m| matches!(m.drag_start_tag, Some(Tag::Command(_))))
             }
             MouseContextVar::DragStartPointerTarget => is_pointer_target_tag(
-                app.mouse_state.drag_start_tag,
+                mouse_state(|m| m.drag_start_tag),
                 app.right_click_popup_pos.is_some(),
             ),
             MouseContextVar::IsPointerTarget => is_pointer_target_tag(
-                app.mouse_state.last_mouse_over_cell_direct,
+                mouse_state(|m| m.last_mouse_over_cell_direct),
                 app.right_click_popup_pos.is_some(),
             ),
-            MouseContextVar::IsMouseScrolling => app.mouse_state.is_mouse_scrolling(),
+            MouseContextVar::IsMouseScrolling => mouse_state(|m| m.is_mouse_scrolling()),
         }
     }
 
@@ -831,9 +837,9 @@ pub static DEFAULT_POINTER_SHAPE_BINDINGS: LazyLock<Vec<MouseBinding>> = LazyLoc
 
 impl MouseEventAction {
     pub(crate) fn run(&self, app: &mut App, mouse: MouseEvent) -> MouseActionOutput {
-        let clicked_tag = app.mouse_state.last_mouse_over_cell_semantic;
+        let clicked_tag = mouse_state(|m| m.last_mouse_over_cell_semantic);
         let move_past_final = !matches!(
-            app.mouse_state.last_mouse_over_cell_direct,
+            mouse_state(|m| m.last_mouse_over_cell_direct),
             Some(Tag::Command(_))
         );
 
@@ -910,7 +916,7 @@ impl MouseEventAction {
                 MouseActionOutput::dont_update()
             }
             MouseEventAction::ScrollSuggestionsBar => {
-                let active_drag_tag = app.mouse_state.drag_start_tag;
+                let active_drag_tag = mouse_state(|m| m.drag_start_tag);
                 if let Some(Tag::TabCompletionScrollBar {
                     max_cell_height,
                     y_start,
@@ -1107,7 +1113,7 @@ impl MouseEventAction {
             MouseEventAction::DragCommand => {
                 if let Some(Tag::Command(byte_pos)) = clicked_tag {
                     if app.settings.select_with_mouse {
-                        let active_drag_tag = app.mouse_state.drag_start_tag;
+                        let active_drag_tag = mouse_state(|m| m.drag_start_tag);
                         if matches!(active_drag_tag, Some(Tag::Command(_))) {
                             app.buffer.start_selection_if_none();
 
@@ -1127,10 +1133,10 @@ impl MouseEventAction {
             MouseEventAction::DragWord => {
                 if let Some(Tag::Command(byte_pos)) = clicked_tag {
                     if app.settings.select_with_mouse {
-                        let active_drag_tag = app.mouse_state.drag_start_tag;
+                        let active_drag_tag = mouse_state(|m| m.drag_start_tag);
                         if matches!(active_drag_tag, Some(Tag::Command(_))) {
                             if let Some(drag_start_pos) =
-                                app.mouse_state.get_last_click_buffer_pos()
+                                mouse_state(|m| m.get_last_click_buffer_pos())
                             {
                                 app.buffer
                                     .try_move_cursor_to_byte_pos(drag_start_pos, move_past_final);
@@ -1159,10 +1165,10 @@ impl MouseEventAction {
             MouseEventAction::DragLine => {
                 if let Some(Tag::Command(byte_pos)) = clicked_tag {
                     if app.settings.select_with_mouse {
-                        let active_drag_tag = app.mouse_state.drag_start_tag;
+                        let active_drag_tag = mouse_state(|m| m.drag_start_tag);
                         if matches!(active_drag_tag, Some(Tag::Command(_))) {
                             if let Some(drag_start_pos) =
-                                app.mouse_state.get_last_click_buffer_pos()
+                                mouse_state(|m| m.get_last_click_buffer_pos())
                             {
                                 app.buffer
                                     .try_move_cursor_to_byte_pos(drag_start_pos, move_past_final);
@@ -1319,9 +1325,11 @@ impl MouseEventAction {
             }
             MouseEventAction::DisableMouseCapture => {
                 log::debug!("Disabling mouse capture due to viewport event in smart mode");
-                app.mouse_state.disable();
-                app.mouse_state.last_mouse_over_cell_semantic = None;
-                app.mouse_state.last_mouse_over_cell_direct = None;
+                mouse_state(|m| m.disable());
+                mouse_state(|m| {
+                    m.last_mouse_over_cell_semantic = None;
+                    m.last_mouse_over_cell_direct = None;
+                });
                 MouseActionOutput::dont_update()
             }
             MouseEventAction::RightClickMenuOpen => {
@@ -1337,8 +1345,7 @@ impl MouseEventAction {
                     content_row,
                     mouse.column,
                 ));
-                app.mouse_state
-                    .set_right_click_down_pos(mouse.row, mouse.column);
+                mouse_state(|m| m.set_right_click_down_pos(mouse.row, mouse.column));
 
                 let target = match clicked_tag {
                     Some(Tag::Suggestion(idx)) => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -42,7 +42,7 @@ use crate::dparser::{AnnotatedToken, ToInclusiveRange};
 use crate::history::{HistoryEntry, HistoryEntryFormatted, HistoryManager};
 use crate::iter_first_last::FirstLast;
 use crate::kill_on_drop_child::KillOnDropChild;
-use crate::mouse_state::{MouseState, PointerShape, XtShiftEscape};
+use crate::mouse_state::{MouseState, mouse_state};
 use crate::palette::{ButtonState, Palette};
 use crate::prompt_manager::PromptManager;
 use crate::settings::{self, MatrixAnimation, MouseMode, Settings};
@@ -91,21 +91,16 @@ fn restore_terminal(write: &mut impl std::io::Write) {
     let reset = |code| Csi::Mode(DecMode::ResetDecPrivateMode(DecPrivateMode::Code(code)));
     let _ = write!(
         write,
-        "{}{}{}{}{}{}{}{}{}",
+        "{}{}{}",
         reset(DecPrivateModeCode::BracketedPaste),
         reset(DecPrivateModeCode::FocusTracking),
-        reset(DecPrivateModeCode::SGRMouse),
-        reset(DecPrivateModeCode::AnyEventMouse),
-        reset(DecPrivateModeCode::ButtonEventMouse),
-        reset(DecPrivateModeCode::MouseTracking),
-        XtShiftEscape::Disable,
-        PointerShape::Default,
         Csi::Keyboard(Keyboard::PopFlags(1))
     );
+    mouse_state(|m| m.disable());
     let _ = write.flush();
 }
 
-fn configure_terminal(extended_key_codes: bool) {
+fn configure_terminal(extended_key_codes: bool, mouse_mode: &crate::settings::MouseMode) {
     let set_mode = |code| Csi::Mode(DecMode::SetDecPrivateMode(DecPrivateMode::Code(code)));
 
     let flags = if extended_key_codes {
@@ -121,6 +116,8 @@ fn configure_terminal(extended_key_codes: bool) {
         set_mode(DecPrivateModeCode::BracketedPaste),
         Csi::Keyboard(Keyboard::PushFlags(flags))
     );
+
+    MouseState::enable_mode(mouse_mode);
 }
 
 fn stdin_unavailable_reason() -> Option<&'static str> {
@@ -351,7 +348,6 @@ pub(crate) struct App<'a> {
     pub(super) dismissed_tab_completion_wuc: Option<String>,
     /// Buffer contents at the time the user last dismissed the agent prompts fuzzy history search.
     pub(super) dismissed_agent_mode_buffer: Option<String>,
-    pub(super) mouse_state: MouseState,
     pub(super) content_mode: ContentMode,
     pub(super) last_contents: Option<DrawnContent>,
     pub(super) tooltip: Option<String>,
@@ -412,7 +408,7 @@ impl<'a> App<'a> {
                 termina::PlatformTerminal::with_reader(event_reader).unwrap();
             platform_terminal.enter_raw_mode().unwrap();
             platform_terminal.set_panic_hook(|write| restore_terminal(write));
-            configure_terminal(settings.enable_extended_key_codes);
+            configure_terminal(settings.enable_extended_key_codes, &settings.mouse_mode);
 
             let backend = ratatui::backend::TerminaBackend::new(platform_terminal);
             use ratatui::backend::Backend;
@@ -491,10 +487,6 @@ impl<'a> App<'a> {
             dismissed_inline_suggestion_buffer: None,
             dismissed_tab_completion_wuc: None,
             dismissed_agent_mode_buffer: None,
-            mouse_state: time_it!(
-                "startup: mouse state",
-                MouseState::initialize(&settings.mouse_mode)
-            ),
             content_mode: ContentMode::Normal,
             last_contents: None,
             tooltip: None,
@@ -812,10 +804,10 @@ impl<'a> App<'a> {
                 let show_terminal_cursor = (self.settings.cursor_config.backend()
                     == crate::cursor::CursorBackend::Terminal
                     || !self.mode.is_running())
-                    && !(self.mouse_state.is_left_button_down()
+                    && !(mouse_state(|m| m.is_left_button_down())
                         && self.buffer.selection_range().is_some()
                         && matches!(
-                            self.mouse_state.last_mouse_over_cell_semantic,
+                            mouse_state(|m| m.last_mouse_over_cell_semantic),
                             Some(Tag::Command(_))
                         ));
                 let needs_full_redraw = self.needs_full_redraw;
@@ -1024,7 +1016,7 @@ impl<'a> App<'a> {
                                 log::debug!(
                                     "Enabling mouse capture due to terminal focus gain in smart mode"
                                 );
-                                self.mouse_state.enable();
+                                mouse_state(|m| m.enable());
                             }
                             false
                         }
@@ -1106,17 +1098,19 @@ impl<'a> App<'a> {
     }
 
     fn toggle_mouse_state(&mut self) {
-        self.mouse_state.toggle();
-        if !self.mouse_state.is_enabled() {
-            self.mouse_state.last_mouse_over_cell_semantic = None;
-            self.mouse_state.last_mouse_over_cell_direct = None;
+        mouse_state(|m| m.toggle());
+        if mouse_state(|m| m.is_disabled()) {
+            mouse_state(|m| {
+                m.last_mouse_over_cell_semantic = None;
+                m.last_mouse_over_cell_direct = None;
+            });
         }
     }
 
     /// This is meant to mimic bash_execute_unix_command from bashline.c
     pub(crate) fn run_bash_command(&mut self, cmd: &str) {
-        let mouse_enabled = self.mouse_state.is_enabled();
-        self.mouse_state.disable();
+        let mouse_enabled = mouse_state(|m| m.is_enabled());
+        mouse_state(|m| m.disable());
 
         // 1. Export READLINE_* variables before running command
         let selection_was_active = self.buffer.selection_byte().is_some();
@@ -1158,9 +1152,12 @@ impl<'a> App<'a> {
         if let Err(e) = self.terminal.backend_mut().terminal_mut().enter_raw_mode() {
             log::error!("Failed to re-enter raw mode after bash command: {}", e);
         }
-        configure_terminal(self.settings.enable_extended_key_codes);
+        configure_terminal(
+            self.settings.enable_extended_key_codes,
+            &self.settings.mouse_mode,
+        );
         if mouse_enabled {
-            self.mouse_state.enable();
+            mouse_state(|m| m.enable());
         }
 
         self.sync_viewport_top_from_cpr();
@@ -1214,9 +1211,9 @@ impl<'a> App<'a> {
     /// based on whether the mouse is hovering it and whether the left mouse
     /// button is currently held down.
     fn button_state_for(&self, tag: Tag) -> ButtonState {
-        if self.mouse_state.last_mouse_over_cell_semantic != Some(tag) {
+        if mouse_state(|m| m.last_mouse_over_cell_semantic) != Some(tag) {
             ButtonState::Normal
-        } else if self.mouse_state.is_left_button_down() {
+        } else if mouse_state(|m| m.is_left_button_down()) {
             ButtonState::Depressed
         } else {
             ButtonState::Hovered
@@ -1233,7 +1230,7 @@ impl<'a> App<'a> {
             matches: Vec::new(),
             time: now,
         });
-        self.mouse_state.last_mouse_pos = Some((mouse.column, mouse.row));
+        mouse_state(|m| m.last_mouse_pos = Some((mouse.column, mouse.row)));
 
         // 1. Resolve tags
         let (direct_tag, mut semantic_tag) = self
@@ -1243,11 +1240,10 @@ impl<'a> App<'a> {
             .map(|(direct, semantic)| (Some(direct), Some(semantic)))
             .unwrap_or((None, None));
 
-        let is_dragging_command = self
-            .mouse_state
-            .drag_start_tag
-            .is_some_and(|tag| matches!(tag, Tag::Command(_)))
-            && matches!(mouse.kind, MouseEventKind::Drag(_));
+        let is_dragging_command = mouse_state(|m| {
+            m.drag_start_tag
+                .is_some_and(|tag| matches!(tag, Tag::Command(_)))
+        }) && matches!(mouse.kind, MouseEventKind::Drag(_));
         if is_dragging_command {
             if let Some(ref drawn) = self.last_contents
                 && let Some(content_row) = drawn.term_em_row_to_content_row(mouse.row)
@@ -1262,37 +1258,39 @@ impl<'a> App<'a> {
         let clicked_tag = semantic_tag;
 
         // 2. Update button states and over-cells in mouse_state
-        match mouse.kind {
-            MouseEventKind::Down(MouseButton::Left) => {
-                self.mouse_state.set_left_button_down();
-                self.mouse_state.set_left_button_dragging(false);
-                self.mouse_state.drag_start_tag = clicked_tag;
-                if let Some(Tag::Command(byte_pos)) = clicked_tag {
-                    self.mouse_state.record_left_click_down(byte_pos);
+        mouse_state(|m| {
+            match mouse.kind {
+                MouseEventKind::Down(MouseButton::Left) => {
+                    m.set_left_button_down();
+                    m.set_left_button_dragging(false);
+                    m.drag_start_tag = clicked_tag;
+                    if let Some(Tag::Command(byte_pos)) = clicked_tag {
+                        m.record_left_click_down(byte_pos);
+                    }
                 }
+                MouseEventKind::Up(MouseButton::Left) => {
+                    m.set_left_button_up();
+                    m.set_left_button_dragging(false);
+                    m.drag_start_tag = None;
+                }
+                MouseEventKind::Drag(MouseButton::Left) => {
+                    m.set_left_button_dragging(true);
+                }
+                MouseEventKind::Up(MouseButton::Right) => {
+                    m.take_right_click_down_pos();
+                }
+                MouseEventKind::ScrollUp
+                | MouseEventKind::ScrollDown
+                | MouseEventKind::ScrollLeft
+                | MouseEventKind::ScrollRight => {
+                    m.record_scroll();
+                }
+                _ => {}
             }
-            MouseEventKind::Up(MouseButton::Left) => {
-                self.mouse_state.set_left_button_up();
-                self.mouse_state.set_left_button_dragging(false);
-                self.mouse_state.drag_start_tag = None;
-            }
-            MouseEventKind::Drag(MouseButton::Left) => {
-                self.mouse_state.set_left_button_dragging(true);
-            }
-            MouseEventKind::Up(MouseButton::Right) => {
-                self.mouse_state.take_right_click_down_pos();
-            }
-            MouseEventKind::ScrollUp
-            | MouseEventKind::ScrollDown
-            | MouseEventKind::ScrollLeft
-            | MouseEventKind::ScrollRight => {
-                self.mouse_state.record_scroll();
-            }
-            _ => {}
-        }
 
-        self.mouse_state.last_mouse_over_cell_semantic = semantic_tag;
-        self.mouse_state.last_mouse_over_cell_direct = direct_tag;
+            m.last_mouse_over_cell_semantic = semantic_tag;
+            m.last_mouse_over_cell_direct = direct_tag;
+        });
 
         // 3. Evaluate context and dispatch declarative mouse action
         use crate::app::actions::mouse::{MouseActionOutput, RedrawUrgency};
@@ -1365,12 +1363,11 @@ impl<'a> App<'a> {
 
     pub fn reevaluate_pointer_shape(&mut self) {
         if self.settings.mouse_mode == settings::MouseMode::Disabled {
-            self.mouse_state
-                .set_pointer_shape(crate::mouse_state::PointerShape::Default);
+            mouse_state(|m| m.set_pointer_shape(crate::mouse_state::PointerShape::Default));
             return;
         }
 
-        let (col, row) = match self.mouse_state.last_mouse_pos {
+        let (col, row) = match mouse_state(|m| m.last_mouse_pos) {
             Some(pos) => pos,
             None => return,
         };
@@ -1382,15 +1379,17 @@ impl<'a> App<'a> {
             .map(|(direct, semantic)| (Some(direct), Some(semantic)))
             .unwrap_or((None, None));
 
-        self.mouse_state.last_mouse_over_cell_semantic = semantic_tag;
-        self.mouse_state.last_mouse_over_cell_direct = direct_tag;
+        mouse_state(|m| {
+            m.last_mouse_over_cell_semantic = semantic_tag;
+            m.last_mouse_over_cell_direct = direct_tag;
+        });
 
         for binding in crate::app::actions::mouse::DEFAULT_POINTER_SHAPE_BINDINGS.iter() {
             if binding.context.evaluate_direct(self) {
                 for action in &binding.actions {
                     if let crate::app::actions::mouse::MouseEventAction::SetPointer(shape) = action
                     {
-                        self.mouse_state.set_pointer_shape(*shape);
+                        mouse_state(|m| m.set_pointer_shape(*shape));
                         return;
                     }
                 }
@@ -1989,7 +1988,7 @@ impl<'a> App<'a> {
             let get_action = |app: &Self, new_wuc: &SubString| -> Option<CompletionAction> {
                 None
                     .or_else(|| {
-                        app.mouse_state.is_left_button_dragging()
+                        mouse_state(|m| m.is_left_button_dragging())
                             // If we're dragging the mouse, we dont want to have tab completions
                             .then_some(CompletionAction::Discard)
                     })

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -450,7 +450,7 @@ impl<'a> App<'a> {
                     content.newline();
                 }
 
-                if !self.mouse_state.is_enabled()
+                if !mouse_state(|m| m.is_enabled())
                     && self.settings.mouse_mode != crate::settings::MouseMode::Disabled
                 {
                     let red = Style::default().fg(Color::Red).slow_blink();
@@ -560,7 +560,7 @@ impl<'a> App<'a> {
 
         let (mut lprompt, rprompt, fill_span) = self.prompt_manager.get_ps1_lines(
             self.settings.show_animations,
-            self.mouse_state.is_enabled(),
+            mouse_state(|m| m.is_enabled()),
             leader_active,
             self.mode.is_running(),
         );
@@ -616,7 +616,7 @@ impl<'a> App<'a> {
         // Apply hover/depress styling to whichever CWD segment the mouse is over.
         if self.mode.is_running()
             && let Some(Tag::PromptCwdWidget(hovered_idx)) =
-                self.mouse_state.last_mouse_over_cell_semantic
+                mouse_state(|m| m.last_mouse_over_cell_semantic)
         {
             let cwd_state = self.button_state_for(Tag::PromptCwdWidget(hovered_idx));
             if !matches!(cwd_state, ButtonState::Normal) {
@@ -770,7 +770,7 @@ impl<'a> App<'a> {
                             focused,
                             &self.settings.cursor_config,
                             selection_bg,
-                            selection_active && self.mouse_state.is_left_button_down(),
+                            selection_active && mouse_state(|m| m.is_left_button_down()),
                         )
                     } else if focused {
                         Some(Palette::cursor_style(255))
@@ -840,11 +840,11 @@ impl<'a> App<'a> {
             _ => None,
         };
 
-        let scrollbar_tag = self.mouse_state.last_mouse_over_cell_semantic;
+        let scrollbar_tag = mouse_state(|m| m.last_mouse_over_cell_semantic);
         let is_scrollbar_hovered =
             matches!(scrollbar_tag, Some(Tag::TabCompletionScrollBar { .. }));
         let scrollbar_state = if is_scrollbar_hovered {
-            if self.mouse_state.is_left_button_down() {
+            if mouse_state(|m| m.is_left_button_down()) {
                 ButtonState::Depressed
             } else {
                 ButtonState::Hovered
@@ -943,8 +943,8 @@ impl<'a> App<'a> {
                 let sandbox_word = sandbox_status.label();
                 let sandbox_msg = sandbox_status.description();
 
-                let hover =
-                    self.mouse_state.last_mouse_over_cell_semantic == Some(Tag::FlycompSandboxInfo);
+                let hover = mouse_state(|m| m.last_mouse_over_cell_semantic)
+                    == Some(Tag::FlycompSandboxInfo);
                 let sandbox_word_style = if hover {
                     self.settings
                         .colour_palette
@@ -959,7 +959,7 @@ impl<'a> App<'a> {
                 };
 
                 let flycomp_hover =
-                    self.mouse_state.last_mouse_over_cell_semantic == Some(Tag::FlycompInfo);
+                    mouse_state(|m| m.last_mouse_over_cell_semantic) == Some(Tag::FlycompInfo);
                 let flycomp_style = if flycomp_hover {
                     self.settings
                         .colour_palette
@@ -1462,12 +1462,12 @@ impl<'a> App<'a> {
                 ("↷ Redo", Tag::RightClickRedo),
             ];
             let extra_entries = [("Run Tutorial", Tag::RightClickRunTutorial)];
-            let selected_tag = self.mouse_state.last_mouse_over_cell_semantic;
+            let selected_tag = mouse_state(|m| m.last_mouse_over_cell_semantic);
             let style = self.settings.colour_palette.right_click_menu();
             let selected_style = Palette::convert_to_highlighted(style);
             let info_lines = ["Toggle mouse capture", "with Escape."];
             let secondary_style = style.fg(ratatui::style::Color::DarkGray);
-            let is_left_button_down = self.mouse_state.is_left_button_down();
+            let is_left_button_down = mouse_state(|m| m.is_left_button_down());
 
             let has_separator = !extra_entries.is_empty() || !info_lines.is_empty();
             let popup_height = (entries.len()

--- a/src/mouse_state.rs
+++ b/src/mouse_state.rs
@@ -1,6 +1,10 @@
 use crate::content_builder::Tag;
 use crate::settings::MouseMode;
 
+use std::sync::Mutex;
+
+pub static GLOBAL_MOUSE_STATE: Mutex<Option<MouseState>> = Mutex::new(None);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClickCount {
     None,
@@ -35,6 +39,7 @@ impl std::fmt::Display for PointerShape {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct MouseState {
     enabled: bool,
     last_left_click_times: Vec<std::time::Instant>,
@@ -55,36 +60,17 @@ pub struct MouseState {
     last_scroll_time: Option<std::time::Instant>,
 }
 
-impl MouseState {
-    /// Initialize mouse state for the given mode, immediately enabling mouse capture
-    /// (via crossterm) when appropriate.
-    pub fn initialize(mode: &MouseMode) -> Self {
-        use termina::escape::csi::{Csi, DecPrivateMode, DecPrivateModeCode, Mode};
-        let set_mode = |code| Csi::Mode(Mode::SetDecPrivateMode(DecPrivateMode::Code(code)));
-        let enabled = match mode {
-            MouseMode::Disabled => false,
-            MouseMode::Simple | MouseMode::Smart => {
-                match crate::flush_stdout!(
-                    "{}{}{}{}{}",
-                    set_mode(DecPrivateModeCode::MouseTracking),
-                    set_mode(DecPrivateModeCode::ButtonEventMouse),
-                    set_mode(DecPrivateModeCode::AnyEventMouse),
-                    set_mode(DecPrivateModeCode::SGRMouse),
-                    XtShiftEscape::Enable
-                ) {
-                    Ok(_) => {
-                        log::trace!("Mouse capture enabled: initial setup for {:?} mode", mode);
-                        true
-                    }
-                    Err(e) => {
-                        log::error!("Failed to enable mouse capture on init: {}", e);
-                        false
-                    }
-                }
-            }
-        };
+/// Access or mutate the global `MouseState` instance.
+pub fn mouse_state<R>(f: impl FnOnce(&mut MouseState) -> R) -> R {
+    let mut lock = GLOBAL_MOUSE_STATE.lock().unwrap_or_else(|e| e.into_inner());
+    let state = lock.get_or_insert_with(MouseState::default);
+    f(state)
+}
+
+impl Default for MouseState {
+    fn default() -> Self {
         MouseState {
-            enabled,
+            enabled: false,
             last_left_click_times: Vec::new(),
             last_left_click_buffer_pos: None,
             left_button_down: false,
@@ -98,60 +84,71 @@ impl MouseState {
             last_scroll_time: None,
         }
     }
+}
 
-    /// Enable mouse capture, logging `reason` to explain why.
-    /// Does nothing (and logs nothing) if mouse capture is already enabled.
+impl MouseState {
+    /// Enable mouse capture for the given mode (or default Smart mode).
+    pub fn enable_mode(mode: &MouseMode) {
+        mouse_state(|m| m.enable_with_mode(mode));
+    }
+
     pub fn enable(&mut self) {
-        if self.enabled {
-            return;
-        }
+        self.enable_with_mode(&MouseMode::Smart);
+    }
+
+    pub fn enable_with_mode(&mut self, mode: &MouseMode) {
         use termina::escape::csi::{Csi, DecPrivateMode, DecPrivateModeCode, Mode};
         let set_mode = |code| Csi::Mode(Mode::SetDecPrivateMode(DecPrivateMode::Code(code)));
-        match crate::flush_stdout!(
-            "{}{}{}{}{}",
-            set_mode(DecPrivateModeCode::MouseTracking),
-            set_mode(DecPrivateModeCode::ButtonEventMouse),
-            set_mode(DecPrivateModeCode::AnyEventMouse),
-            set_mode(DecPrivateModeCode::SGRMouse),
-            XtShiftEscape::Enable
-        ) {
-            Ok(_) => {
-                log::info!("Mouse capture enabled");
-                self.enabled = true;
+
+        match mode {
+            MouseMode::Disabled => {
+                if self.enabled {
+                    self.disable();
+                }
             }
-            Err(e) => {
-                log::info!("Failed to enable mouse capture: {}", e);
+            MouseMode::Simple | MouseMode::Smart => {
+                if self.enabled {
+                    return;
+                }
+                match crate::flush_stdout!(
+                    "{}{}{}{}{}",
+                    set_mode(DecPrivateModeCode::MouseTracking),
+                    set_mode(DecPrivateModeCode::ButtonEventMouse),
+                    set_mode(DecPrivateModeCode::AnyEventMouse),
+                    set_mode(DecPrivateModeCode::SGRMouse),
+                    XtShiftEscape::Enable
+                ) {
+                    Ok(_) => {
+                        log::trace!("Mouse capture enabled for {:?} mode", mode);
+                        self.enabled = true;
+                    }
+                    Err(e) => {
+                        log::error!("Failed to enable mouse capture: {}", e);
+                        self.enabled = false;
+                    }
+                }
             }
         }
     }
 
-    /// Disable mouse capture, logging `reason` to explain why.
-    /// Does nothing (and logs nothing) if mouse capture is already disabled.
     pub fn disable(&mut self) {
         if !self.enabled {
             return;
         }
-        self.left_button_down = false;
-        // Reset pointer shape before actually disabling, so the code is written
-        self.set_pointer_shape(PointerShape::Default);
         use termina::escape::csi::{Csi, DecPrivateMode, DecPrivateModeCode, Mode};
         let reset_mode = |code| Csi::Mode(Mode::ResetDecPrivateMode(DecPrivateMode::Code(code)));
-        match crate::flush_stdout!(
-            "{}{}{}{}{}",
-            reset_mode(DecPrivateModeCode::SGRMouse),
+        let _ = crate::flush_stdout!(
+            "{}{}{}{}{}{}",
+            PointerShape::Default,
             reset_mode(DecPrivateModeCode::AnyEventMouse),
             reset_mode(DecPrivateModeCode::ButtonEventMouse),
             reset_mode(DecPrivateModeCode::MouseTracking),
+            reset_mode(DecPrivateModeCode::SGRMouse),
             XtShiftEscape::Disable
-        ) {
-            Ok(_) => {
-                log::trace!("Mouse capture disabled");
-                self.enabled = false;
-            }
-            Err(e) => {
-                log::error!("Failed to disable mouse capture: {}", e);
-            }
-        }
+        );
+        self.enabled = false;
+        self.left_button_down = false;
+        self.current_pointer_shape = PointerShape::Default;
     }
 
     pub fn toggle(&mut self) {
@@ -258,25 +255,7 @@ impl MouseState {
 
         log::info!("pointer shape set: {:?}", shape);
 
-        use std::io::Write;
-        let mut stdout = std::io::stdout();
-        let _ = write!(stdout, "{}", shape).and_then(|_| stdout.flush());
-    }
-}
-
-impl Drop for MouseState {
-    fn drop(&mut self) {
-        if self.enabled {
-            use std::io::Write;
-            let mut stdout = std::io::stdout();
-            let _ = write!(
-                stdout,
-                "{}{}",
-                PointerShape::Default,
-                XtShiftEscape::Disable
-            )
-            .and_then(|_| stdout.flush());
-        }
+        let _ = crate::flush_stdout!("{}", shape);
     }
 }
 


### PR DESCRIPTION
Mouse state is a pretty much a global resource especially the enabled / disabled state.
And we really need to handle it during terminal restore and configure.

This is a potential fix for #901.