### PR TITLE
feat: move settings into a global var

### DIFF
--- a/src/app/actions/keyboard.rs
+++ b/src/app/actions/keyboard.rs
@@ -3293,7 +3293,7 @@ pub fn print_bindings_table(
     }
 }
 
-impl<'a> App<'a> {
+impl App {
     pub fn handle_key_event(&mut self, key: KeyEvent) {
         let _timer = crate::perf::PerfTimer::start("handle_key_event");
         let initial_leader_time = self.leader_key_active_at;

--- a/src/app/actions/keyboard.rs
+++ b/src/app/actions/keyboard.rs
@@ -362,7 +362,7 @@ impl KeyEventAction {
                         }
                         FlycompPromptSelection::No => {}
                         FlycompPromptSelection::DontAsk => {
-                            app.settings.flycomp.add_to_blacklist(command_word);
+                            crate::settings().flycomp.add_to_blacklist(command_word);
                         }
                     }
                 }
@@ -524,7 +524,7 @@ impl KeyEventAction {
             KeyEventAction::RunFlycomp => app.force_start_flycomp(),
             KeyEventAction::ToggleMouse => {
                 if matches!(
-                    app.settings.mouse_mode,
+                    crate::settings().mouse_mode,
                     MouseMode::Simple | MouseMode::Smart
                 ) {
                     log::info!("Toggling mouse state due to toggle_mouse action");
@@ -540,7 +540,7 @@ impl KeyEventAction {
             KeyEventAction::Cancel => {
                 let buf = app.buffer.buffer();
                 if !buf.trim().is_empty() {
-                    app.settings
+                    crate::settings()
                         .cancelled_command_history_manager
                         .push_entry(buf.to_string());
                 }
@@ -553,17 +553,17 @@ impl KeyEventAction {
                 app.try_submit_current_buffer();
             }
             KeyEventAction::RunFuzzyHistorySearch => {
-                if app.settings.history_backend == crate::settings::HistoryBackend::Flyline {
-                    app.settings.history_manager.refresh_jsonl_backend();
+                if crate::settings().history_backend == crate::settings::HistoryBackend::Flyline {
+                    crate::settings().history_manager.refresh_jsonl_backend();
                 }
-                app.settings
+                crate::settings()
                     .history_manager
                     .warm_fuzzy_search_cache(app.buffer.buffer(), Some(0));
                 app.content_mode =
                     ContentMode::FuzzyHistorySearch(FuzzyHistorySource::PastCommands);
             }
             KeyEventAction::RunFuzzyCancelledHistorySearch => {
-                app.settings
+                crate::settings()
                     .cancelled_command_history_manager
                     .warm_fuzzy_search_cache(app.buffer.buffer(), Some(0));
                 app.content_mode =
@@ -597,7 +597,7 @@ impl KeyEventAction {
                 if app.buffer.delete_selection() {
                     return;
                 }
-                if app.settings.auto_close_chars {
+                if crate::settings().auto_close_chars {
                     // Backspace: if the char to the right of the cursor is an auto-inserted closing token
                     // paired with the char about to be deleted, remove it as well.
                     app.delete_auto_inserted_closing_if_present();
@@ -670,8 +670,7 @@ impl KeyEventAction {
                 app.buffer.clear_selection();
                 app.buffer_before_history_navigation
                     .get_or_insert_with(|| app.buffer.buffer().to_string());
-                if let Some(entry) = app
-                    .settings
+                if let Some(entry) = crate::settings()
                     .history_manager
                     .search_in_history(app.buffer.buffer(), HistorySearchDirection::Backward)
                 {
@@ -680,8 +679,7 @@ impl KeyEventAction {
             }
             KeyEventAction::NextHistoryEntry => {
                 app.buffer.clear_selection();
-                match app
-                    .settings
+                match crate::settings()
                     .history_manager
                     .search_in_history(app.buffer.buffer(), HistorySearchDirection::Forward)
                 {
@@ -716,7 +714,7 @@ impl KeyEventAction {
                 }
                 app.buffer.delete_selection();
                 if let KeyCode::Char(c) = key.code {
-                    if app.settings.auto_close_chars {
+                    if crate::settings().auto_close_chars {
                         app.handle_char_insertion(c);
                     } else {
                         app.buffer.insert_char(c);
@@ -852,8 +850,7 @@ impl KeyEventAction {
                 app.buffer.clear_selection();
 
                 // Get the last word of the history command we are currently looking at
-                let last_word_of_current_history_cmd = app
-                    .settings
+                let last_word_of_current_history_cmd = crate::settings()
                     .history_manager
                     .get_last_word_insert_command()
                     .and_then(|cmd| crate::history::get_last_word(cmd));
@@ -866,11 +863,14 @@ impl KeyEventAction {
                 let is_continuation = target_sub.is_some();
 
                 if !is_continuation {
-                    app.settings.history_manager.last_word_insert_reset();
+                    crate::settings().history_manager.last_word_insert_reset();
                 }
 
                 // Move to the previous command with non-empty words
-                if let Some(cmd) = app.settings.history_manager.last_word_insert_move_prev() {
+                if let Some(cmd) = crate::settings()
+                    .history_manager
+                    .last_word_insert_move_prev()
+                {
                     if let Some(w) = crate::history::get_last_word(cmd) {
                         if let Some(sub) = &target_sub {
                             let _ = app.buffer.replace_word_under_cursor(&w, sub);
@@ -3298,7 +3298,7 @@ impl App {
         let _timer = crate::perf::PerfTimer::start("handle_key_event");
         let initial_leader_time = self.leader_key_active_at;
         log::trace!("Key event: {:?}", key);
-        let key = apply_remappings(key, &self.settings.key_remappings);
+        let key = apply_remappings(key, &crate::settings().key_remappings);
         log::trace!("Key event after remapping: {:?}", key);
 
         // Evaluate every context variable once up front, so each variable's
@@ -3312,8 +3312,7 @@ impl App {
         // Find the highest-priority binding whose context is satisfied and
         // matches the key event. User bindings take priority over default bindings.
         let mut matched: Option<(Vec<KeyEventAction>, String)> = None;
-        for binding in self
-            .settings
+        for binding in crate::settings()
             .keybindings
             .iter()
             .rev()
@@ -3355,7 +3354,7 @@ impl App {
         if matched
             .as_ref()
             .is_some_and(|(actions, _)| !actions.contains(&KeyEventAction::ToggleMouse))
-            && self.settings.mouse_mode == MouseMode::Smart
+            && crate::settings().mouse_mode == MouseMode::Smart
             && crate::mouse_state::mouse_state(|m| m.is_disabled())
         {
             log::debug!("Reenabling mouse due to key event");

--- a/src/app/actions/mouse.rs
+++ b/src/app/actions/mouse.rs
@@ -231,7 +231,7 @@ impl super::ContextVar for MouseContextVar {
             MouseContextVar::NotOverCellSemantically(pattern) => !pattern.matches(clicked_tag),
             MouseContextVar::OverCellDirectly(pattern) => pattern.matches(direct_tag),
             MouseContextVar::SmartModeClickAboveViewport => {
-                app.settings.mouse_mode == MouseMode::Smart
+                crate::settings().mouse_mode == MouseMode::Smart
                     && last_mouse.is_some_and(|m| {
                         matches!(m.kind, MouseEventKind::Down(_))
                             && app.last_contents.as_ref().is_some_and(|c| {
@@ -241,7 +241,7 @@ impl super::ContextVar for MouseContextVar {
                     })
             }
             MouseContextVar::SmartModeScroll => {
-                app.settings.mouse_mode == MouseMode::Smart
+                crate::settings().mouse_mode == MouseMode::Smart
                     && last_mouse.is_some_and(|m| {
                         matches!(
                             m.kind,
@@ -878,8 +878,8 @@ impl MouseEventAction {
                 MouseActionOutput::update_now()
             }
             MouseEventAction::RunTutorial => {
-                app.settings.run_tutorial = true;
-                app.settings.tutorial_step = crate::tutorial::TutorialStep::Welcome;
+                crate::settings().run_tutorial = true;
+                crate::settings().tutorial_step = crate::tutorial::TutorialStep::Welcome;
                 use termina::escape::csi::{Csi, Cursor, Edit, EraseInDisplay};
                 if let Err(e) = crate::flush_stdout!(
                     "{}{}",
@@ -1054,7 +1054,7 @@ impl MouseEventAction {
             }
             MouseEventAction::ClickCommand => {
                 if let Some(Tag::Command(byte_pos)) = clicked_tag {
-                    if app.settings.select_with_mouse {
+                    if crate::settings().select_with_mouse {
                         let extend_selection = mouse.modifiers.contains(KeyModifiers::SHIFT);
                         if extend_selection {
                             app.buffer.start_selection_if_none();
@@ -1079,7 +1079,7 @@ impl MouseEventAction {
             }
             MouseEventAction::ReleaseCommand => MouseActionOutput::update_now(),
             MouseEventAction::SelectAll => {
-                if app.settings.select_with_mouse {
+                if crate::settings().select_with_mouse {
                     app.buffer.select_entire_buffer();
                     MouseActionOutput::update_now()
                 } else {
@@ -1088,7 +1088,7 @@ impl MouseEventAction {
             }
             MouseEventAction::SelectWord => {
                 if let Some(Tag::Command(byte_pos)) = clicked_tag {
-                    if app.settings.select_with_mouse {
+                    if crate::settings().select_with_mouse {
                         app.buffer
                             .try_move_cursor_to_byte_pos(byte_pos, move_past_final);
                         app.buffer.select_word_using_mouse();
@@ -1102,7 +1102,7 @@ impl MouseEventAction {
             }
             MouseEventAction::SelectLine => {
                 if let Some(Tag::Command(byte_pos)) = clicked_tag {
-                    if app.settings.select_with_mouse {
+                    if crate::settings().select_with_mouse {
                         app.buffer
                             .try_move_cursor_to_byte_pos(byte_pos, move_past_final);
                         app.buffer.select_line_using_mouse();
@@ -1116,7 +1116,7 @@ impl MouseEventAction {
             }
             MouseEventAction::DragCommand => {
                 if let Some(Tag::Command(byte_pos)) = clicked_tag {
-                    if app.settings.select_with_mouse {
+                    if crate::settings().select_with_mouse {
                         let active_drag_tag = mouse_state(|m| m.drag_start_tag);
                         if matches!(active_drag_tag, Some(Tag::Command(_))) {
                             app.buffer.start_selection_if_none();
@@ -1136,7 +1136,7 @@ impl MouseEventAction {
             }
             MouseEventAction::DragWord => {
                 if let Some(Tag::Command(byte_pos)) = clicked_tag {
-                    if app.settings.select_with_mouse {
+                    if crate::settings().select_with_mouse {
                         let active_drag_tag = mouse_state(|m| m.drag_start_tag);
                         if matches!(active_drag_tag, Some(Tag::Command(_))) {
                             if let Some(drag_start_pos) =
@@ -1168,7 +1168,7 @@ impl MouseEventAction {
             }
             MouseEventAction::DragLine => {
                 if let Some(Tag::Command(byte_pos)) = clicked_tag {
-                    if app.settings.select_with_mouse {
+                    if crate::settings().select_with_mouse {
                         let active_drag_tag = mouse_state(|m| m.drag_start_tag);
                         if matches!(active_drag_tag, Some(Tag::Command(_))) {
                             if let Some(drag_start_pos) =
@@ -1199,7 +1199,7 @@ impl MouseEventAction {
                 }
             }
             MouseEventAction::DragAll => {
-                if app.settings.select_with_mouse {
+                if crate::settings().select_with_mouse {
                     app.buffer.select_entire_buffer();
                     MouseActionOutput::update_soon()
                 } else {
@@ -1207,18 +1207,18 @@ impl MouseEventAction {
                 }
             }
             MouseEventAction::ClickTutorialPrev => {
-                app.settings.tutorial_step.prev();
+                crate::settings().tutorial_step.prev();
                 log::info!(
                     "Tutorial navigated to prev: {:?}",
-                    app.settings.tutorial_step
+                    crate::settings().tutorial_step
                 );
                 MouseActionOutput::dont_update()
             }
             MouseEventAction::ClickTutorialNext => {
-                app.settings.tutorial_step.next();
+                crate::settings().tutorial_step.next();
                 log::info!(
                     "Tutorial navigated to next: {:?}",
-                    app.settings.tutorial_step
+                    crate::settings().tutorial_step
                 );
                 MouseActionOutput::dont_update()
             }
@@ -1317,7 +1317,7 @@ impl MouseEventAction {
                     if matches!(mouse.kind, MouseEventKind::Up(MouseButton::Left)) {
                         let mode = std::mem::replace(&mut app.content_mode, ContentMode::Normal);
                         if let ContentMode::TabCompletionAskForFlycomp { command_word, .. } = mode {
-                            app.settings.flycomp.add_to_blacklist(command_word);
+                            crate::settings().flycomp.add_to_blacklist(command_word);
                         }
                         MouseActionOutput::update_now()
                     } else {

--- a/src/app/auto_close.rs
+++ b/src/app/auto_close.rs
@@ -101,7 +101,7 @@ pub(crate) fn delete_auto_inserted_closing_if_present(
     }
 }
 
-impl<'a> App<'a> {
+impl App {
     pub(crate) fn handle_char_insertion(&mut self, c: char) {
         handle_char_insertion(&mut self.buffer, &mut self.dparser_tokens_cache, c);
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -46,7 +46,7 @@ use crate::kill_on_drop_child::KillOnDropChild;
 use crate::mouse_state::{MouseState, mouse_state};
 use crate::palette::{ButtonState, Palette};
 use crate::prompt_manager::PromptManager;
-use crate::settings::{self, MatrixAnimation, MouseMode, Settings};
+use crate::settings::{self, MatrixAnimation, MouseMode, SettingsRef};
 use crate::shell_integration;
 use crate::{command_acceptance, dparser};
 use crate::{shell, tab_completion_context};
@@ -201,7 +201,7 @@ impl AppRunningState {
     }
 }
 
-pub fn get_command(settings: &mut Settings) -> ExitState {
+pub fn get_command() -> ExitState {
     // If stdin is closed, bash expects us to just return EOF a few times
     if let Some(reason) = stdin_unavailable_reason() {
         log::error!(
@@ -212,7 +212,7 @@ pub fn get_command(settings: &mut Settings) -> ExitState {
         return ExitState::EOF;
     }
 
-    let app = time_it!("startup: app creation", App::new(settings));
+    let app = time_it!("startup: app creation", App::new());
 
     let end_state = app.run();
 
@@ -304,7 +304,7 @@ pub(crate) enum ContentMode {
     },
 }
 
-pub(crate) struct App<'a> {
+pub(crate) struct App {
     pub(super) terminal:
         ratatui::Terminal<ratatui::backend::TerminaBackend<termina::PlatformTerminal>>,
     pub(super) mode: AppRunningState,
@@ -330,7 +330,7 @@ pub(crate) struct App<'a> {
     pub(super) content_mode: ContentMode,
     pub(super) last_contents: Option<DrawnContent>,
     pub(super) tooltip: Option<String>,
-    pub(super) settings: &'a mut Settings,
+    pub(super) settings: SettingsRef,
     /// Terminal row (absolute) where the inline viewport starts; used by smart mouse mode.
     /// Timestamp of the last draw operation.
     pub(super) last_draw_time: std::time::Instant,
@@ -356,8 +356,9 @@ pub(crate) struct App<'a> {
     pub(super) git_warming_subshell: Option<SubshellHandle<Option<crate::git::GitRepoPayload>>>,
 }
 
-impl<'a> App<'a> {
-    fn new(settings: &'a mut Settings) -> Self {
+impl App {
+    fn new() -> Self {
+        let mut settings = crate::settings();
         let unfinished_from_prev_command = shell::backend().multiline_command_count() > 0;
         let initial_buf_val = settings.initial_buffer.take().unwrap_or_default();
         let buffer = TextBuffer::new(&initial_buf_val);
@@ -366,9 +367,10 @@ impl<'a> App<'a> {
         time_it!("startup: reload history", {
             match settings.history_backend {
                 crate::settings::HistoryBackend::Bash => {
+                    let zsh_history_path = settings.zsh_history_path.clone();
                     settings
                         .history_manager
-                        .reload_from_bash_history(settings.zsh_history_path.as_deref());
+                        .reload_from_bash_history(zsh_history_path.as_deref());
                 }
                 crate::settings::HistoryBackend::Flyline => {
                     // We dont refresh it here often so that when we press Up

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -46,7 +46,7 @@ use crate::kill_on_drop_child::KillOnDropChild;
 use crate::mouse_state::{MouseState, mouse_state};
 use crate::palette::{ButtonState, Palette};
 use crate::prompt_manager::PromptManager;
-use crate::settings::{self, MatrixAnimation, MouseMode, SettingsRef};
+use crate::settings::{self, MatrixAnimation, MouseMode};
 use crate::shell_integration;
 use crate::{command_acceptance, dparser};
 use crate::{shell, tab_completion_context};
@@ -330,7 +330,6 @@ pub(crate) struct App {
     pub(super) content_mode: ContentMode,
     pub(super) last_contents: Option<DrawnContent>,
     pub(super) tooltip: Option<String>,
-    pub(super) settings: SettingsRef,
     /// Terminal row (absolute) where the inline viewport starts; used by smart mouse mode.
     /// Timestamp of the last draw operation.
     pub(super) last_draw_time: std::time::Instant,
@@ -358,7 +357,7 @@ pub(crate) struct App {
 
 impl App {
     fn new() -> Self {
-        let mut settings = crate::settings();
+        let settings = crate::settings();
         let unfinished_from_prev_command = shell::backend().multiline_command_count() > 0;
         let initial_buf_val = settings.initial_buffer.take().unwrap_or_default();
         let buffer = TextBuffer::new(&initial_buf_val);
@@ -496,7 +495,6 @@ impl App {
             content_mode: ContentMode::Normal,
             last_contents: None,
             tooltip: None,
-            settings,
             last_draw_time: std::time::Instant::now(),
             needs_screen_cleared: false,
             needs_full_redraw: false,
@@ -714,11 +712,11 @@ impl App {
         source: &FuzzyHistorySource,
     ) -> &mut HistoryManager {
         match source {
-            FuzzyHistorySource::PastCommands => &mut self.settings.history_manager,
+            FuzzyHistorySource::PastCommands => &mut crate::settings().history_manager,
             FuzzyHistorySource::CancelledCommands => {
-                &mut self.settings.cancelled_command_history_manager
+                &mut crate::settings().cancelled_command_history_manager
             }
-            FuzzyHistorySource::AgentPrompts => &mut self.settings.agent_prompt_history_manager,
+            FuzzyHistorySource::AgentPrompts => &mut crate::settings().agent_prompt_history_manager,
         }
     }
 
@@ -728,18 +726,20 @@ impl App {
         source: &FuzzyHistorySource,
     ) -> &HistoryManager {
         match source {
-            FuzzyHistorySource::PastCommands => &self.settings.history_manager,
+            FuzzyHistorySource::PastCommands => &crate::settings().history_manager,
             FuzzyHistorySource::CancelledCommands => {
-                &self.settings.cancelled_command_history_manager
+                &crate::settings().cancelled_command_history_manager
             }
-            FuzzyHistorySource::AgentPrompts => &self.settings.agent_prompt_history_manager,
+            FuzzyHistorySource::AgentPrompts => &crate::settings().agent_prompt_history_manager,
         }
     }
 
     pub fn run(mut self) -> ExitState {
         // Send execution finished escape codes (previous command has completed).
         time_it!("startup: escape codes", {
-            if self.settings.send_shell_integration_codes == settings::ShellIntegrationLevel::Full {
+            if crate::settings().send_shell_integration_codes
+                == settings::ShellIntegrationLevel::Full
+            {
                 let last_command_exit_value = shell::backend().last_command_exit_status();
                 let hostname = shell::backend().hostname();
                 let cwd = shell::backend().cwd();
@@ -856,7 +856,7 @@ impl App {
                 }
 
                 let prev_contents = std::mem::take(&mut self.last_contents);
-                let show_terminal_cursor = (self.settings.cursor_config.backend()
+                let show_terminal_cursor = (crate::settings().cursor_config.backend()
                     == crate::cursor::CursorBackend::Terminal
                     || !self.mode.is_running())
                     && !(mouse_state(|m| m.is_left_button_down())
@@ -907,7 +907,7 @@ impl App {
                         }
 
                         if matches!(
-                            self.settings.send_shell_integration_codes,
+                            crate::settings().send_shell_integration_codes,
                             settings::ShellIntegrationLevel::OnlyPromptPos
                                 | settings::ShellIntegrationLevel::Full
                         ) {
@@ -958,9 +958,9 @@ impl App {
 
             let is_idle = self.last_activity_time.elapsed() >= IDLE_TIMEOUT;
             let effective_fps = if is_idle {
-                IDLE_FRAME_RATE.min(self.settings.frame_rate as f64)
+                IDLE_FRAME_RATE.min(crate::settings().frame_rate as f64)
             } else {
-                self.settings.frame_rate as f64
+                crate::settings().frame_rate as f64
             };
             let min_refresh_rate: Duration = Duration::from_millis((1000.0 / effective_fps) as u64);
 
@@ -982,13 +982,13 @@ impl App {
                                 height: winsize.rows,
                             };
 
-                            let effective_logic = self.settings.resize_logic.resolve();
+                            let effective_logic = crate::settings().resize_logic.resolve();
 
                             log::debug!(
                                 "[Resize] Event received: cols={}, rows={}, resize_logic={:?} (resolved={:?})",
                                 winsize.cols,
                                 winsize.rows,
-                                self.settings.resize_logic,
+                                crate::settings().resize_logic,
                                 effective_logic
                             );
 
@@ -1105,7 +1105,7 @@ impl App {
                         TerminaEvent::FocusIn => {
                             // log::trace!("Terminal focus gained");
                             self.term_has_focus = true;
-                            if self.settings.mouse_mode == MouseMode::Smart {
+                            if crate::settings().mouse_mode == MouseMode::Smart {
                                 log::debug!(
                                     "Enabling mouse capture due to terminal focus gain in smart mode"
                                 );
@@ -1161,7 +1161,7 @@ impl App {
 
         match self.mode {
             AppRunningState::Exiting(ExitState::WithCommand(cmd)) => {
-                if self.settings.send_shell_integration_codes
+                if crate::settings().send_shell_integration_codes
                     == settings::ShellIntegrationLevel::Full
                 {
                     shell_integration::write_on_exit_codes(Some(&cmd)).unwrap_or_else(|e| {
@@ -1173,7 +1173,7 @@ impl App {
                 ExitState::WithCommand(cmd)
             }
             _ => {
-                if self.settings.send_shell_integration_codes
+                if crate::settings().send_shell_integration_codes
                     == settings::ShellIntegrationLevel::Full
                 {
                     shell_integration::write_on_exit_codes(None).unwrap_or_else(|e| {
@@ -1246,8 +1246,8 @@ impl App {
             log::error!("Failed to re-enter raw mode after bash command: {}", e);
         }
         configure_terminal(
-            self.settings.enable_extended_key_codes,
-            &self.settings.mouse_mode,
+            crate::settings().enable_extended_key_codes,
+            &crate::settings().mouse_mode,
         );
         if mouse_enabled {
             mouse_state(|m| m.enable());
@@ -1455,7 +1455,7 @@ impl App {
     }
 
     pub fn reevaluate_pointer_shape(&mut self) {
-        if self.settings.mouse_mode == settings::MouseMode::Disabled {
+        if crate::settings().mouse_mode == settings::MouseMode::Disabled {
             mouse_state(|m| m.set_pointer_shape(crate::mouse_state::PointerShape::Default));
             return;
         }
@@ -1527,8 +1527,7 @@ impl App {
         if let ContentMode::FuzzyHistorySearch(FuzzyHistorySource::AgentPrompts) =
             &self.content_mode
         {
-            let entry = self
-                .settings
+            let entry = crate::settings()
                 .agent_prompt_history_manager
                 .accept_fuzzy_search_result()
                 .cloned();
@@ -1542,7 +1541,7 @@ impl App {
                             self.content_mode =
                                 ContentMode::AgentOutputSelection(AiOutputSelection::new(
                                     parsed,
-                                    &self.settings.colour_palette,
+                                    &crate::settings().colour_palette,
                                     self.buffer.buffer(),
                                 ));
                             return;
@@ -1616,7 +1615,7 @@ impl App {
         if let Some(result) = ai_result {
             match result {
                 Ok(raw_output) => {
-                    self.settings
+                    crate::settings()
                         .agent_prompt_history_manager
                         .set_last_raw_output(raw_output.clone());
                     match parse_ai_output(&raw_output) {
@@ -1624,7 +1623,7 @@ impl App {
                             self.content_mode =
                                 ContentMode::AgentOutputSelection(AiOutputSelection::new(
                                     parsed,
-                                    &self.settings.colour_palette,
+                                    &crate::settings().colour_palette,
                                     self.buffer.buffer(),
                                 ));
                         }
@@ -1642,7 +1641,7 @@ impl App {
                 }
                 Err((msg, raw_output)) => {
                     log::error!("AI command failed: {}", msg);
-                    self.settings
+                    crate::settings()
                         .agent_prompt_history_manager
                         .set_last_raw_output(raw_output.clone());
                     self.dismissed_agent_mode_buffer = Some(self.buffer.buffer().to_string());
@@ -1728,7 +1727,7 @@ impl App {
                 IpcStatus::Ready(script) => {
                     let cmd_word = command_word.clone();
                     log::info!("flycomp succeeded for command '{}'", cmd_word);
-                    let output_dir = self.settings.flycomp.output_dir();
+                    let output_dir = crate::settings().flycomp.output_dir();
                     let _ = shell::backend()
                         .resolve_and_write_completion_script(&cmd_word, &script, output_dir);
                     let _ = shell::backend().evaluate_shell_string(&script);
@@ -1861,7 +1860,7 @@ impl App {
             }
         }
         let start_time = std::time::Instant::now();
-        let flycomp_settings = self.settings.flycomp.clone();
+        let flycomp_settings = crate::settings().flycomp.clone();
 
         if let Some(handle) = subshell_ipc::spawn_subshell(move || {
             crate::reset_sigchld();
@@ -1923,8 +1922,7 @@ impl App {
         }
 
         let buf = self.buffer.buffer();
-        let none_prefix_cmd = self
-            .settings
+        let none_prefix_cmd = crate::settings()
             .agent_commands
             .get(&None)
             .map(|cmd| (cmd.clone(), buf.to_string()));
@@ -1933,7 +1931,7 @@ impl App {
             return none_prefix_cmd;
         }
         // Ignore the prefixing and just get any command.
-        self.settings
+        crate::settings()
             .agent_commands
             .values()
             .next()
@@ -1944,7 +1942,7 @@ impl App {
         &self,
     ) -> Option<(&settings::AgentModeCommand, &str)> {
         let buf = self.buffer.buffer();
-        for (prefix_key, agent_cmd) in &self.settings.agent_commands {
+        for (prefix_key, agent_cmd) in &crate::settings().agent_commands {
             if let Some(prefix) = prefix_key
                 && let Some(stripped) = buf.strip_prefix(prefix.as_str())
             {
@@ -1961,7 +1959,7 @@ impl App {
         // TODO: think through UX for running agent mode with an empty buffer
         // (e.g. opening the agent-prompts fuzzy history search). For now we
         // always push the (possibly empty) buffer and spawn the command.
-        self.settings
+        crate::settings()
             .agent_prompt_history_manager
             .push_entry(self.buffer.buffer().to_string());
         let cmd_args = agent_cmd.command;
@@ -2088,7 +2086,7 @@ impl App {
                 && let Some((_agent_cmd, _stripped)) =
                     self.buffer_starts_with_agent_command_prefix()
             {
-                self.settings
+                crate::settings()
                     .agent_prompt_history_manager
                     .warm_fuzzy_search_cache(self.buffer.buffer(), None);
                 self.content_mode =
@@ -2108,7 +2106,7 @@ impl App {
             ContentMode::TabCompletion(_) | ContentMode::TabCompletionWaiting { .. }
         );
 
-        if (self.settings.auto_suggest || is_tab_completion_active) && self.last_key.is_some() {
+        if (crate::settings().auto_suggest || is_tab_completion_active) && self.last_key.is_some() {
             #[derive(Debug, Clone, Copy, PartialEq, Eq)]
             enum CompletionAction {
                 Keep,
@@ -2194,7 +2192,7 @@ impl App {
                     })
                     // Lets get the auto suggestionns going!
                     .or_else(|| {
-                        (app.settings.auto_suggest && matches!(app.content_mode, ContentMode::Normal))
+                        (crate::settings().auto_suggest && matches!(app.content_mode, ContentMode::Normal))
                             .then_some(CompletionAction::Restart { carry_over: false })
                     })
                     // This block is more about refining the tab completions when active and knowing when to discard them (e.g. moved cursor to another word)
@@ -2216,7 +2214,7 @@ impl App {
                                 } else if !new_wuc.s.starts_with(old_wuc)
                                     && !old_wuc.starts_with(&new_wuc.s)
                                 {
-                                    if app.settings.auto_suggest {
+                                    if crate::settings().auto_suggest {
                                         Some(CompletionAction::Restart { carry_over: false })
                                     } else {
                                         Some(CompletionAction::Discard)
@@ -2274,7 +2272,7 @@ impl App {
                                         current_wuc,
                                         new_wuc
                                     );
-                                    if app.settings.auto_suggest {
+                                    if crate::settings().auto_suggest {
                                         Some(CompletionAction::Restart { carry_over: false })
                                     } else {
                                         Some(CompletionAction::Discard)
@@ -2344,13 +2342,13 @@ impl App {
             self.dismissed_inline_suggestion_buffer = None;
         }
 
-        self.inline_history_suggestion = if !self.settings.show_inline_history
+        self.inline_history_suggestion = if !crate::settings().show_inline_history
             || history_buffer.is_empty()
             || self.dismissed_inline_suggestion_buffer.is_some()
         {
             None
         } else {
-            self.settings
+            crate::settings()
                 .history_manager
                 .get_command_suggestion_suffix(history_buffer)
         };
@@ -2367,8 +2365,8 @@ impl App {
                 self.buffer.cursor_byte_pos(),
                 self.buffer.selection_byte(),
                 self.buffer.buffer().len(),
-                &self.settings.colour_palette,
-                self.settings.enable_easter_eggs,
+                &crate::settings().colour_palette,
+                crate::settings().enable_easter_eggs,
             )
         } else {
             format_buffer(
@@ -2377,8 +2375,8 @@ impl App {
                 self.buffer.selection_byte(),
                 self.buffer.buffer().len(),
                 self.mode.is_running(),
-                &self.settings.colour_palette,
-                self.settings.enable_easter_eggs,
+                &crate::settings().colour_palette,
+                crate::settings().enable_easter_eggs,
             )
         };
 

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::content::{
     Coord, RelativePosition, gaussian_wave_animated, split_line_to_terminal_rows, vec_spans_width,
 };
+use crate::settings::Settings;
 use crate::tutorial;
 use ratatui::prelude::*;
 
@@ -112,7 +113,7 @@ impl DrawnContent {
     }
 }
 
-impl<'a> App<'a> {
+impl App {
     fn render_history_entry(
         content: &mut Contents,
         formatted_entry: &HistoryEntryFormatted,
@@ -370,7 +371,7 @@ impl<'a> App<'a> {
                 content.move_to_final_line();
                 content.newline();
             } else if let Some(tutorial_tagged_lines) = crate::tutorial::generate_tutorial_text(
-                self.settings,
+                &*self.settings,
                 self.settings.tutorial_step,
                 &self.settings.colour_palette,
             ) {
@@ -1212,6 +1213,7 @@ impl<'a> App<'a> {
                     FuzzyHistorySource::CancelledCommands => Some(0),
                     FuzzyHistorySource::AgentPrompts => None,
                 };
+                let colour_palette = self.settings.colour_palette.clone();
                 let (entries, fuzzy_results, fuzzy_search_index, num_results, num_searched) =
                     match source {
                         FuzzyHistorySource::PastCommands => &mut self.settings.history_manager,
@@ -1265,7 +1267,7 @@ impl<'a> App<'a> {
                         num_digits_for_score,
                         header_prefix_width,
                         available_cols,
-                        &self.settings.colour_palette,
+                        &colour_palette,
                     );
 
                     if content.cursor_position().row.saturating_sub(starting_row)

--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -353,7 +353,7 @@ impl App {
 
         // Render tutorial text above the prompt when a tutorial step is active.
         if self.mode.is_running() {
-            if self.settings.tutorial_step == tutorial::TutorialStep::Welcome {
+            if crate::settings().tutorial_step == tutorial::TutorialStep::Welcome {
                 // Welcome step: draw the large block-art logo, then overlay the
                 // animated action prompt in the lower-right of the logo.
                 let logo_lines = crate::tutorial::generate_welcome_logo_lines(width);
@@ -371,9 +371,9 @@ impl App {
                 content.move_to_final_line();
                 content.newline();
             } else if let Some(tutorial_tagged_lines) = crate::tutorial::generate_tutorial_text(
-                &*self.settings,
-                self.settings.tutorial_step,
-                &self.settings.colour_palette,
+                crate::settings(),
+                crate::settings().tutorial_step,
+                &crate::settings().colour_palette,
             ) {
                 const BUTTON_HEIGHT: u16 = 30;
 
@@ -451,7 +451,7 @@ impl App {
                 }
 
                 if !mouse_state(|m| m.is_enabled())
-                    && self.settings.mouse_mode != crate::settings::MouseMode::Disabled
+                    && crate::settings().mouse_mode != crate::settings::MouseMode::Disabled
                 {
                     let red = Style::default().fg(Color::Red).slow_blink();
                     let escape_hint = TaggedLine::from(vec![TaggedSpan::new(
@@ -481,7 +481,7 @@ impl App {
             }
         }
 
-        if self.settings.key_debug
+        if crate::settings().key_debug
             && let Some(last_key) = &self.last_key
         {
             let actions_str = last_key
@@ -497,7 +497,7 @@ impl App {
                         last_key.display, last_key.context, actions_str
                     ))
                     .style(
-                        self.settings
+                        crate::settings()
                             .colour_palette
                             .secondary_text()
                             .add_modifier(Modifier::BOLD),
@@ -509,7 +509,7 @@ impl App {
         }
 
         if self.mode.is_running()
-            && self.settings.mouse_debug
+            && crate::settings().mouse_debug
             && let Some(last_mouse) = &self.last_mouse
         {
             content.write_tagged_line(
@@ -522,7 +522,7 @@ impl App {
                         last_mouse.mouse.modifiers,
                     ))
                     .style(
-                        self.settings
+                        crate::settings()
                             .colour_palette
                             .secondary_text()
                             .add_modifier(Modifier::BOLD),
@@ -541,7 +541,7 @@ impl App {
             content.write_tagged_line(
                 &TaggedLine::from_line(
                     Line::from(format!("       context: {}  action: {}", ctx, act)).style(
-                        self.settings
+                        crate::settings()
                             .colour_palette
                             .secondary_text()
                             .add_modifier(Modifier::BOLD),
@@ -559,7 +559,7 @@ impl App {
         });
 
         let (mut lprompt, rprompt, fill_span, prompt_ruler) = self.prompt_manager.get_ps1_lines(
-            self.settings.show_animations,
+            crate::settings().show_animations,
             mouse_state(|m| m.is_enabled()),
             leader_active,
             self.mode.is_running(),
@@ -707,7 +707,7 @@ impl App {
         );
 
         for part in self.formatted_buffer_cache.parts.iter() {
-            let animation_time = if self.mode.is_running() && self.settings.show_animations {
+            let animation_time = if self.mode.is_running() && crate::settings().show_animations {
                 Some(now)
             } else {
                 None
@@ -717,10 +717,9 @@ impl App {
                 part.get_spans(animation_time, selection_range.clone())
             {
                 if is_cancelled {
-                    sub_span.style = self.settings.colour_palette.secondary_text();
+                    sub_span.style = crate::settings().colour_palette.secondary_text();
                 } else if is_in_selection {
-                    sub_span.style = self
-                        .settings
+                    sub_span.style = crate::settings()
                         .colour_palette
                         .convert_to_selected(sub_span.style);
                 }
@@ -744,7 +743,7 @@ impl App {
                 let ps2_spans = self.prompt_manager.get_ps2(
                     line_idx + 1,
                     max_digits,
-                    self.settings.show_animations,
+                    crate::settings().show_animations,
                 );
                 for span in ps2_spans {
                     content.write_tagged_span(&span);
@@ -774,15 +773,15 @@ impl App {
             && let Some(cursor_pos) = cursor_pos_maybe
         {
             self.cursor.update_logical_pos(cursor_pos);
-            let cursor_render_pos = if self.settings.show_animations
-                && self.settings.cursor_config.backend() != CursorBackend::Terminal
+            let cursor_render_pos = if crate::settings().show_animations
+                && crate::settings().cursor_config.backend() != CursorBackend::Terminal
             {
-                self.cursor.get_render_pos(&self.settings.cursor_config)
+                self.cursor.get_render_pos(&crate::settings().cursor_config)
             } else {
                 cursor_pos
             };
             let cursor_style = {
-                if self.settings.cursor_config.backend() == CursorBackend::Terminal {
+                if crate::settings().cursor_config.backend() == CursorBackend::Terminal {
                     None
                 } else {
                     let focused = self.term_has_focus
@@ -799,14 +798,14 @@ impl App {
                             .selection_byte()
                             .is_some_and(|anchor| self.buffer.cursor_byte_pos() < anchor)
                     {
-                        self.settings.colour_palette.selected_text().bg
+                        crate::settings().colour_palette.selected_text().bg
                     } else {
                         None
                     };
-                    if self.settings.show_animations {
+                    if crate::settings().show_animations {
                         self.cursor.get_style(
                             focused,
-                            &self.settings.cursor_config,
+                            &crate::settings().cursor_config,
                             selection_bg,
                             selection_active && mouse_state(|m| m.is_left_button_down()),
                         )
@@ -837,7 +836,7 @@ impl App {
 
                     content.write_tagged_span_dont_overwrite(&TaggedSpan::new(
                         Span::from(line.to_owned())
-                            .style(self.settings.colour_palette.secondary_text()),
+                            .style(crate::settings().colour_palette.secondary_text()),
                         Tag::HistorySuggestion,
                     ));
 
@@ -850,15 +849,15 @@ impl App {
 
                         content.write_tagged_span_dont_overwrite(&TaggedSpan::new(
                             Span::from(extra_info_text)
-                                .style(self.settings.colour_palette.inline_suggestion()),
+                                .style(crate::settings().colour_palette.inline_suggestion()),
                             Tag::HistorySuggestion,
                         ));
 
-                        if self.settings.run_tutorial {
+                        if crate::settings().run_tutorial {
                             content.write_tagged_span_dont_overwrite(&TaggedSpan::new(
                                 Span::styled(
                                     " 💡 Press → or End to accept",
-                                    self.settings.colour_palette.tutorial_hint(),
+                                    crate::settings().colour_palette.tutorial_hint(),
                                 ),
                                 Tag::Tutorial,
                             ));
@@ -883,25 +882,25 @@ impl App {
             matches!(scrollbar_tag, Some(Tag::TabCompletionScrollBar { .. }));
         let scrollbar_style = if is_scrollbar_hovered {
             if mouse_state(|m| m.is_left_button_down()) {
-                self.settings
+                crate::settings()
                     .colour_palette
                     .scrollbar()
                     .fg(Color::Rgb(150, 150, 150))
             } else {
-                self.settings
+                crate::settings()
                     .colour_palette
                     .scrollbar()
                     .add_modifier(Modifier::DIM)
             }
         } else {
-            self.settings.colour_palette.scrollbar()
+            crate::settings().colour_palette.scrollbar()
         };
 
         match &mut self.content_mode {
             ContentMode::TabCompletion(active_suggestions) if self.mode.is_running() => {
                 if active_suggestions.auto_started {
                     Self::render_auto_suggestions(
-                        &self.settings,
+                        crate::settings(),
                         active_suggestions,
                         &mut content,
                         width,
@@ -914,7 +913,7 @@ impl App {
                     );
                 } else {
                     Self::render_user_suggestions(
-                        &self.settings,
+                        crate::settings(),
                         active_suggestions,
                         &mut content,
                         width,
@@ -933,7 +932,7 @@ impl App {
                 if now.duration_since(*start_time) >= std::time::Duration::from_millis(100) {
                     if *auto_started {
                         Self::render_auto_suggestions_loading(
-                            &self.settings,
+                            crate::settings(),
                             &mut content,
                             width,
                             cursor_pos_maybe,
@@ -951,7 +950,7 @@ impl App {
                 } else if let Some(active_suggestions) = last_active_suggestions {
                     if *auto_started {
                         Self::render_auto_suggestions(
-                            &self.settings,
+                            crate::settings(),
                             active_suggestions,
                             &mut content,
                             width,
@@ -964,7 +963,7 @@ impl App {
                         );
                     } else {
                         Self::render_user_suggestions(
-                            &self.settings,
+                            crate::settings(),
                             active_suggestions,
                             &mut content,
                             width,
@@ -982,20 +981,20 @@ impl App {
                 ..
             } if self.mode.is_running() => {
                 content.newline();
-                let sandbox_status = self.settings.flycomp.sandbox_status();
+                let sandbox_status = crate::settings().flycomp.sandbox_status();
                 let sandbox_word = sandbox_status.label();
                 let sandbox_msg = sandbox_status.description();
 
                 let hover = mouse_state(|m| m.last_mouse_over_cell_semantic)
                     == Some(Tag::FlycompSandboxInfo);
                 let sandbox_word_style = if hover {
-                    self.settings
+                    crate::settings()
                         .colour_palette
                         .key_sequence_style()
                         .add_modifier(Modifier::UNDERLINED)
                         .add_modifier(Modifier::BOLD)
                 } else {
-                    self.settings
+                    crate::settings()
                         .colour_palette
                         .key_sequence_style()
                         .add_modifier(Modifier::UNDERLINED)
@@ -1004,13 +1003,13 @@ impl App {
                 let flycomp_hover =
                     mouse_state(|m| m.last_mouse_over_cell_semantic) == Some(Tag::FlycompInfo);
                 let flycomp_style = if flycomp_hover {
-                    self.settings
+                    crate::settings()
                         .colour_palette
                         .key_sequence_style()
                         .add_modifier(Modifier::UNDERLINED)
                         .add_modifier(Modifier::BOLD)
                 } else {
-                    self.settings
+                    crate::settings()
                         .colour_palette
                         .key_sequence_style()
                         .add_modifier(Modifier::UNDERLINED)
@@ -1023,7 +1022,7 @@ impl App {
                 };
 
                 content.write_tagged_span(&TaggedSpan::new(
-                    Span::styled(prefix_msg, self.settings.colour_palette.normal_text()),
+                    Span::styled(prefix_msg, crate::settings().colour_palette.normal_text()),
                     Tag::Normal,
                 ));
 
@@ -1035,7 +1034,7 @@ impl App {
                 ));
 
                 content.write_tagged_span(&TaggedSpan::new(
-                    Span::styled(" (", self.settings.colour_palette.normal_text()),
+                    Span::styled(" (", crate::settings().colour_palette.normal_text()),
                     Tag::Normal,
                 ));
 
@@ -1049,21 +1048,21 @@ impl App {
                 let suffix_msg = format!(") to synthesize completions for '{}'?", command_word);
 
                 content.write_tagged_span(&TaggedSpan::new(
-                    Span::styled(suffix_msg, self.settings.colour_palette.normal_text()),
+                    Span::styled(suffix_msg, crate::settings().colour_palette.normal_text()),
                     Tag::Normal,
                 ));
                 content.newline();
                 content.write_tagged_span(&TaggedSpan::new(
                     Span::styled(
                         "  Would create: ",
-                        self.settings.colour_palette.normal_text(),
+                        crate::settings().colour_palette.normal_text(),
                     ),
                     Tag::Normal,
                 ));
                 content.write_tagged_span(&TaggedSpan::new(
                     Span::styled(
                         dump_path.to_string(),
-                        self.settings.colour_palette.key_sequence_style(),
+                        crate::settings().colour_palette.key_sequence_style(),
                     ),
                     Tag::Normal,
                 ));
@@ -1071,7 +1070,7 @@ impl App {
                 content.write_tagged_span(&TaggedSpan::new(
                     Span::styled(
                         ">",
-                        self.settings
+                        crate::settings()
                             .colour_palette
                             .normal_text()
                             .add_modifier(Modifier::BOLD),
@@ -1079,7 +1078,10 @@ impl App {
                     Tag::Normal,
                 ));
                 content.write_tagged_span(&TaggedSpan::new(
-                    Span::styled("  Proceed? ", self.settings.colour_palette.normal_text()),
+                    Span::styled(
+                        "  Proceed? ",
+                        crate::settings().colour_palette.normal_text(),
+                    ),
                     Tag::Normal,
                 ));
 
@@ -1131,7 +1133,7 @@ impl App {
                 content.newline();
 
                 if hover {
-                    let popup_style = self.settings.colour_palette.normal_text();
+                    let popup_style = crate::settings().colour_palette.normal_text();
                     content.draw_popup(
                         sandbox_msg,
                         anchor_pos.row + 1,
@@ -1143,7 +1145,7 @@ impl App {
                 }
 
                 if flycomp_hover {
-                    let popup_style = self.settings.colour_palette.normal_text();
+                    let popup_style = crate::settings().colour_palette.normal_text();
                     let flycomp_msg = "flycomp parses CLI `--help` outputs and man pages to dynamically synthesize shell completion scripts.\nGitHub: https://github.com/HalFrgrd/flycomp";
                     content.draw_popup(
                         flycomp_msg,
@@ -1191,7 +1193,7 @@ impl App {
                 content.write_tagged_span(&TaggedSpan::new(
                     Span::styled(
                         "Press any key to return to normal editing.",
-                        self.settings.colour_palette.secondary_text(),
+                        crate::settings().colour_palette.secondary_text(),
                     ),
                     Tag::Normal,
                 ));
@@ -1205,23 +1207,20 @@ impl App {
                     .clamp(2, 30);
 
                 let history_buffer = self.buffer.buffer();
-                // Use explicit field borrows instead of `select_fuzzy_history_manager_mut` to allow
-                // split-borrowing: `fuzzy_results` borrows only the specific manager field while
-                // `self.settings.color_palette` (a different field) remains accessible below.
                 let default_index = match source {
                     FuzzyHistorySource::PastCommands => Some(0),
                     FuzzyHistorySource::CancelledCommands => Some(0),
                     FuzzyHistorySource::AgentPrompts => None,
                 };
-                let colour_palette = self.settings.colour_palette.clone();
+                let colour_palette = crate::settings().colour_palette.clone();
                 let (entries, fuzzy_results, fuzzy_search_index, num_results, num_searched) =
                     match source {
-                        FuzzyHistorySource::PastCommands => &mut self.settings.history_manager,
+                        FuzzyHistorySource::PastCommands => &mut crate::settings().history_manager,
                         FuzzyHistorySource::CancelledCommands => {
-                            &mut self.settings.cancelled_command_history_manager
+                            &mut crate::settings().cancelled_command_history_manager
                         }
                         FuzzyHistorySource::AgentPrompts => {
-                            &mut self.settings.agent_prompt_history_manager
+                            &mut crate::settings().agent_prompt_history_manager
                         }
                     }
                     .get_fuzzy_search_results(
@@ -1280,7 +1279,7 @@ impl App {
                 content.write_tagged_span(&TaggedSpan::new(
                     Span::styled(
                         format!("# {}: {}/{}", source.label(), num_results, num_searched),
-                        self.settings.colour_palette.secondary_text(),
+                        crate::settings().colour_palette.secondary_text(),
                     ),
                     Tag::FuzzySearch,
                 ));
@@ -1290,7 +1289,7 @@ impl App {
                     content.newline();
                     let tooltip_line = Line::from(Span::styled(
                         tooltip.clone(),
-                        self.settings.colour_palette.secondary_text(),
+                        crate::settings().colour_palette.secondary_text(),
                     ));
 
                     let max_tool_tip_rows: u16 = 3;
@@ -1315,7 +1314,7 @@ impl App {
                             content.set_cursor_col(last_col);
                         }
                         content.write_tagged_span(&TaggedSpan::new(
-                            Span::styled("…", self.settings.colour_palette.secondary_text()),
+                            Span::styled("…", crate::settings().colour_palette.secondary_text()),
                             Tag::Tooltip,
                         ));
                     }
@@ -1334,7 +1333,7 @@ impl App {
                 let command_display_span = TaggedSpan::new(
                     Span::styled(
                         command_display.clone(),
-                        self.settings.colour_palette.secondary_text(),
+                        crate::settings().colour_palette.secondary_text(),
                     ),
                     Tag::Normal,
                 );
@@ -1353,12 +1352,12 @@ impl App {
                     }
                     let indicator = if is_selected { "▐" } else { " " };
                     let indicator_style = if is_selected {
-                        self.settings
+                        crate::settings()
                             .colour_palette
                             .matching_char()
                             .remove_modifier(Modifier::UNDERLINED)
                     } else {
-                        self.settings.colour_palette.secondary_text()
+                        crate::settings().colour_palette.secondary_text()
                     };
                     content.write_tagged_span(&TaggedSpan::new(
                         Span::styled(indicator, indicator_style),
@@ -1367,10 +1366,10 @@ impl App {
                     // Description line
                     let desc_style = if is_selected {
                         Palette::convert_to_highlighted(
-                            self.settings.colour_palette.secondary_text(),
+                            crate::settings().colour_palette.secondary_text(),
                         )
                     } else {
-                        self.settings.colour_palette.secondary_text()
+                        crate::settings().colour_palette.secondary_text()
                     };
                     content.write_tagged_span(&TaggedSpan::new(
                         Span::styled(suggestion.description.clone(), desc_style),
@@ -1395,8 +1394,8 @@ impl App {
                         None,
                         cmd.len(),
                         false,
-                        &self.settings.colour_palette,
-                        self.settings.enable_easter_eggs,
+                        &crate::settings().colour_palette,
+                        crate::settings().enable_easter_eggs,
                     );
                     for part in &formatted_cmd.parts {
                         if matches!(part.token.token.kind, TokenKind::Newline) {
@@ -1441,7 +1440,7 @@ impl App {
                         content.write_tagged_span(&TaggedSpan::new(
                             Span::styled(
                                 line.to_string(),
-                                self.settings.colour_palette.secondary_text(),
+                                crate::settings().colour_palette.secondary_text(),
                             ),
                             Tag::Normal,
                         ));
@@ -1454,7 +1453,7 @@ impl App {
                     "Press Enter to run `flyline set-agent-mode --help`.".to_string()
                 };
                 content.write_tagged_span(&TaggedSpan::new(
-                    Span::styled(hint, self.settings.colour_palette.secondary_text()),
+                    Span::styled(hint, crate::settings().colour_palette.secondary_text()),
                     Tag::Blank,
                 ));
             }
@@ -1462,7 +1461,7 @@ impl App {
         }
 
         let show_matrix = self.mode.is_running()
-            && match &self.settings.matrix_animation {
+            && match &crate::settings().matrix_animation {
                 MatrixAnimation::Off => false,
                 MatrixAnimation::On => true,
                 MatrixAnimation::IdleSecs(secs) => {
@@ -1512,7 +1511,7 @@ impl App {
                 ("↷ Redo", Tag::RightClickRedo),
             ];
             let selected_tag = mouse_state(|m| m.last_mouse_over_cell_semantic);
-            let style = self.settings.colour_palette.right_click_menu();
+            let style = crate::settings().colour_palette.right_click_menu();
             let selected_style = Palette::convert_to_highlighted(style);
 
             let showing_history_details = matches!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1002,7 +1002,7 @@ enum PromptWidgetSubcommands {
 #[cfg(not(test))]
 pub(crate) fn call(words: *const bash_symbols::WordList) -> c_int {
     let _sigchld_guard = crate::SigchldGuard::new();
-    let mut settings = crate::settings();
+    let settings = crate::settings();
     let mut args = vec![];
     unsafe {
         let mut current = words;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,6 @@ use strum::VariantArray;
 
 #[allow(unused_imports)]
 use crate::{
-    Flyline,
     app::actions::{self},
     content,
     cursor::{self, CursorStyleConfig},
@@ -1000,814 +999,799 @@ enum PromptWidgetSubcommands {
         inactive_text: String,
     },
 }
-impl Flyline {
-    #[cfg(not(test))]
-    pub(crate) fn call(&mut self, words: *const bash_symbols::WordList) -> c_int {
-        let _sigchld_guard = crate::SigchldGuard::new();
-        let mut args = vec![];
-        unsafe {
-            let mut current = words;
-            while !current.is_null() {
-                let word_desc = &*(*current).word;
-                if !word_desc.word.is_null() {
-                    let c_str = std::ffi::CStr::from_ptr(word_desc.word);
-                    if let Ok(str_slice) = c_str.to_str() {
-                        args.push(str_slice);
-                        // TODO what do the flags mean?
-                        // println!("arg: {} flags: {}", str_slice, word_desc.flags);
-                    }
+#[cfg(not(test))]
+pub(crate) fn call(words: *const bash_symbols::WordList) -> c_int {
+    let _sigchld_guard = crate::SigchldGuard::new();
+    let mut settings = crate::settings();
+    let mut args = vec![];
+    unsafe {
+        let mut current = words;
+        while !current.is_null() {
+            let word_desc = &*(*current).word;
+            if !word_desc.word.is_null() {
+                let c_str = std::ffi::CStr::from_ptr(word_desc.word);
+                if let Ok(str_slice) = c_str.to_str() {
+                    args.push(str_slice);
+                    // TODO what do the flags mean?
+                    // println!("arg: {} flags: {}", str_slice, word_desc.flags);
                 }
-                current = (*current).next;
             }
+            current = (*current).next;
         }
-        log::debug!("flyline called with args: {:?}", args);
+    }
+    log::debug!("flyline called with args: {:?}", args);
 
-        // args contains words from WordList; first word is not the command name unlike argv
-        let args_with_prog = std::iter::once("flyline").chain(args.iter().copied());
+    // args contains words from WordList; first word is not the command name unlike argv
+    let args_with_prog = std::iter::once("flyline").chain(args.iter().copied());
 
-        match FlylineArgs::try_parse_from(args_with_prog) {
-            Ok(parsed) if !args.is_empty() => {
-                log::debug!("Parsed flyline arguments: {:?}", parsed);
+    match FlylineArgs::try_parse_from(args_with_prog) {
+        Ok(parsed) if !args.is_empty() => {
+            log::debug!("Parsed flyline arguments: {:?}", parsed);
 
-                if parsed.version {
-                    show_version(false);
+            if parsed.version {
+                show_version(false);
+                return shell::BuiltinExitCode::ExecutionSuccess as c_int;
+            }
+
+            if let Some(path) = parsed.load_zsh_history {
+                settings.zsh_history_path = Some(path);
+            }
+
+            if let Some(enabled) = parsed.show_animations {
+                log::info!("Animations disabled: {}", enabled);
+                settings.show_animations = enabled;
+            }
+
+            if let Some(val) = parsed.matrix_animation {
+                log::info!("Matrix animation set to {:?}", val);
+                settings.matrix_animation = val;
+            }
+
+            if let Some(fps) = parsed.frame_rate {
+                log::info!("Frame rate set to {}", fps);
+                settings.frame_rate = fps;
+            }
+
+            if let Some(mode) = parsed.mouse_mode {
+                log::info!("Mouse mode set to {:?}", mode);
+                settings.mouse_mode = mode;
+            }
+
+            if let Some(level) = parsed.send_shell_integration_codes {
+                log::info!("Shell integration codes set to {:?}", level);
+                settings.send_shell_integration_codes = level;
+            }
+
+            if let Some(enabled) = parsed.enable_extended_key_codes {
+                log::info!("Extended keyboard codes enabled: {}", enabled);
+                settings.enable_extended_key_codes = enabled;
+            }
+
+            if let Some(enabled) = parsed.enable_easter_eggs {
+                log::info!("Easter eggs enabled: {}", enabled);
+                settings.enable_easter_eggs = enabled;
+            }
+
+            if let Some(logic) = parsed.set_resize_logic {
+                log::info!("Resize logic set to {:?}", logic);
+                settings.resize_logic = logic;
+            }
+
+            match parsed.command {
+                Some(Commands::Version { copy }) => {
+                    show_version(copy);
                     return shell::BuiltinExitCode::ExecutionSuccess as c_int;
                 }
-
-                if let Some(path) = parsed.load_zsh_history {
-                    self.settings.zsh_history_path = Some(path);
-                }
-
-                if let Some(enabled) = parsed.show_animations {
-                    log::info!("Animations disabled: {}", enabled);
-                    self.settings.show_animations = enabled;
-                }
-
-                if let Some(val) = parsed.matrix_animation {
-                    log::info!("Matrix animation set to {:?}", val);
-                    self.settings.matrix_animation = val;
-                }
-
-                if let Some(fps) = parsed.frame_rate {
-                    log::info!("Frame rate set to {}", fps);
-                    self.settings.frame_rate = fps;
-                }
-
-                if let Some(mode) = parsed.mouse_mode {
-                    log::info!("Mouse mode set to {:?}", mode);
-                    self.settings.mouse_mode = mode;
-                }
-
-                if let Some(level) = parsed.send_shell_integration_codes {
-                    log::info!("Shell integration codes set to {:?}", level);
-                    self.settings.send_shell_integration_codes = level;
-                }
-
-                if let Some(enabled) = parsed.enable_extended_key_codes {
-                    log::info!("Extended keyboard codes enabled: {}", enabled);
-                    self.settings.enable_extended_key_codes = enabled;
-                }
-
-                if let Some(enabled) = parsed.enable_easter_eggs {
-                    log::info!("Easter eggs enabled: {}", enabled);
-                    self.settings.enable_easter_eggs = enabled;
-                }
-
-                if let Some(logic) = parsed.set_resize_logic {
-                    log::info!("Resize logic set to {:?}", logic);
-                    self.settings.resize_logic = logic;
-                }
-
-                match parsed.command {
-                    Some(Commands::Version { copy }) => {
-                        show_version(copy);
-                        return shell::BuiltinExitCode::ExecutionSuccess as c_int;
+                Some(Commands::AgentMode {
+                    system_prompt,
+                    trigger_prefix,
+                    command,
+                }) => {
+                    let command_args: Vec<String> = shlex::split(&command)
+                        .unwrap_or_else(|| command.split_whitespace().map(String::from).collect());
+                    if command_args.is_empty() {
+                        return_usage_error!("flyline set-agent-mode: --command must not be empty");
                     }
-                    Some(Commands::AgentMode {
-                        system_prompt,
-                        trigger_prefix,
+                    log::info!(
+                        "AI command set: {:?} (trigger_prefix={:?})",
+                        command_args,
+                        trigger_prefix
+                    );
+                    settings.agent_commands.insert(
+                        trigger_prefix.clone(),
+                        settings::AgentModeCommand {
+                            command: command_args,
+                            system_prompt: system_prompt.clone(),
+                        },
+                    );
+                }
+                Some(Commands::CreatePromptWidget { subcommand }) => match subcommand {
+                    PromptWidgetSubcommands::Animation {
+                        name,
+                        fps,
+                        frames,
+                        ping_pong,
+                    } => {
+                        if fps <= 0.0 {
+                            return_usage_error!(
+                                "flyline create-prompt-widget animation: --fps must be greater than 0 (got {}); animation '{}' not registered",
+                                fps,
+                                name
+                            );
+                        }
+                        log::info!(
+                            "Registering animation '{}' at {} fps with {} frame(s) (ping_pong={})",
+                            name,
+                            fps,
+                            frames.len(),
+                            ping_pong
+                        );
+                        settings.custom_animations.insert(
+                            name.clone(),
+                            settings::PromptAnimation {
+                                name,
+                                fps,
+                                frames,
+                                ping_pong,
+                            },
+                        );
+                    }
+                    PromptWidgetSubcommands::MouseMode {
+                        name,
+                        enabled_text,
+                        disabled_text,
+                    } => {
+                        log::info!(
+                            "Registering mouse-mode widget '{}' (enabled={:?}, disabled={:?})",
+                            name,
+                            enabled_text,
+                            disabled_text
+                        );
+                        settings.custom_prompt_widgets.insert(
+                            name.clone(),
+                            settings::PromptWidget::MouseMode {
+                                name,
+                                enabled_text,
+                                disabled_text,
+                            },
+                        );
+                    }
+                    PromptWidgetSubcommands::CopyBuffer { name, text } => {
+                        log::info!(
+                            "Registering copy-buffer widget '{}' (text={:?})",
+                            name,
+                            text
+                        );
+                        settings.custom_prompt_widgets.insert(
+                            name.clone(),
+                            settings::PromptWidget::CopyBuffer { name, text },
+                        );
+                    }
+                    PromptWidgetSubcommands::Custom {
+                        name,
                         command,
-                    }) => {
+                        block,
+                        placeholder,
+                    } => {
                         let command_args: Vec<String> =
                             shlex::split(&command).unwrap_or_else(|| {
                                 command.split_whitespace().map(String::from).collect()
                             });
                         if command_args.is_empty() {
                             return_usage_error!(
-                                "flyline set-agent-mode: --command must not be empty"
+                                "flyline create-prompt-widget custom: --command must not be empty"
                             );
                         }
+                        if let Some(ms) = block
+                            && ms < 0
+                        {
+                            return_usage_error!(
+                                "flyline create-prompt-widget custom: --block timeout must be non-negative (got {})",
+                                ms
+                            );
+                        }
+                        let placeholder_spec = match placeholder {
+                            None => None,
+                            Some(ref s) if s == "prev" => Some(settings::Placeholder::Prev),
+                            Some(ref s) => match s.parse::<usize>() {
+                                Ok(n) => Some(settings::Placeholder::Spaces(n)),
+                                Err(_) => {
+                                    return_usage_error!(
+                                        "flyline create-prompt-widget custom: --placeholder must be a number or 'prev', got {:?}",
+                                        s
+                                    );
+                                }
+                            },
+                        };
                         log::info!(
-                            "AI command set: {:?} (trigger_prefix={:?})",
+                            "Registering custom widget '{}' (command={:?}, block={:?}, placeholder={:?})",
+                            name,
                             command_args,
-                            trigger_prefix
+                            block,
+                            placeholder
                         );
-                        self.settings.agent_commands.insert(
-                            trigger_prefix.clone(),
-                            settings::AgentModeCommand {
+                        settings.custom_prompt_widgets.insert(
+                            name.clone(),
+                            settings::PromptWidget::Custom(settings::PromptWidgetCustom {
+                                name,
                                 command: command_args,
-                                system_prompt: system_prompt.clone(),
+                                block,
+                                placeholder: placeholder_spec.unwrap_or_default(),
+                                prev_output: std::sync::Arc::new(std::sync::Mutex::new(vec![])),
+                            }),
+                        );
+                    }
+                    PromptWidgetSubcommands::LastCommandDuration { name } => {
+                        log::info!("Registering last-command-duration widget '{}'", name);
+                        settings.custom_prompt_widgets.insert(
+                            name.clone(),
+                            settings::PromptWidget::LastCommandDuration { name },
+                        );
+                    }
+                    PromptWidgetSubcommands::LeaderMode {
+                        name,
+                        active_text,
+                        inactive_text,
+                    } => {
+                        log::info!(
+                            "Registering leader-mode widget '{}' (active={:?}, inactive={:?})",
+                            name,
+                            active_text,
+                            inactive_text
+                        );
+                        settings.custom_prompt_widgets.insert(
+                            name.clone(),
+                            settings::PromptWidget::LeaderMode {
+                                name,
+                                active_text,
+                                inactive_text,
                             },
                         );
                     }
-                    Some(Commands::CreatePromptWidget { subcommand }) => match subcommand {
-                        PromptWidgetSubcommands::Animation {
-                            name,
-                            fps,
-                            frames,
-                            ping_pong,
-                        } => {
-                            if fps <= 0.0 {
+                },
+                Some(Commands::SetColour {
+                    default_theme,
+                    styles,
+                }) => {
+                    if let Some(preset) = default_theme {
+                        settings.colour_palette.apply_theme(preset);
+                        log::info!("Colour theme set to {:?}", preset);
+                    }
+
+                    for spec in &styles {
+                        let Some((name, style_str)) = spec.split_once('=') else {
+                            return_usage_error!(
+                                "flyline set-style: argument must be NAME=STYLE, got {:?}",
+                                spec
+                            );
+                        };
+                        let kind = match name.parse::<palette::PaletteStyleKind>() {
+                            Ok(k) => k,
+                            Err(_) => {
                                 return_usage_error!(
-                                    "flyline create-prompt-widget animation: --fps must be greater than 0 (got {}); animation '{}' not registered",
-                                    fps,
+                                    "flyline set-style: unknown style name {:?}. Run 'flyline set-style --help' for valid names.",
                                     name
                                 );
                             }
-                            log::info!(
-                                "Registering animation '{}' at {} fps with {} frame(s) (ping_pong={})",
-                                name,
-                                fps,
-                                frames.len(),
-                                ping_pong
-                            );
-                            self.settings.custom_animations.insert(
-                                name.clone(),
-                                settings::PromptAnimation {
-                                    name,
-                                    fps,
-                                    frames,
-                                    ping_pong,
-                                },
-                            );
-                        }
-                        PromptWidgetSubcommands::MouseMode {
-                            name,
-                            enabled_text,
-                            disabled_text,
-                        } => {
-                            log::info!(
-                                "Registering mouse-mode widget '{}' (enabled={:?}, disabled={:?})",
-                                name,
-                                enabled_text,
-                                disabled_text
-                            );
-                            self.settings.custom_prompt_widgets.insert(
-                                name.clone(),
-                                settings::PromptWidget::MouseMode {
-                                    name,
-                                    enabled_text,
-                                    disabled_text,
-                                },
-                            );
-                        }
-                        PromptWidgetSubcommands::CopyBuffer { name, text } => {
-                            log::info!(
-                                "Registering copy-buffer widget '{}' (text={:?})",
-                                name,
-                                text
-                            );
-                            self.settings.custom_prompt_widgets.insert(
-                                name.clone(),
-                                settings::PromptWidget::CopyBuffer { name, text },
-                            );
-                        }
-                        PromptWidgetSubcommands::Custom {
-                            name,
-                            command,
-                            block,
-                            placeholder,
-                        } => {
-                            let command_args: Vec<String> =
-                                shlex::split(&command).unwrap_or_else(|| {
-                                    command.split_whitespace().map(String::from).collect()
-                                });
-                            if command_args.is_empty() {
+                        };
+                        match palette::parse_str_to_style(style_str) {
+                            Ok(style) => {
+                                settings.colour_palette.set(kind, style);
+                                log::info!("{} style set to {:?}", name, style_str);
+                            }
+                            Err(e) => {
                                 return_usage_error!(
-                                    "flyline create-prompt-widget custom: --command must not be empty"
+                                    "flyline set-style: invalid style for {:?}: {}",
+                                    name,
+                                    e
                                 );
                             }
-                            if let Some(ms) = block
-                                && ms < 0
-                            {
-                                return_usage_error!(
-                                    "flyline create-prompt-widget custom: --block timeout must be non-negative (got {})",
-                                    ms
-                                );
-                            }
-                            let placeholder_spec = match placeholder {
-                                None => None,
-                                Some(ref s) if s == "prev" => Some(settings::Placeholder::Prev),
-                                Some(ref s) => match s.parse::<usize>() {
-                                    Ok(n) => Some(settings::Placeholder::Spaces(n)),
-                                    Err(_) => {
-                                        return_usage_error!(
-                                            "flyline create-prompt-widget custom: --placeholder must be a number or 'prev', got {:?}",
-                                            s
-                                        );
-                                    }
-                                },
-                            };
-                            log::info!(
-                                "Registering custom widget '{}' (command={:?}, block={:?}, placeholder={:?})",
-                                name,
-                                command_args,
-                                block,
-                                placeholder
-                            );
-                            self.settings.custom_prompt_widgets.insert(
-                                name.clone(),
-                                settings::PromptWidget::Custom(settings::PromptWidgetCustom {
-                                    name,
-                                    command: command_args,
-                                    block,
-                                    placeholder: placeholder_spec.unwrap_or_default(),
-                                    prev_output: std::sync::Arc::new(std::sync::Mutex::new(vec![])),
-                                }),
-                            );
                         }
-                        PromptWidgetSubcommands::LastCommandDuration { name } => {
-                            log::info!("Registering last-command-duration widget '{}'", name);
-                            self.settings.custom_prompt_widgets.insert(
-                                name.clone(),
-                                settings::PromptWidget::LastCommandDuration { name },
-                            );
-                        }
-                        PromptWidgetSubcommands::LeaderMode {
-                            name,
-                            active_text,
-                            inactive_text,
-                        } => {
-                            log::info!(
-                                "Registering leader-mode widget '{}' (active={:?}, inactive={:?})",
-                                name,
-                                active_text,
-                                inactive_text
-                            );
-                            self.settings.custom_prompt_widgets.insert(
-                                name.clone(),
-                                settings::PromptWidget::LeaderMode {
-                                    name,
-                                    active_text,
-                                    inactive_text,
-                                },
-                            );
-                        }
-                    },
-                    Some(Commands::SetColour {
-                        default_theme,
-                        styles,
-                    }) => {
-                        if let Some(preset) = default_theme {
-                            self.settings.colour_palette.apply_theme(preset);
-                            log::info!("Colour theme set to {:?}", preset);
-                        }
+                    }
+                }
+                Some(Commands::Key {
+                    debug,
+                    clear_defaults,
+                    subcommand,
+                }) => {
+                    if let Some(enabled) = debug {
+                        log::info!("Key debug mode enabled: {}", enabled);
+                        settings.key_debug = enabled;
+                    }
+                    if let Some(enabled) = clear_defaults {
+                        log::info!("Clear default keybindings: {}", enabled);
+                        settings.clear_default_keybindings = enabled;
+                        actions::CLEAR_DEFAULTS
+                            .store(enabled, std::sync::atomic::Ordering::Relaxed);
+                    }
 
-                        for spec in &styles {
-                            let Some((name, style_str)) = spec.split_once('=') else {
-                                return_usage_error!(
-                                    "flyline set-style: argument must be NAME=STYLE, got {:?}",
-                                    spec
-                                );
-                            };
-                            let kind = match name.parse::<palette::PaletteStyleKind>() {
-                                Ok(k) => k,
-                                Err(_) => {
-                                    return_usage_error!(
-                                        "flyline set-style: unknown style name {:?}. Run 'flyline set-style --help' for valid names.",
-                                        name
+                    match subcommand {
+                        Some(KeySubcommands::Bind {
+                            key_sequence,
+                            context_and_action,
+                        }) => {
+                            let binding = actions::Binding::try_new_from_strs(
+                                &key_sequence,
+                                &context_and_action,
+                            );
+                            match binding {
+                                Ok(binding) => {
+                                    log::info!(
+                                        "Registering key binding: {} -> {}",
+                                        key_sequence,
+                                        context_and_action
                                     );
+                                    settings.keybindings.push(binding);
                                 }
-                            };
-                            match palette::parse_str_to_style(style_str) {
-                                Ok(style) => {
-                                    self.settings.colour_palette.set(kind, style);
-                                    log::info!("{} style set to {:?}", name, style_str);
+                                Err(e) => {
+                                    return_usage_error!("flyline key bind: {}", e);
+                                }
+                            }
+                        }
+                        Some(KeySubcommands::List { key_sequence }) => {
+                            actions::print_bindings_table(
+                                &settings.keybindings,
+                                key_sequence.as_deref(),
+                                &settings.key_remappings,
+                            );
+                        }
+                        Some(KeySubcommands::Remap { from, to }) => {
+                            match actions::try_parse_remap(&from, &to) {
+                                Ok(remap) => {
+                                    log::info!("Registering key remap: {} -> {}", from, to);
+                                    settings.key_remappings.push(remap);
                                 }
                                 Err(e) => {
                                     return_usage_error!(
-                                        "flyline set-style: invalid style for {:?}: {}",
-                                        name,
+                                        "flyline key remap: failed to parse remap '{}' -> '{}': {}",
+                                        from,
+                                        to,
                                         e
                                     );
                                 }
                             }
                         }
+                        None => {}
                     }
-                    Some(Commands::Key {
-                        debug,
-                        clear_defaults,
-                        subcommand,
-                    }) => {
-                        if let Some(enabled) = debug {
-                            log::info!("Key debug mode enabled: {}", enabled);
-                            self.settings.key_debug = enabled;
-                        }
-                        if let Some(enabled) = clear_defaults {
-                            log::info!("Clear default keybindings: {}", enabled);
-                            self.settings.clear_default_keybindings = enabled;
-                            actions::CLEAR_DEFAULTS
-                                .store(enabled, std::sync::atomic::Ordering::Relaxed);
-                        }
-
-                        match subcommand {
-                            Some(KeySubcommands::Bind {
-                                key_sequence,
-                                context_and_action,
-                            }) => {
-                                let binding = actions::Binding::try_new_from_strs(
-                                    &key_sequence,
-                                    &context_and_action,
-                                );
-                                match binding {
-                                    Ok(binding) => {
-                                        log::info!(
-                                            "Registering key binding: {} -> {}",
-                                            key_sequence,
-                                            context_and_action
-                                        );
-                                        self.settings.keybindings.push(binding);
-                                    }
-                                    Err(e) => {
-                                        return_usage_error!("flyline key bind: {}", e);
+                }
+                Some(Commands::Mouse {
+                    debug,
+                    change_shape,
+                    mode,
+                }) => {
+                    if let Some(enabled) = debug {
+                        log::info!("Mouse debug mode enabled: {}", enabled);
+                        settings.mouse_debug = enabled;
+                    }
+                    if let Some(enabled) = change_shape {
+                        log::info!("Mouse change shape enabled: {}", enabled);
+                        settings.mouse_change_shape = enabled;
+                    }
+                    if let Some(m) = mode {
+                        log::info!("Mouse mode set to {:?}", m);
+                        settings.mouse_mode = m;
+                    }
+                }
+                None => {}
+                Some(Commands::Log { subcommand }) => match subcommand {
+                    LogSubcommands::Dump { last } => {
+                        match crate::logging::get_filtered_logs(last.as_deref()) {
+                            Ok(entries) => {
+                                use std::io::Write;
+                                let stdout = std::io::stdout();
+                                let mut out = stdout.lock();
+                                for entry in entries {
+                                    if let Err(e) = writeln!(out, "{}", entry) {
+                                        eprintln!("Failed to write log entry: {}", e);
                                     }
                                 }
                             }
-                            Some(KeySubcommands::List { key_sequence }) => {
-                                actions::print_bindings_table(
-                                    &self.settings.keybindings,
-                                    key_sequence.as_deref(),
-                                    &self.settings.key_remappings,
-                                );
+                            Err(e) => {
+                                eprintln!("Failed to retrieve logs: {}", e);
                             }
-                            Some(KeySubcommands::Remap { from, to }) => {
-                                match actions::try_parse_remap(&from, &to) {
-                                    Ok(remap) => {
-                                        log::info!("Registering key remap: {} -> {}", from, to);
-                                        self.settings.key_remappings.push(remap);
-                                    }
-                                    Err(e) => {
-                                        return_usage_error!(
-                                            "flyline key remap: failed to parse remap '{}' -> '{}': {}",
-                                            from,
-                                            to,
-                                            e
-                                        );
-                                    }
-                                }
-                            }
-                            None => {}
                         }
                     }
-                    Some(Commands::Mouse {
-                        debug,
-                        change_shape,
-                        mode,
-                    }) => {
-                        if let Some(enabled) = debug {
-                            log::info!("Mouse debug mode enabled: {}", enabled);
-                            self.settings.mouse_debug = enabled;
-                        }
-                        if let Some(enabled) = change_shape {
-                            log::info!("Mouse change shape enabled: {}", enabled);
-                            self.settings.mouse_change_shape = enabled;
-                        }
-                        if let Some(m) = mode {
-                            log::info!("Mouse mode set to {:?}", m);
-                            self.settings.mouse_mode = m;
-                        }
-                    }
-                    None => {}
-                    Some(Commands::Log { subcommand }) => match subcommand {
-                        LogSubcommands::Dump { last } => {
-                            match crate::logging::get_filtered_logs(last.as_deref()) {
-                                Ok(entries) => {
-                                    use std::io::Write;
-                                    let stdout = std::io::stdout();
-                                    let mut out = stdout.lock();
-                                    for entry in entries {
-                                        if let Err(e) = writeln!(out, "{}", entry) {
-                                            eprintln!("Failed to write log entry: {}", e);
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    eprintln!("Failed to retrieve logs: {}", e);
-                                }
-                            }
-                        }
-                        LogSubcommands::Copy { last } => {
-                            match crate::logging::get_filtered_logs(last.as_deref()) {
-                                Ok(entries) => {
-                                    let len = entries.len();
-                                    let logs_to_copy = if len > 10_000 {
-                                        entries[len - 10_000..].to_vec()
-                                    } else {
-                                        entries
-                                    };
-                                    let joined_logs = logs_to_copy.join("\n");
-                                    if let Err(e) = crate::flush_stdout!(
-                                        "{}",
-                                        termina::escape::osc::Osc::SetSelection(
-                                            termina::escape::osc::Selection::CLIPBOARD,
-                                            &joined_logs
-                                        )
-                                    ) {
-                                        eprintln!(
-                                            "Failed to copy logs to clipboard via OSC 52: {}",
-                                            e
-                                        );
-                                    } else {
-                                        println!("Copied {} log lines!", logs_to_copy.len());
-                                    }
-                                }
-                                Err(e) => {
-                                    eprintln!("Failed to retrieve logs: {}", e);
-                                }
-                            }
-                        }
-                        LogSubcommands::SetLevel { level } => {
-                            let filter = log::LevelFilter::from(level);
-                            log::set_max_level(filter);
-                            log::info!("Log level set to {:?}", filter);
-                        }
-                        LogSubcommands::Stream { dest } => match logging::stream_logs(&dest) {
-                            Ok(()) => {
-                                if dest == "terminal" {
-                                    log::info!("Log streaming to terminal");
+                    LogSubcommands::Copy { last } => {
+                        match crate::logging::get_filtered_logs(last.as_deref()) {
+                            Ok(entries) => {
+                                let len = entries.len();
+                                let logs_to_copy = if len > 10_000 {
+                                    entries[len - 10_000..].to_vec()
                                 } else {
-                                    println!("Flyline logs streaming to {}", dest);
+                                    entries
+                                };
+                                let joined_logs = logs_to_copy.join("\n");
+                                if let Err(e) = crate::flush_stdout!(
+                                    "{}",
+                                    termina::escape::osc::Osc::SetSelection(
+                                        termina::escape::osc::Selection::CLIPBOARD,
+                                        &joined_logs
+                                    )
+                                ) {
+                                    eprintln!("Failed to copy logs to clipboard via OSC 52: {}", e);
+                                } else {
+                                    println!("Copied {} log lines!", logs_to_copy.len());
                                 }
                             }
-                            Err(e) => eprintln!("Failed to stream logs: {}", e),
-                        },
-                    },
-                    Some(Commands::RunTutorial { enabled }) => {
-                        let enabled = enabled.unwrap_or(true);
-                        log::info!("Run tutorial set to {}", enabled);
-                        self.settings.run_tutorial = enabled;
-                        if enabled {
-                            self.settings.tutorial_step = tutorial::TutorialStep::Welcome;
-                            // clear the terminal:
-                            use termina::escape::csi::{Csi, Cursor, Edit, EraseInDisplay};
-                            if let Err(e) = crate::flush_stdout!(
-                                "{}{}",
-                                Csi::Edit(Edit::EraseInDisplay(EraseInDisplay::EraseDisplay)),
-                                Csi::Cursor(Cursor::goto(0, 0))
-                            ) {
-                                log::warn!("Failed to clear terminal: {}", e);
+                            Err(e) => {
+                                eprintln!("Failed to retrieve logs: {}", e);
                             }
-                        } else {
-                            self.settings.tutorial_step = tutorial::TutorialStep::NotRunning;
                         }
                     }
-                    Some(Commands::Editor {
-                        auto_close_chars,
-                        show_inline_history,
-                        select_with_mouse,
-                    }) => {
-                        if let Some(enabled) = auto_close_chars {
-                            log::info!("Auto closing char set to {}", enabled);
-                            self.settings.auto_close_chars = enabled;
-                        }
-                        if let Some(enabled) = show_inline_history {
-                            log::info!("Inline history suggestions set to {}", enabled);
-                            self.settings.show_inline_history = enabled;
-                        }
-                        if let Some(enabled) = select_with_mouse {
-                            log::info!("Select with mouse set to {}", enabled);
-                            self.settings.select_with_mouse = enabled;
-                        }
+                    LogSubcommands::SetLevel { level } => {
+                        let filter = log::LevelFilter::from(level);
+                        log::set_max_level(filter);
+                        log::info!("Log level set to {:?}", filter);
                     }
-                    Some(Commands::History {
-                        subcommand,
-                        backend,
-                        jsonl_path,
-                    }) => {
-                        if let Some(path) = jsonl_path {
-                            let expanded =
-                                std::path::PathBuf::from(shell::backend().expand_filename(&path));
-                            self.settings
-                                .history_manager
-                                .set_jsonl_history_path(expanded);
+                    LogSubcommands::Stream { dest } => match logging::stream_logs(&dest) {
+                        Ok(()) => {
+                            if dest == "terminal" {
+                                log::info!("Log streaming to terminal");
+                            } else {
+                                println!("Flyline logs streaming to {}", dest);
+                            }
                         }
-                        if let Some(sub) = subcommand {
-                            match sub {
-                                HistorySubcommands::Import { path } => {
-                                    let target_jsonl_path =
-                                        self.settings.history_manager.jsonl_path();
-                                    let result = if let Some(ref p) = path {
-                                        let expanded_p = std::path::PathBuf::from(
-                                            shell::backend().expand_filename(&p.to_string_lossy()),
-                                        );
-                                        crate::history::import_history_file(
-                                            &expanded_p,
-                                            &target_jsonl_path,
-                                        )
-                                        .map(|count| (count, expanded_p.display().to_string()))
-                                    } else {
-                                        crate::history::import_atuin_history(&target_jsonl_path)
-                                            .map(|count| (count, "Atuin".to_string()))
-                                    };
+                        Err(e) => eprintln!("Failed to stream logs: {}", e),
+                    },
+                },
+                Some(Commands::RunTutorial { enabled }) => {
+                    let enabled = enabled.unwrap_or(true);
+                    log::info!("Run tutorial set to {}", enabled);
+                    settings.run_tutorial = enabled;
+                    if enabled {
+                        settings.tutorial_step = tutorial::TutorialStep::Welcome;
+                        // clear the terminal:
+                        use termina::escape::csi::{Csi, Cursor, Edit, EraseInDisplay};
+                        if let Err(e) = crate::flush_stdout!(
+                            "{}{}",
+                            Csi::Edit(Edit::EraseInDisplay(EraseInDisplay::EraseDisplay)),
+                            Csi::Cursor(Cursor::goto(0, 0))
+                        ) {
+                            log::warn!("Failed to clear terminal: {}", e);
+                        }
+                    } else {
+                        settings.tutorial_step = tutorial::TutorialStep::NotRunning;
+                    }
+                }
+                Some(Commands::Editor {
+                    auto_close_chars,
+                    show_inline_history,
+                    select_with_mouse,
+                }) => {
+                    if let Some(enabled) = auto_close_chars {
+                        log::info!("Auto closing char set to {}", enabled);
+                        settings.auto_close_chars = enabled;
+                    }
+                    if let Some(enabled) = show_inline_history {
+                        log::info!("Inline history suggestions set to {}", enabled);
+                        settings.show_inline_history = enabled;
+                    }
+                    if let Some(enabled) = select_with_mouse {
+                        log::info!("Select with mouse set to {}", enabled);
+                        settings.select_with_mouse = enabled;
+                    }
+                }
+                Some(Commands::History {
+                    subcommand,
+                    backend,
+                    jsonl_path,
+                }) => {
+                    if let Some(path) = jsonl_path {
+                        let expanded =
+                            std::path::PathBuf::from(shell::backend().expand_filename(&path));
+                        settings.history_manager.set_jsonl_history_path(expanded);
+                    }
+                    if let Some(sub) = subcommand {
+                        match sub {
+                            HistorySubcommands::Import { path } => {
+                                let target_jsonl_path = settings.history_manager.jsonl_path();
+                                let result = if let Some(ref p) = path {
+                                    let expanded_p = std::path::PathBuf::from(
+                                        shell::backend().expand_filename(&p.to_string_lossy()),
+                                    );
+                                    crate::history::import_history_file(
+                                        &expanded_p,
+                                        &target_jsonl_path,
+                                    )
+                                    .map(|count| (count, expanded_p.display().to_string()))
+                                } else {
+                                    crate::history::import_atuin_history(&target_jsonl_path)
+                                        .map(|count| (count, "Atuin".to_string()))
+                                };
 
-                                    match result {
-                                        Ok((count, src)) => {
-                                            println!(
-                                                "Successfully imported {} history entries from {} into {}",
-                                                count,
-                                                src,
-                                                target_jsonl_path.display()
-                                            );
-                                        }
-                                        Err(e) => {
-                                            eprintln!("Failed to import history: {}", e);
-                                        }
+                                match result {
+                                    Ok((count, src)) => {
+                                        println!(
+                                            "Successfully imported {} history entries from {} into {}",
+                                            count,
+                                            src,
+                                            target_jsonl_path.display()
+                                        );
+                                    }
+                                    Err(e) => {
+                                        eprintln!("Failed to import history: {}", e);
                                     }
                                 }
                             }
                         }
-                        if let Some(b) = backend {
-                            log::info!("History backend set to {:?}", b);
-                            self.settings.history_backend = b;
-                        }
                     }
-                    Some(Commands::Suggestions {
-                        subcommand,
-                        auto_suggest,
-                        git_ref_mtime,
-                        use_flycomp,
-                        sort_order,
-                        num_suggestion_rows,
-                        flycomp_output,
-                        flycomp_blacklist,
-                    }) => {
-                        if let Some(sub) = subcommand {
-                            match sub {
-                                SuggestionsSubcommands::SetFuzzyMode { mode } => {
-                                    log::info!("Fuzzy mode set to {:?}", mode);
-                                    self.settings.fuzzy_mode = mode;
-                                }
-                                SuggestionsSubcommands::Flycomp(opts) => {
-                                    log::info!("Flycomp settings updated: {:?}", opts);
-                                    self.settings.flycomp.update(opts);
-                                }
+                    if let Some(b) = backend {
+                        log::info!("History backend set to {:?}", b);
+                        settings.history_backend = b;
+                    }
+                }
+                Some(Commands::Suggestions {
+                    subcommand,
+                    auto_suggest,
+                    git_ref_mtime,
+                    use_flycomp,
+                    sort_order,
+                    num_suggestion_rows,
+                    flycomp_output,
+                    flycomp_blacklist,
+                }) => {
+                    if let Some(sub) = subcommand {
+                        match sub {
+                            SuggestionsSubcommands::SetFuzzyMode { mode } => {
+                                log::info!("Fuzzy mode set to {:?}", mode);
+                                settings.fuzzy_mode = mode;
+                            }
+                            SuggestionsSubcommands::Flycomp(opts) => {
+                                log::info!("Flycomp settings updated: {:?}", opts);
+                                settings.flycomp.update(opts);
                             }
                         }
+                    }
 
-                        if let Some(list) = flycomp_blacklist {
-                            log::info!("Flycomp blacklist set to {:?}", list);
-                            self.settings.flycomp.blacklist = Some(list);
-                        }
-                        if let Some(enabled) = auto_suggest {
-                            log::info!("Auto tab-completion suggestions set to {}", enabled);
-                            self.settings.auto_suggest = enabled;
-                        }
-                        if let Some(enabled) = git_ref_mtime {
-                            log::info!(
-                                "Git reference modification time display set to {}",
-                                enabled
+                    if let Some(list) = flycomp_blacklist {
+                        log::info!("Flycomp blacklist set to {:?}", list);
+                        settings.flycomp.blacklist = Some(list);
+                    }
+                    if let Some(enabled) = auto_suggest {
+                        log::info!("Auto tab-completion suggestions set to {}", enabled);
+                        settings.auto_suggest = enabled;
+                    }
+                    if let Some(enabled) = git_ref_mtime {
+                        log::info!("Git reference modification time display set to {}", enabled);
+                        settings.git_ref_mtime = enabled;
+                    }
+                    if let Some(enabled) = use_flycomp {
+                        log::info!("Use flycomp set to {}", enabled);
+                        settings.flycomp.enabled = Some(enabled);
+                    }
+                    if let Some(order) = sort_order {
+                        log::info!("Suggestion sort order set to {:?}", order);
+                        settings.suggestion_sort_order = order;
+                    }
+                    if let Some(num) = num_suggestion_rows {
+                        if num == 0 {
+                            return_usage_error!(
+                                "flyline suggestions: --num-suggestion-rows must be greater than 0"
                             );
-                            self.settings.git_ref_mtime = enabled;
                         }
-                        if let Some(enabled) = use_flycomp {
-                            log::info!("Use flycomp set to {}", enabled);
-                            self.settings.flycomp.enabled = Some(enabled);
-                        }
-                        if let Some(order) = sort_order {
-                            log::info!("Suggestion sort order set to {:?}", order);
-                            self.settings.suggestion_sort_order = order;
-                        }
-                        if let Some(num) = num_suggestion_rows {
-                            if num == 0 {
-                                return_usage_error!(
-                                    "flyline suggestions: --num-suggestion-rows must be greater than 0"
-                                );
-                            }
-                            log::info!("Suggestion row limit set to {}", num);
-                            self.settings.num_suggestion_rows = num;
-                        }
-                        if let Some(path) = flycomp_output {
-                            log::info!("Flycomp output directory set to '{}'", path);
-                            self.settings.flycomp.output_dir = Some(path);
-                        }
+                        log::info!("Suggestion row limit set to {}", num);
+                        settings.num_suggestion_rows = num;
                     }
-                    Some(Commands::Time { format }) => {
-                        if let Some(fmt) = format {
-                            let has_error = chrono::format::strftime::StrftimeItems::new(&fmt)
-                                .any(|item| matches!(item, chrono::format::Item::Error));
-                            if has_error {
-                                return_usage_error!(
-                                    "flyline time: invalid Chrono format string: {:?}",
-                                    fmt
-                                );
-                            }
-                            println!("{}", chrono::Local::now().format(&fmt));
-                        } else {
-                            let ns = std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .unwrap_or_default()
-                                .as_nanos();
-                            println!("{}", ns);
-                        }
+                    if let Some(path) = flycomp_output {
+                        log::info!("Flycomp output directory set to '{}'", path);
+                        settings.flycomp.output_dir = Some(path);
                     }
-                    Some(Commands::SetCursor {
-                        backend,
-                        interpolate,
-                        interpolate_easing,
-                        style,
-                        effect,
-                        effect_speed,
-                        effect_easing,
-                    }) => {
-                        // If the user configures flyline-only options without explicitly setting the backend,
-                        // and we defaulted to terminal (e.g. on kitty), automatically switch to flyline.
-                        if backend.is_none()
-                            && self.settings.cursor_config.is_backend_unset()
+                }
+                Some(Commands::Time { format }) => {
+                    if let Some(fmt) = format {
+                        let has_error = chrono::format::strftime::StrftimeItems::new(&fmt)
+                            .any(|item| matches!(item, chrono::format::Item::Error));
+                        if has_error {
+                            return_usage_error!(
+                                "flyline time: invalid Chrono format string: {:?}",
+                                fmt
+                            );
+                        }
+                        println!("{}", chrono::Local::now().format(&fmt));
+                    } else {
+                        let ns = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_nanos();
+                        println!("{}", ns);
+                    }
+                }
+                Some(Commands::SetCursor {
+                    backend,
+                    interpolate,
+                    interpolate_easing,
+                    style,
+                    effect,
+                    effect_speed,
+                    effect_easing,
+                }) => {
+                    // If the user configures flyline-only options without explicitly setting the backend,
+                    // and we defaulted to terminal (e.g. on kitty), automatically switch to flyline.
+                    if backend.is_none()
+                        && settings.cursor_config.is_backend_unset()
+                        && (style.is_some()
+                            || effect.is_some()
+                            || effect_speed.is_some()
+                            || effect_easing.is_some())
+                    {
+                        log::info!(
+                            "Auto-switching cursor backend to Flyline for configured options"
+                        );
+                        settings
+                            .cursor_config
+                            .set_backend(Some(cursor::CursorBackend::Flyline));
+                    }
+
+                    // set backend first since it affects the validity of other options
+                    if let Some(b) = backend {
+                        log::info!("Cursor backend set to {:?}", b);
+                        settings.cursor_config.set_backend(Some(b));
+                        if b == cursor::CursorBackend::Terminal
                             && (style.is_some()
                                 || effect.is_some()
                                 || effect_speed.is_some()
                                 || effect_easing.is_some())
                         {
-                            log::info!(
-                                "Auto-switching cursor backend to Flyline for configured options"
+                            return_usage_error!(
+                                "flyline set-cursor: --style, --effect, --effect-speed, and --effect-easing require --backend flyline"
                             );
-                            self.settings
-                                .cursor_config
-                                .set_backend(Some(cursor::CursorBackend::Flyline));
                         }
+                    }
 
-                        // set backend first since it affects the validity of other options
-                        if let Some(b) = backend {
-                            log::info!("Cursor backend set to {:?}", b);
-                            self.settings.cursor_config.set_backend(Some(b));
-                            if b == cursor::CursorBackend::Terminal
-                                && (style.is_some()
-                                    || effect.is_some()
-                                    || effect_speed.is_some()
-                                    || effect_easing.is_some())
-                            {
-                                return_usage_error!(
-                                    "flyline set-cursor: --style, --effect, --effect-speed, and --effect-easing require --backend flyline"
-                                );
-                            }
-                        }
+                    // Helper closure: every flyline-only option emits the same error.
+                    // Returning a `bool` lets callers chain it with the option-presence check.
+                    let backend_is_terminal =
+                        settings.cursor_config.backend() == cursor::CursorBackend::Terminal;
 
-                        // Helper closure: every flyline-only option emits the same error.
-                        // Returning a `bool` lets callers chain it with the option-presence check.
-                        let backend_is_terminal = self.settings.cursor_config.backend()
-                            == cursor::CursorBackend::Terminal;
-
-                        if let Some(interp_str) = interpolate {
-                            if interp_str.eq_ignore_ascii_case("none") {
-                                log::info!("Cursor interpolation disabled");
-                                self.settings.cursor_config.interpolate = None;
-                            } else {
-                                match interp_str.parse::<f32>() {
-                                    Ok(speed) if speed > 0.0 => {
-                                        log::info!("Cursor interpolation speed set to {}", speed);
-                                        self.settings.cursor_config.interpolate = Some(speed);
-                                    }
-                                    _ => {
-                                        return_usage_error!(
-                                            "flyline set-cursor: --interpolate must be a positive number or 'none' (got {:?})",
-                                            interp_str
-                                        );
-                                    }
+                    if let Some(interp_str) = interpolate {
+                        if interp_str.eq_ignore_ascii_case("none") {
+                            log::info!("Cursor interpolation disabled");
+                            settings.cursor_config.interpolate = None;
+                        } else {
+                            match interp_str.parse::<f32>() {
+                                Ok(speed) if speed > 0.0 => {
+                                    log::info!("Cursor interpolation speed set to {}", speed);
+                                    settings.cursor_config.interpolate = Some(speed);
                                 }
-                            }
-                        }
-
-                        if let Some(easing) = interpolate_easing {
-                            log::info!("Cursor interpolation easing set to {:?}", easing);
-                            self.settings.cursor_config.interpolate_easing = easing;
-                        }
-
-                        if let Some(style_str) = style {
-                            if backend_is_terminal {
-                                return_usage_error!(
-                                    "flyline set-cursor: --style requires --backend flyline"
-                                );
-                            }
-                            match palette::parse_cursor_style_str(&style_str) {
-                                Ok(s) => {
-                                    log::info!("Cursor style set to {:?}", s);
-                                    self.settings.cursor_config.style = s;
-                                }
-                                Err(e) => {
+                                _ => {
                                     return_usage_error!(
-                                        "flyline set-cursor: invalid --style {:?}: {}",
-                                        style_str,
-                                        e
+                                        "flyline set-cursor: --interpolate must be a positive number or 'none' (got {:?})",
+                                        interp_str
                                     );
                                 }
                             }
                         }
+                    }
 
-                        if let Some(eff) = effect {
-                            if backend_is_terminal {
-                                return_usage_error!(
-                                    "flyline set-cursor: --effect requires --backend flyline"
-                                );
-                            }
-                            if eff == cursor::CursorEffect::Fade
-                                && let CursorStyleConfig::Custom(style) =
-                                    self.settings.cursor_config.style
-                                && !matches!(style.bg, Some(ratatui::style::Color::Rgb(..)))
-                            {
-                                return_usage_error!(
-                                    "flyline set-cursor: --effect fade requires a custom style with an RGB background color (e.g. '#ff0000')"
-                                );
-                            }
-                            log::info!("Cursor effect set to {:?}", eff);
-                            self.settings.cursor_config.effect = eff;
+                    if let Some(easing) = interpolate_easing {
+                        log::info!("Cursor interpolation easing set to {:?}", easing);
+                        settings.cursor_config.interpolate_easing = easing;
+                    }
+
+                    if let Some(style_str) = style {
+                        if backend_is_terminal {
+                            return_usage_error!(
+                                "flyline set-cursor: --style requires --backend flyline"
+                            );
                         }
-
-                        if let Some(speed) = effect_speed {
-                            if backend_is_terminal {
+                        match palette::parse_cursor_style_str(&style_str) {
+                            Ok(s) => {
+                                log::info!("Cursor style set to {:?}", s);
+                                settings.cursor_config.style = s;
+                            }
+                            Err(e) => {
                                 return_usage_error!(
-                                    "flyline set-cursor: --effect-speed requires --backend flyline"
+                                    "flyline set-cursor: invalid --style {:?}: {}",
+                                    style_str,
+                                    e
                                 );
                             }
-                            if speed > 0.0 {
-                                log::info!("Cursor effect speed set to {}", speed);
-                                self.settings.cursor_config.effect_speed = speed;
-                            } else {
-                                return_usage_error!(
-                                    "flyline set-cursor: --effect-speed must be positive (got {})",
-                                    speed
-                                );
-                            }
-                        }
-
-                        if let Some(easing) = effect_easing {
-                            if backend_is_terminal {
-                                return_usage_error!(
-                                    "flyline set-cursor: --effect-easing requires --backend flyline"
-                                );
-                            }
-                            log::info!("Cursor effect easing set to {:?}", easing);
-                            self.settings.cursor_config.effect_easing = easing;
                         }
                     }
-                    Some(Commands::Perf { subcommand }) => match subcommand {
-                        PerfSubcommands::Start => {
-                            crate::perf::start_recording();
-                            println!("Performance recording started.");
+
+                    if let Some(eff) = effect {
+                        if backend_is_terminal {
+                            return_usage_error!(
+                                "flyline set-cursor: --effect requires --backend flyline"
+                            );
                         }
-                        PerfSubcommands::Stop => {
-                            crate::perf::stop_recording();
-                            println!("Performance recording stopped.");
+                        if eff == cursor::CursorEffect::Fade
+                            && let CursorStyleConfig::Custom(style) = settings.cursor_config.style
+                            && !matches!(style.bg, Some(ratatui::style::Color::Rgb(..)))
+                        {
+                            return_usage_error!(
+                                "flyline set-cursor: --effect fade requires a custom style with an RGB background color (e.g. '#ff0000')"
+                            );
                         }
-                        PerfSubcommands::Dump => {
-                            crate::perf::dump_to_stdout();
-                        }
-                    },
-                    Some(Commands::Changelog) => {
-                        let content = crate::changelog::pretty_changelog();
-                        println!("{}", content);
+                        log::info!("Cursor effect set to {:?}", eff);
+                        settings.cursor_config.effect = eff;
                     }
-                    Some(Commands::Upgrade) => {
-                        println!("Flyline is a purely offline piece of software. Please run:");
-                        println!(
-                            "source <(curl -sSfL https://github.com/HalFrgrd/flyline/releases/latest/download/install.sh)"
-                        );
-                        self.settings.initial_buffer = Some("source <(curl -sSfL https://github.com/HalFrgrd/flyline/releases/latest/download/install.sh)".to_string());
+
+                    if let Some(speed) = effect_speed {
+                        if backend_is_terminal {
+                            return_usage_error!(
+                                "flyline set-cursor: --effect-speed requires --backend flyline"
+                            );
+                        }
+                        if speed > 0.0 {
+                            log::info!("Cursor effect speed set to {}", speed);
+                            settings.cursor_config.effect_speed = speed;
+                        } else {
+                            return_usage_error!(
+                                "flyline set-cursor: --effect-speed must be positive (got {})",
+                                speed
+                            );
+                        }
                     }
-                    Some(Commands::Settings { all }) => {
-                        show_settings(&self.settings, all);
+
+                    if let Some(easing) = effect_easing {
+                        if backend_is_terminal {
+                            return_usage_error!(
+                                "flyline set-cursor: --effect-easing requires --backend flyline"
+                            );
+                        }
+                        log::info!("Cursor effect easing set to {:?}", easing);
+                        settings.cursor_config.effect_easing = easing;
                     }
                 }
+                Some(Commands::Perf { subcommand }) => match subcommand {
+                    PerfSubcommands::Start => {
+                        crate::perf::start_recording();
+                        println!("Performance recording started.");
+                    }
+                    PerfSubcommands::Stop => {
+                        crate::perf::stop_recording();
+                        println!("Performance recording stopped.");
+                    }
+                    PerfSubcommands::Dump => {
+                        crate::perf::dump_to_stdout();
+                    }
+                },
+                Some(Commands::Changelog) => {
+                    let content = crate::changelog::pretty_changelog();
+                    println!("{}", content);
+                }
+                Some(Commands::Upgrade) => {
+                    println!("Flyline is a purely offline piece of software. Please run:");
+                    println!(
+                        "source <(curl -sSfL https://github.com/HalFrgrd/flyline/releases/latest/download/install.sh)"
+                    );
+                    settings.initial_buffer = Some("source <(curl -sSfL https://github.com/HalFrgrd/flyline/releases/latest/download/install.sh)".to_string());
+                }
+                Some(Commands::Settings { all }) => {
+                    show_settings(&*settings, all);
+                }
+            }
 
-                shell::BuiltinExitCode::ExecutionSuccess as c_int
-            }
-            Ok(_) => {
-                log::debug!("No arguments provided to flyline");
-                FlylineArgs::command().print_help().ok();
-                shell::BuiltinExitCode::Usage as c_int
-            }
-            Err(err) => {
-                match err.kind() {
-                    ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
-                        // user asked for --help / --version
-                        err.print().unwrap();
-                        shell::BuiltinExitCode::ExecutionSuccess as c_int
-                    }
-                    ErrorKind::UnknownArgument
-                    | ErrorKind::InvalidValue
-                    | ErrorKind::InvalidSubcommand
-                    | ErrorKind::MissingRequiredArgument
-                    | ErrorKind::TooManyValues
-                    | ErrorKind::TooFewValues
-                    | ErrorKind::ValueValidation => {
-                        // user mistake → show error + usage
-                        err.print().unwrap();
-                        shell::BuiltinExitCode::Usage as c_int
-                    }
-                    _ => {
-                        // unexpected / internal error
-                        eprintln!("{err}");
-                        shell::BuiltinExitCode::Usage as c_int
-                    }
+            shell::BuiltinExitCode::ExecutionSuccess as c_int
+        }
+        Ok(_) => {
+            log::debug!("No arguments provided to flyline");
+            FlylineArgs::command().print_help().ok();
+            shell::BuiltinExitCode::Usage as c_int
+        }
+        Err(err) => {
+            match err.kind() {
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
+                    // user asked for --help / --version
+                    err.print().unwrap();
+                    shell::BuiltinExitCode::ExecutionSuccess as c_int
+                }
+                ErrorKind::UnknownArgument
+                | ErrorKind::InvalidValue
+                | ErrorKind::InvalidSubcommand
+                | ErrorKind::MissingRequiredArgument
+                | ErrorKind::TooManyValues
+                | ErrorKind::TooFewValues
+                | ErrorKind::ValueValidation => {
+                    // user mistake → show error + usage
+                    err.print().unwrap();
+                    shell::BuiltinExitCode::Usage as c_int
+                }
+                _ => {
+                    // unexpected / internal error
+                    eprintln!("{err}");
+                    shell::BuiltinExitCode::Usage as c_int
                 }
             }
         }

--- a/src/completions/tab_completion.rs
+++ b/src/completions/tab_completion.rs
@@ -1154,8 +1154,8 @@ impl App {
                 wuc_substring,
                 load_time,
                 auto_started,
-                self.settings.suggestion_sort_order,
-                self.settings.fuzzy_mode,
+                crate::settings().suggestion_sort_order,
+                crate::settings().fuzzy_mode,
             );
             self.content_mode = ContentMode::TabCompletion(Box::new(suggestions));
         } else {
@@ -1170,8 +1170,8 @@ impl App {
                         final_wuc,
                         load_time,
                         auto_started,
-                        self.settings.suggestion_sort_order,
-                        self.settings.fuzzy_mode,
+                        crate::settings().suggestion_sort_order,
+                        crate::settings().fuzzy_mode,
                     );
                     self.content_mode = ContentMode::TabCompletion(Box::new(suggestions));
                 }
@@ -1184,7 +1184,7 @@ impl App {
         word_under_cursor: String,
         forced: bool,
     ) {
-        let output_dir = self.settings.flycomp.output_dir();
+        let output_dir = crate::settings().flycomp.output_dir();
         let dump_path = shell::backend()
             .resolve_completion_script_path(&command_word, output_dir)
             .to_string_lossy()
@@ -1251,8 +1251,8 @@ impl App {
             .next()
             .unwrap_or("")
             .to_string();
-        let will_run_flycomp_if_prog_comp_is_useless = self.settings.flycomp.enabled()
-            && !self.settings.flycomp.is_blacklisted(&command_word)
+        let will_run_flycomp_if_prog_comp_is_useless = crate::settings().flycomp.enabled()
+            && !crate::settings().flycomp.is_blacklisted(&command_word)
             && !auto_started
             && (wuc_substring.s.is_empty() || wuc_substring.s.chars().all(|c| c == '-'));
 

--- a/src/completions/tab_completion.rs
+++ b/src/completions/tab_completion.rs
@@ -1081,7 +1081,7 @@ pub(crate) fn apply_tab_complete_to_buffer(
     TabCompleteBufferOutcome::Pending { final_wuc }
 }
 
-impl App<'_> {
+impl App {
     pub(crate) fn get_completion_context(&self) -> tab_completion_context::CompletionContext<'_> {
         tab_completion_context::get_completion_context(
             self.buffer.buffer(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ impl Flyline {
         if self.content.is_empty() || self.position >= self.content.len() {
             log::info!("---------------------- Starting app ------------------------");
 
-            let mut settings = crate::settings();
+            let settings = crate::settings();
 
             if settings.history_backend == crate::settings::HistoryBackend::Flyline {
                 let exit_status = unsafe { bash_symbols::last_command_exit_value };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ mod mouse_state;
 pub mod path;
 mod prompt_manager;
 mod settings;
+pub(crate) use settings::settings;
 pub mod shell;
 mod shell_integration;
 pub(crate) mod subshell_ipc;
@@ -137,17 +138,7 @@ extern "C" fn flyline_unget_char(c: c_int) -> c_int {
 
 #[cfg(not(test))]
 extern "C" fn flyline_call_command(words: *const bash_symbols::WordList) -> c_int {
-    let result = catch_unwind_safe(|| {
-        if let Some(boxed) = FLYLINE_INSTANCE_PTR
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .as_mut()
-        {
-            return boxed.call(words);
-        }
-        report_stderr_no_panic("flyline_call_command: FLYLINE_INSTANCE_PTR is None");
-        0
-    });
+    let result = catch_unwind_safe(|| cli::call(words));
     match result {
         Ok(code) => code,
         Err(_) => {
@@ -162,7 +153,6 @@ extern "C" fn flyline_call_command(words: *const bash_symbols::WordList) -> c_in
 pub(crate) struct Flyline {
     content: Vec<u8>,
     position: usize,
-    settings: settings::Settings,
 }
 
 impl Flyline {
@@ -170,7 +160,6 @@ impl Flyline {
         Self {
             content: vec![],
             position: 0,
-            settings: settings::Settings::default(),
         }
     }
 
@@ -180,10 +169,12 @@ impl Flyline {
         if self.content.is_empty() || self.position >= self.content.len() {
             log::info!("---------------------- Starting app ------------------------");
 
-            if self.settings.history_backend == crate::settings::HistoryBackend::Flyline {
+            let mut settings = crate::settings();
+
+            if settings.history_backend == crate::settings::HistoryBackend::Flyline {
                 let exit_status = unsafe { bash_symbols::last_command_exit_value };
                 let pipestatus = bash_funcs::get_pipestatus();
-                self.settings
+                settings
                     .history_manager
                     .record_last_command_end(exit_status, pipestatus);
             }
@@ -204,9 +195,9 @@ impl Flyline {
             // SigchldGuard restores Bash's original handler upon drop.
             let _sigchld_guard = SigchldGuard::new();
 
-            let result = app::get_command(&mut self.settings);
+            let result = app::get_command();
 
-            self.settings.last_app_closed_at = Some(std::time::Instant::now());
+            settings.last_app_closed_at = Some(std::time::Instant::now());
 
             // unsafe {
             //     // This doesn't seem to be strictly necessary but yy_readline_get does it here.
@@ -223,28 +214,24 @@ impl Flyline {
 
             self.content = match result {
                 app::ExitState::WithCommand(cmd) => {
-                    if self.settings.history_backend == crate::settings::HistoryBackend::Flyline {
+                    if settings.history_backend == crate::settings::HistoryBackend::Flyline {
                         let should_add_to_history = bash_funcs::check_add_history(&cmd);
                         if should_add_to_history {
-                            let cmd_id = self
-                                .settings
+                            let cmd_id = settings
                                 .history_manager
                                 .push_entry_and_jsonl_append(cmd.clone());
                             if !cmd.trim().is_empty() {
-                                self.settings
+                                settings
                                     .history_manager
                                     .set_last_submitted_command(cmd_id, std::time::Instant::now());
                             }
                         }
                     }
-                    if self.settings.tutorial_step.is_active() && cmd.trim().is_empty() {
-                        self.settings.tutorial_step.next();
-                        log::info!(
-                            "Tutorial step advanced to {:?}",
-                            self.settings.tutorial_step
-                        );
-                        if !self.settings.tutorial_step.is_active() {
-                            self.settings.run_tutorial = false;
+                    if settings.tutorial_step.is_active() && cmd.trim().is_empty() {
+                        settings.tutorial_step.next();
+                        log::info!("Tutorial step advanced to {:?}", settings.tutorial_step);
+                        if !settings.tutorial_step.is_active() {
+                            settings.run_tutorial = false;
                         }
                     }
 
@@ -388,6 +375,7 @@ fn flyline_load_common() -> c_int {
         }
 
         // Store the Arc globally so C callbacks can access it
+        settings::reset_settings();
         *FLYLINE_INSTANCE_PTR
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = Some(Box::new(Flyline::new()));

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -443,34 +443,15 @@ unsafe impl Sync for GlobalSettings {}
 static GLOBAL_SETTINGS: std::sync::LazyLock<GlobalSettings> =
     std::sync::LazyLock::new(|| GlobalSettings(std::cell::UnsafeCell::new(Settings::default())));
 
-/// Handle to the process-wide [`Settings`]. Zero-sized, and materialises a
-/// borrow only for the duration of each access, so a `flyline set-style` that
-/// re-enters while `App` holds one of these does not alias a live borrow.
-/// A borrow derived from a handle MUST NOT be held across a call into Bash's
-/// evaluator (`evaluate_shell_string`, `decode_prompt`) -- that is where the
-/// re-entry lands.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct SettingsRef;
-
-impl std::ops::Deref for SettingsRef {
-    type Target = Settings;
-
-    fn deref(&self) -> &Self::Target {
-        // SAFETY: single-threaded; see `GlobalSettings`'s `Sync` impl.
-        unsafe { &*GLOBAL_SETTINGS.0.get() }
-    }
-}
-
-impl std::ops::DerefMut for SettingsRef {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        // SAFETY: single-threaded; see `GlobalSettings`'s `Sync` impl.
-        unsafe { &mut *GLOBAL_SETTINGS.0.get() }
-    }
-}
-
-/// Returns a handle to the process-wide [`Settings`].
-pub fn settings() -> SettingsRef {
-    SettingsRef
+/// Returns a mutable reference to the process-wide global [`Settings`].
+///
+/// # Safety / Aliasing Rule
+/// Borrows must be short-lived and MUST NOT be held across calls into
+/// Bash FFI functions (`evaluate_shell_string`, `decode_prompt`, etc.),
+/// because Bash may re-enter `flyline` on the same thread.
+pub fn settings() -> &'static mut Settings {
+    // SAFETY: single-threaded on Bash's main thread; see `GlobalSettings`'s `Sync` impl.
+    unsafe { &mut *GLOBAL_SETTINGS.0.get() }
 }
 
 /// Resets the process-wide [`Settings`] to [`Settings::default`].

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -433,6 +433,51 @@ impl Default for Settings {
     }
 }
 
+struct GlobalSettings(std::cell::UnsafeCell<Settings>);
+
+// SAFETY: only ever touched from Bash's main thread; flyline spawns no threads
+// and `spawn_subshell` forks. A lock here would deadlock rather than serialise,
+// because Bash re-enters the `flyline` builtin on that same thread.
+unsafe impl Sync for GlobalSettings {}
+
+static GLOBAL_SETTINGS: std::sync::LazyLock<GlobalSettings> =
+    std::sync::LazyLock::new(|| GlobalSettings(std::cell::UnsafeCell::new(Settings::default())));
+
+/// Handle to the process-wide [`Settings`]. Zero-sized, and materialises a
+/// borrow only for the duration of each access, so a `flyline set-style` that
+/// re-enters while `App` holds one of these does not alias a live borrow.
+/// A borrow derived from a handle MUST NOT be held across a call into Bash's
+/// evaluator (`evaluate_shell_string`, `decode_prompt`) -- that is where the
+/// re-entry lands.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SettingsRef;
+
+impl std::ops::Deref for SettingsRef {
+    type Target = Settings;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: single-threaded; see `GlobalSettings`'s `Sync` impl.
+        unsafe { &*GLOBAL_SETTINGS.0.get() }
+    }
+}
+
+impl std::ops::DerefMut for SettingsRef {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: single-threaded; see `GlobalSettings`'s `Sync` impl.
+        unsafe { &mut *GLOBAL_SETTINGS.0.get() }
+    }
+}
+
+/// Returns a handle to the process-wide [`Settings`].
+pub fn settings() -> SettingsRef {
+    SettingsRef
+}
+
+/// Resets the process-wide [`Settings`] to [`Settings::default`].
+pub(crate) fn reset_settings() {
+    *settings() = Settings::default();
+}
+
 /// A single diff entry between current session settings and default settings.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SettingDiffEntry {
@@ -634,5 +679,15 @@ mod tests {
             "Expected pretty binding string, got: {}",
             changed[0].current
         );
+    }
+
+    /// A re-entrant builtin call must reach the same settings the app is holding.
+    /// The only test that touches the global, so it cannot race the others.
+    #[test]
+    fn reentrant_handles_share_one_settings_instance() {
+        let mut app_view = settings();
+        app_view.frame_rate = 11;
+        settings().frame_rate = 30;
+        assert_eq!(app_view.frame_rate, 30);
     }
 }


### PR DESCRIPTION
This change resolves a deadlock that would occur when calling `flyline` from a signal handler (e.g. for `SIGUSR2` or `SIGALRM`) that flyline itself executes (i.e. flyline handles the signal itself).

---

- ref #852
- ref #931
- ref #933

---

<details>
<summary>Agent Plan</summary>

# Suggested Plan

## Global settings object to fix builtin re-entrancy

### Verification of HalFrgrd's claim

Confirmed, with one caveat worth stating in the PR.

- `Flyline::call` (`src/cli.rs` (`src/cli.rs#L997`)) touches only self.settings — `rg --pcre2 'self\.(?!settings\b)' src/cli.rs` finds nothing. So moving settings out is sufficient to make `flyline_call_command` independent of `FLYLINE_INSTANCE_PTR`.
- Caveat: a global behind a lock does not fix anything. App would hold that lock for the whole session and the re-entrant builtin would block on it exactly as it blocks on `FLYLINE_INSTANCE_PTR` today. The global must hand out a borrow per access, never a guard held across a call into Bash's evaluator.
- Corroboration that same-thread re-entry is already an accepted reality here: `BASH_LOCK` is a `parking_lot::ReentrantMutex` (`src/shell/bash/symbols.rs` (`src/shell/bash/symbols.rs#L462`)) for this exact reason.
- Done per-access, this is strictly sounder than the dropped commit: the app holds a zero-sized handle, not a &mut Settings, so during re-entry there is no live borrow to alias. The thread-local pointer publish had two overlapping `&mut Flyline`.
- Flyline never spawns threads (`git grep 'thread::spawn' origin/master -- src crates` is empty; `subshell_ipc::spawn_subshell` forks), so a lock buys nothing but deadlocks.

### Where re-entry happens

```txt
┌───────────────────────────────────────┐
│                                       │
│                                       │
│            flyline_get_char           │
│       locks FLYLINE_INSTANCE_PTR      │
│                                       │
└───────────────────┬───────────────────┘
                    ▼
┌───────────────────────────────────────┐
│                                       │
│                App::run               │
│                                       │
└───────────────────┬───────────────────┘
                    ▼
┌───────────────────────────────────────┐
│                                       │
│ evaluate_shell_string / decode_prompt │
│                                       │
└───────────────────┬───────────────────┘
                    ▼
┌───────────────────────────────────────┐
│                                       │
│     Bash evaluator runs user code     │
│                                       │
└───────────────────┬───────────────────┘
                    ▼
┌───────────────────────────────────────┐
│                                       │
│                                       │
│            flyline builtin            ├─────────────────┐
│          flyline_call_command         │     after: settings() handle
│                                       │                 │
└──────today:─locks─the─same─mutex──────┘                 │
                    ▼                                     ▼
┌───────────────────────────────────────┐   ┌───────────────────────────┐
│                                       │   │                           │
│                deadlock               │   │ mutates settings, returns │
│                                       │   │                           │
└───────────────────────────────────────┘   └───────────────────────────┘
```

Three evaluator entry points: `src/app/mod.rs:1213` (`src/app/mod.rs#L1213`) (`run_bash_command`), `src/app/mod.rs:1707` (`src/app/mod.rs#L1707`) (`flycomp` script), and prompt expansion via decode_prompt. `flyline_unget_char` is not reachable during eval because `evalstring` pushes its own input stream.

## Design

A lock-free global plus a zero-sized handle that derefs to it. The handle is what keeps the diff small: `App.settings` changes type but all ~136 `self.settings.foo` sites compile unchanged through `Deref`/`DerefMut`, including ones that hand out borrows like `src/app/mod.rs:693` (`src/app/mod.rs#L693`) (-> &mut
HistoryManager), which a closure- or guard-based API cannot express.
In `src/settings.rs` (`src/settings.rs`), next to Settings:

```rust
struct GlobalSettings(std::cell::UnsafeCell<Settings>);
// SAFETY: only ever touched from Bash's main thread; flyline spawns no threads
// and `spawn_subshell` forks. A lock here would deadlock rather than serialise,
// because Bash re-enters the `flyline` builtin on that same thread.
unsafe impl Sync for GlobalSettings {}

static GLOBAL_SETTINGS: std::sync::LazyLock<GlobalSettings> = ...;

/// Handle to the process-wide [`Settings`]. Zero-sized, and materialises a
/// borrow only for the duration of each access, so a `flyline set-style` that
/// re-enters while `App` holds one of these does not alias a live borrow.
/// A borrow derived from a handle MUST NOT be held across a call into Bash's
/// evaluator (`evaluate_shell_string`, `decode_prompt`) -- that is where the
/// re-entry lands.
#[derive(Clone, Copy, Debug, Default)]
pub struct SettingsRef;

impl Deref for SettingsRef { /* unsafe { &*GLOBAL_SETTINGS.0.get() } */ }
impl DerefMut for SettingsRef { /* ... */ }

pub fn settings() -> SettingsRef { SettingsRef }
```

`pub(crate) use settings::settings;` in `src/lib.rs` gives `crate::settings()` as requested; the module and the function occupy different namespaces, so crate::settings::Settings keeps working.
I audited the three evaluator sites for the "no live borrow" invariant: `run_bash_command` holds none; `poll_flycomp`'s `output_dir()` borrow ends on the line before the eval; the `get_ps1_lines(self.settings.show_animations, ...)` read is a bool copy whose borrow NLL ends before the call.

## Edits

- `src/settings.rs`: add the global, SettingsRef, settings(), and the unit test below.
- `src/lib.rs`: drop settings from Flyline (keeps content/position); in `Flyline::get`, open with `let mut settings = crate::settings();` and rewrite `self.settings.` to `settings.`; `app::get_command()` loses its argument; `flyline_call_command` becomes `catch_unwind_safe(|| cli::call(words))` and stops
  locking `FLYLINE_INSTANCE_PTR`; reset the global in `setup_bash_input` where `Flyline::new()` is stored, so enable -d / enable -f still starts from defaults.
- `src/cli.rs`: turn `impl Flyline { fn call(&mut self, words) }` into a free `pub(crate) fn call(words) -> c_int` opening with `let mut settings = crate::settings();`, and rewrite the 58 `self.settings.` occurrences to `settings.`. Watch the `settings::AgentModeCommand` paths — multi-segment paths
  resolve in the type namespace, so the local does not shadow the module, but confirm at compile time.
- `src/app/mod.rs`: `get_command()` and `App::new()` lose the parameter (`App::new` opens with `let mut settings = crate::settings();`, body otherwise unchanged); `struct App<'a>` becomes `struct App`; field becomes `settings: SettingsRef`.
- Drop the now-unused lifetime in four more impl headers: `src/app/ui.rs:115`, `src/app/auto_close.rs:104` (src/app/auto_close.rs#L104), src/app/actions/keyboard.rs:3296 (src/app/actions/keyboard.rs#L3296), src/completions/tab_completion.rs:1078
  (`src/completions/tab_completion.rs#L1078`).

Everything else that reads settings stays byte-identical, including &self.settings passed to &Settings parameters (deref coercion) and show_settings(&settings, all).

## Check

One unit test in src/settings.rs (src/settings.rs), the smallest thing that fails if the design regresses — it deadlocks if a lock reappears in settings() and asserts if the handle ever starts copying:

```rust
/// A re-entrant builtin call must reach the same settings the app is holding.
/// The only test that touches the global, so it cannot race the others.
#[test]
fn reentrant_handles_share_one_settings_instance() {
    let mut app_view = settings();  // stands in for `App::settings`
    app_view.frame_rate = 11;
    settings().frame_rate = 30;     // stands in for `flyline --frame-rate 30`
    assert_eq!(app_view.frame_rate, 30);
}
```

Then cargo fmt, cargo clippy --quiet --bins --tests --benches --no-deps -- -D warnings, cargo test --lib.
Manual, on bash 5.2.21 with cargo build and enable -f target/debug/libflyline.so flyline:
- In-process re-entry: flyline key bind Ctrl+g 'always=runBashCommand("flyline --frame-rate 5")', then Ctrl+g in the app. Hangs the shell today; must return and take effect (flyline settings shows frame_rate: 5).
- Forked re-entry, no keystrokes needed: PS1='$(flyline --version)\$ '. The command-substitution child inherits the locked mutex today and hangs; afterwards the prompt renders the version.
- No regression: flyline --frame-rate 30 && flyline settings | grep frame_rate, settings still survive across builtin calls and the app honours them.

I will not run the Docker matrix (tests/docker_integration_tests.rs); nothing here touches Bash symbols or version gating.

</details>