### PR TITLE
Make lexer more granular for better globbing and brace handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,6 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 [[package]]
 name = "flash"
 version = "0.0.6"
-source = "git+https://github.com/HalFrgrd/flash.git?rev=59af2ab94aaa6b7a407d09549605b1d3bc81256c#59af2ab94aaa6b7a407d09549605b1d3bc81256c"
 dependencies = [
  "atty",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 [[package]]
 name = "flash"
 version = "0.0.6"
+source = "git+https://github.com/HalFrgrd/flash.git?rev=4a9145d17bd8b62fe8e872de10f837ef1dd5b72a#4a9145d17bd8b62fe8e872de10f837ef1dd5b72a"
 dependencies = [
  "atty",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ ctor = "1.0"
 dirs = "6.0"
 duration-str = "0.21"
 easing-function.workspace = true
-flash = { git = "https://github.com/HalFrgrd/flash.git", rev = "59af2ab94aaa6b7a407d09549605b1d3bc81256c" }
+flash = { git = "https://github.com/HalFrgrd/flash.git", rev = "4a9145d17bd8b62fe8e872de10f837ef1dd5b72a" }
 flybuffer.workspace = true
 flycomp = { git = "https://github.com/HalFrgrd/flycomp.git", rev = "754be16d7a2130ad12b6d038d42a8933c92c103f" }
 flycontent.workspace = true
@@ -117,7 +117,4 @@ dockerfile = "docker/cross/x86_64-unknown-linux-gnu.Dockerfile"
 [patch.crates-io]
 ratatui-core = { git = "https://github.com/HalFrgrd/ratatui.git", branch = "inline_viewport_improvments" }
 termina = { git = "https://github.com/HalFrgrd/termina.git", rev = "5b67693f2c5173c61a13d18517e2cebfc96a6a9d" }
-
-[patch."https://github.com/HalFrgrd/flash.git"]
-flash = { path = "../flash" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,3 +118,6 @@ dockerfile = "docker/cross/x86_64-unknown-linux-gnu.Dockerfile"
 ratatui-core = { git = "https://github.com/HalFrgrd/ratatui.git", branch = "inline_viewport_improvments" }
 termina = { git = "https://github.com/HalFrgrd/termina.git", rev = "5b67693f2c5173c61a13d18517e2cebfc96a6a9d" }
 
+[patch."https://github.com/HalFrgrd/flash.git"]
+flash = { path = "../flash" }
+

--- a/src/app/auto_close.rs
+++ b/src/app/auto_close.rs
@@ -441,4 +441,66 @@ mod tests {
         assert_eq!(buffer.cursor_byte_pos(), 5);
         let _ = tokens;
     }
+
+    #[test]
+    fn brace_autoclose_in_word_prefix() {
+        let mut buffer = TextBuffer::new("echo ./foo/");
+        let mut tokens = parsed(buffer.buffer());
+
+        handle_char_insertion(&mut buffer, &mut tokens, '{');
+
+        assert_eq!(buffer.buffer(), "echo ./foo/{}");
+        assert_eq!(buffer.cursor_byte_pos(), 12);
+
+        delete_auto_inserted_closing_if_present(&mut buffer, &tokens);
+        buffer.delete_left();
+        tokens = dparser::DParser::parse_and_transfer_auto_inserted_flags(buffer.buffer(), &tokens);
+
+        assert_eq!(buffer.buffer(), "echo ./foo/");
+        assert_eq!(buffer.cursor_byte_pos(), 11);
+        let _ = tokens;
+    }
+
+    #[test]
+    fn brace_with_content_double_backspace_removes_auto_inserted_closing() {
+        let mut buffer = TextBuffer::new("echo ./foo/");
+        let mut tokens = parsed(buffer.buffer());
+
+        handle_char_insertion(&mut buffer, &mut tokens, '{');
+        assert_eq!(buffer.buffer(), "echo ./foo/{}");
+        assert_eq!(buffer.cursor_byte_pos(), 12);
+
+        handle_char_insertion(&mut buffer, &mut tokens, 'a');
+        assert_eq!(buffer.buffer(), "echo ./foo/{a}");
+        assert_eq!(buffer.cursor_byte_pos(), 13);
+
+        // First backspace: deletes 'a'
+        delete_auto_inserted_closing_if_present(&mut buffer, &tokens);
+        buffer.delete_left();
+        tokens = dparser::DParser::parse_and_transfer_auto_inserted_flags(buffer.buffer(), &tokens);
+        assert_eq!(buffer.buffer(), "echo ./foo/{}");
+        assert_eq!(buffer.cursor_byte_pos(), 12);
+
+        // Second backspace: deletes '{' and also removes auto-inserted '}'
+        delete_auto_inserted_closing_if_present(&mut buffer, &tokens);
+        buffer.delete_left();
+        tokens = dparser::DParser::parse_and_transfer_auto_inserted_flags(buffer.buffer(), &tokens);
+        assert_eq!(buffer.buffer(), "echo ./foo/");
+        assert_eq!(buffer.cursor_byte_pos(), 11);
+        let _ = tokens;
+    }
+
+    #[test]
+    fn brace_overwrite_auto_inserted_closing() {
+        let mut buffer = TextBuffer::new("echo ./foo/");
+        let mut tokens = parsed(buffer.buffer());
+
+        handle_char_insertion(&mut buffer, &mut tokens, '{');
+        assert_eq!(buffer.buffer(), "echo ./foo/{}");
+        assert_eq!(buffer.cursor_byte_pos(), 12);
+
+        handle_char_insertion(&mut buffer, &mut tokens, '}');
+        assert_eq!(buffer.buffer(), "echo ./foo/{}");
+        assert_eq!(buffer.cursor_byte_pos(), 13);
+    }
 }

--- a/src/completions/context.rs
+++ b/src/completions/context.rs
@@ -358,7 +358,18 @@ pub fn get_completion_context<'a>(
         {
             cursor_byte_pos..cursor_byte_pos
         }
-        Some((node_idx, cursor_node)) if cursor_node.token.kind.is_word() => {
+        Some((node_idx, cursor_node))
+            if cursor_node.token.kind.is_word()
+                || cursor_node.annotations.is_glob
+                || matches!(
+                    cursor_node.token.kind,
+                    TokenKind::LBrace
+                        | TokenKind::RBrace
+                        | TokenKind::LBracket
+                        | TokenKind::RBracket
+                        | TokenKind::ExtGlob(_)
+                ) =>
+        {
             let byte_range = cursor_node.token.byte_range();
 
             let mut start = byte_range.start;
@@ -384,34 +395,37 @@ pub fn get_completion_context<'a>(
                     {
                         start = t.token.byte_range().start;
                     }
-                    Some(t) if t.token.kind.is_word() && cursor_node.token.value.contains('/') => {
+                    Some(t)
+                        if t.token.kind.is_word()
+                            && (cursor_node.token.value.contains('/')
+                                || cursor_node.annotations.is_glob
+                                || t.annotations.is_glob
+                                || t.token.byte_range().end == start)
+                            && (!range_contains_dollar
+                                || cursor_node.token.value.contains('/')
+                                || t.token.value.contains('/')) =>
+                    {
                         start = t.token.byte_range().start;
                     }
                     Some(t) if t.token.kind == TokenKind::Dollar => {
                         start = t.token.byte_range().start;
                     }
-                    Some(t) if t.token.kind == TokenKind::RBrace => {
-                        // Merge brace expressions like {foo,bar} with following glob patterns like *
-                        // Find the matching LBrace by looking at the closing annotation
-                        if let Some(closing) = &t.annotations.closing
-                            && let Some(opening_token) = parser.tokens().get(closing.opening_idx)
-                            && opening_token.token.kind == TokenKind::LBrace
-                        {
-                            start = opening_token.token.byte_range().start;
-                            break; // Stop here after merging the entire brace group
-                        }
-                        break;
+                    Some(t)
+                        if t.annotations.is_glob
+                            || matches!(
+                                t.token.kind,
+                                TokenKind::LBrace
+                                    | TokenKind::RBrace
+                                    | TokenKind::LBracket
+                                    | TokenKind::RBracket
+                                    | TokenKind::ExtGlob(_)
+                            ) =>
+                    {
+                        start = t.token.byte_range().start;
                     }
                     _ => break,
                 }
             }
-
-            // if let Some(cursor_to_end) = buffer.get(cursor_byte_pos..end) {
-            //     // if there is a / in cursor_to_end, move the end closer to cursor so that we dont have the /
-            //     if let Some(slash_pos) = cursor_to_end.find('/') {
-            //         end = cursor_byte_pos + slash_pos;
-            //     }
-            // }
 
             start..end
         }

--- a/src/completions/context.rs
+++ b/src/completions/context.rs
@@ -310,6 +310,18 @@ impl<'a> CompletionContext<'a> {
     }
 }
 
+#[inline]
+fn is_contiguous_pattern_delimiter(kind: &TokenKind) -> bool {
+    matches!(
+        kind,
+        TokenKind::LBrace
+            | TokenKind::RBrace
+            | TokenKind::LBracket
+            | TokenKind::RBracket
+            | TokenKind::ExtGlob(_)
+    )
+}
+
 pub fn get_completion_context<'a>(
     buffer: &'a str,
     cursor_byte_pos: usize,
@@ -361,14 +373,7 @@ pub fn get_completion_context<'a>(
         Some((node_idx, cursor_node))
             if cursor_node.token.kind.is_word()
                 || cursor_node.annotations.is_glob
-                || matches!(
-                    cursor_node.token.kind,
-                    TokenKind::LBrace
-                        | TokenKind::RBrace
-                        | TokenKind::LBracket
-                        | TokenKind::RBracket
-                        | TokenKind::ExtGlob(_)
-                ) =>
+                || is_contiguous_pattern_delimiter(&cursor_node.token.kind) =>
         {
             let byte_range = cursor_node.token.byte_range();
 
@@ -412,14 +417,7 @@ pub fn get_completion_context<'a>(
                     }
                     Some(t)
                         if t.annotations.is_glob
-                            || matches!(
-                                t.token.kind,
-                                TokenKind::LBrace
-                                    | TokenKind::RBrace
-                                    | TokenKind::LBracket
-                                    | TokenKind::RBracket
-                                    | TokenKind::ExtGlob(_)
-                            ) =>
+                            || is_contiguous_pattern_delimiter(&t.token.kind) =>
                     {
                         start = t.token.byte_range().start;
                     }

--- a/src/completions/context.rs
+++ b/src/completions/context.rs
@@ -427,6 +427,34 @@ pub fn get_completion_context<'a>(
                 }
             }
 
+            for t in context_tokens.iter().skip(node_idx + 1) {
+                if t.token.byte_range().start != end {
+                    break;
+                }
+                if t.token.kind.is_whitespace()
+                    || t.token.value.trim().is_empty()
+                    || matches!(
+                        t.token.kind,
+                        TokenKind::Newline
+                            | TokenKind::Semicolon
+                            | TokenKind::DoubleSemicolon
+                            | TokenKind::And
+                            | TokenKind::Or
+                            | TokenKind::Background
+                            | TokenKind::EOF
+                            | TokenKind::Quote
+                            | TokenKind::SingleQuote
+                            | TokenKind::Dollar
+                    )
+                {
+                    break;
+                }
+                if t.token.kind == TokenKind::Pipe && !t.annotations.is_glob {
+                    break;
+                }
+                end = t.token.byte_range().end;
+            }
+
             start..end
         }
         Some((_, cursor_node)) => cursor_node.token.byte_range(),
@@ -1942,6 +1970,48 @@ mod tests {
             vec![
                 CompType::CommandComp {
                     command_word: "echo".to_string()
+                },
+                CompType::GlobExpansion,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_brace_glob_completion_context_inside_and_end() {
+        // Cursor on '*'
+        let ctx_star = run_inline("ll -d ./target/d{eb*█,oc}");
+        assert_eq!(ctx_star.word_under_cursor.as_ref(), "./target/d{eb*,oc}");
+        assert_eq!(
+            ctx_star.comp_types(),
+            vec![
+                CompType::CommandComp {
+                    command_word: "ll".to_string()
+                },
+                CompType::GlobExpansion,
+            ]
+        );
+
+        // Cursor on ','
+        let ctx_comma = run_inline("ll -d ./target/d{eb*,█oc}");
+        assert_eq!(ctx_comma.word_under_cursor.as_ref(), "./target/d{eb*,oc}");
+        assert_eq!(
+            ctx_comma.comp_types(),
+            vec![
+                CompType::CommandComp {
+                    command_word: "ll".to_string()
+                },
+                CompType::GlobExpansion,
+            ]
+        );
+
+        // Cursor on '}'
+        let ctx_brace = run_inline("ll -d ./target/d{eb*,oc}█");
+        assert_eq!(ctx_brace.word_under_cursor.as_ref(), "./target/d{eb*,oc}");
+        assert_eq!(
+            ctx_brace.comp_types(),
+            vec![
+                CompType::CommandComp {
+                    command_word: "ll".to_string()
                 },
                 CompType::GlobExpansion,
             ]

--- a/src/completions/context.rs
+++ b/src/completions/context.rs
@@ -1922,4 +1922,29 @@ mod tests {
         let ctx = run_inline("/asd/qwe::/foo/ba█r");
         assert_eq!(ctx.word_under_cursor.as_ref(), "/foo/bar");
     }
+
+    #[test]
+    fn test_extglob_completion_context() {
+        let ctx = run_inline("ls !(foo|*ba█r)");
+        assert_eq!(
+            ctx.comp_types(),
+            vec![
+                CompType::CommandComp {
+                    command_word: "ls".to_string()
+                },
+                CompType::GlobExpansion,
+            ]
+        );
+
+        let ctx2 = run_inline("echo ./target/@(foo|ba█r)");
+        assert_eq!(
+            ctx2.comp_types(),
+            vec![
+                CompType::CommandComp {
+                    command_word: "echo".to_string()
+                },
+                CompType::GlobExpansion,
+            ]
+        );
+    }
 }

--- a/src/globbing.rs
+++ b/src/globbing.rs
@@ -37,19 +37,8 @@ fn first_glob_pos(s: &str) -> Option<usize> {
         if annotated.annotations.is_glob {
             match &annotated.token.kind {
                 TokenKind::Word(val) => {
-                    let mut escaped = false;
-                    for (offset, c) in val.char_indices() {
-                        if escaped {
-                            escaped = false;
-                            continue;
-                        }
-                        if c == '\\' {
-                            escaped = true;
-                            continue;
-                        }
-                        if c == '*' || c == '?' {
-                            return Some(annotated.token.byte_range().start + offset);
-                        }
+                    if let Some(offset) = DParser::first_unescaped_wildcard(val) {
+                        return Some(annotated.token.byte_range().start + offset);
                     }
                 }
                 _ => {

--- a/src/globbing.rs
+++ b/src/globbing.rs
@@ -1,5 +1,7 @@
+use crate::grammar::dparser::DParser;
 use crate::grammar::{QuoteType, dequoting_function_rust, quoting_function_rust};
 use crate::shell;
+use flash::lexer::TokenKind;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct GlobPatternSplit<'a> {
@@ -30,100 +32,34 @@ pub fn split_glob_pattern(s: &str) -> GlobPatternSplit<'_> {
 }
 
 fn first_glob_pos(s: &str) -> Option<usize> {
-    let mut escaped = false;
-    let mut quote = None;
-    let mut prev_char = None;
-
-    for (i, c) in s.char_indices() {
-        if escaped {
-            escaped = false;
-            prev_char = Some(c);
-            continue;
-        }
-
-        if c == '\\' {
-            escaped = true;
-            prev_char = Some(c);
-            continue;
-        }
-
-        if c == '\'' || c == '"' {
-            if quote == Some(c) {
-                quote = None;
-            } else if quote.is_none() {
-                quote = Some(c);
+    let tokens = DParser::parse_and_annotate(s);
+    for annotated in &tokens {
+        if annotated.annotations.is_glob {
+            match &annotated.token.kind {
+                TokenKind::Word(val) => {
+                    let mut escaped = false;
+                    for (offset, c) in val.char_indices() {
+                        if escaped {
+                            escaped = false;
+                            continue;
+                        }
+                        if c == '\\' {
+                            escaped = true;
+                            continue;
+                        }
+                        if c == '*' || c == '?' {
+                            return Some(annotated.token.byte_range().start + offset);
+                        }
+                    }
+                }
+                _ => {
+                    return Some(annotated.token.byte_range().start);
+                }
             }
-            prev_char = Some(c);
-            continue;
         }
-
-        if quote.is_some() {
-            prev_char = Some(c);
-            continue;
-        }
-
-        match c {
-            '*' | '?' => return Some(i),
-            '[' if has_unescaped_closing_bracket(&s[i + c.len_utf8()..]) => return Some(i),
-            '{' if prev_char != Some('$')
-                && has_unescaped_brace_expansion(&s[i + c.len_utf8()..]) =>
-            {
-                return Some(i);
-            }
-            _ => {}
-        }
-
-        prev_char = Some(c);
     }
 
     None
-}
-
-fn has_unescaped_closing_bracket(s: &str) -> bool {
-    let mut escaped = false;
-
-    for c in s.chars() {
-        if escaped {
-            escaped = false;
-            continue;
-        }
-
-        match c {
-            '\\' => escaped = true,
-            ']' => return true,
-            _ => {}
-        }
-    }
-
-    false
-}
-
-fn has_unescaped_brace_expansion(s: &str) -> bool {
-    let mut escaped = false;
-    let mut depth = 0;
-    let mut has_comma = false;
-    let mut has_sequence = false;
-
-    for (i, c) in s.char_indices() {
-        if escaped {
-            escaped = false;
-            continue;
-        }
-
-        match c {
-            '\\' => escaped = true,
-            '{' => depth += 1,
-            '}' if depth == 0 => return has_comma || has_sequence,
-            '}' => depth -= 1,
-            ',' if depth == 0 => has_comma = true,
-            '.' if depth == 0 && s[i + c.len_utf8()..].starts_with('.') => {
-                has_sequence = true;
-            }
-            _ => {}
-        }
-    }
-
-    false
 }
 
 #[derive(Debug)]

--- a/src/grammar/command_acceptance.rs
+++ b/src/grammar/command_acceptance.rs
@@ -111,38 +111,27 @@ fn is_function_header_without_body(tokens: &[Token]) -> bool {
 
         // Check token immediately after header
         let next_token = non_trivia[end_idx + 1];
-        if matches!(next_token.kind, TokenKind::LParen) {
-            // Function body is a subshell `( ... )`.
-            // Check if there is a matching RParen closing this subshell.
-            let mut depth = 0;
-            for t in &non_trivia[end_idx + 1..] {
-                if matches!(t.kind, TokenKind::LParen) {
-                    depth += 1;
-                } else if matches!(t.kind, TokenKind::RParen) {
-                    depth -= 1;
-                }
-            }
-            if depth > 0 {
-                return true;
-            }
-        } else if matches!(next_token.kind, TokenKind::LBrace) {
-            // Function body is a brace block `{ ... }`.
-            // Check if there is a matching RBrace closing this function body.
-            let mut depth = 0;
-            for t in &non_trivia[end_idx + 1..] {
-                if matches!(t.kind, TokenKind::LBrace) {
-                    depth += 1;
-                } else if matches!(t.kind, TokenKind::RBrace) {
-                    depth -= 1;
-                }
-            }
-            if depth > 0 {
-                return true;
-            }
+        let body_tokens = &non_trivia[end_idx + 1..];
+        if next_token.kind == TokenKind::LParen {
+            return is_unclosed_block(body_tokens, TokenKind::LParen, TokenKind::RParen);
+        } else if next_token.kind == TokenKind::LBrace {
+            return is_unclosed_block(body_tokens, TokenKind::LBrace, TokenKind::RBrace);
         }
     }
 
     false
+}
+
+fn is_unclosed_block(tokens: &[&Token], open: TokenKind, close: TokenKind) -> bool {
+    let mut depth = 0;
+    for t in tokens {
+        if t.kind == open {
+            depth += 1;
+        } else if t.kind == close {
+            depth -= 1;
+        }
+    }
+    depth > 0
 }
 
 #[cfg(test)]

--- a/src/grammar/command_acceptance.rs
+++ b/src/grammar/command_acceptance.rs
@@ -125,6 +125,20 @@ fn is_function_header_without_body(tokens: &[Token]) -> bool {
             if depth > 0 {
                 return true;
             }
+        } else if matches!(next_token.kind, TokenKind::LBrace) {
+            // Function body is a brace block `{ ... }`.
+            // Check if there is a matching RBrace closing this function body.
+            let mut depth = 0;
+            for t in &non_trivia[end_idx + 1..] {
+                if matches!(t.kind, TokenKind::LBrace) {
+                    depth += 1;
+                } else if matches!(t.kind, TokenKind::RBrace) {
+                    depth -= 1;
+                }
+            }
+            if depth > 0 {
+                return true;
+            }
         }
     }
 
@@ -415,12 +429,21 @@ mod tests {
         assert!(will_bash_accept_buffer("echo }"));
         assert!(will_bash_accept_buffer("echo ]"));
 
-        // These are accepted by bash but are harder to analyse since they might affect
-        // nesting levels. e.g this wont be accepted: function abc {
-        // assert_eq!(will_bash_accept_buffer("echo {"), true);
-        // assert_eq!(will_bash_accept_buffer("echo ["), true);
-        // assert_eq!(will_bash_accept_buffer("echo [["), true);
-        // assert_eq!(will_bash_accept_buffer("echo {{"), true);
+        assert!(will_bash_accept_buffer("echo {"));
+        assert!(will_bash_accept_buffer("echo ./foo/{"));
+        assert!(will_bash_accept_buffer("echo {a,b"));
+        assert!(will_bash_accept_buffer("echo ["));
+        assert!(will_bash_accept_buffer("echo [x"));
+    }
+
+    #[test]
+    fn test_group_commands() {
+        assert!(!will_bash_accept_buffer("{ echo hello;"));
+        assert!(will_bash_accept_buffer("{ echo hello; }"));
+        assert!(!will_bash_accept_buffer("echo a; { echo b;"));
+        assert!(will_bash_accept_buffer("echo a; { echo b; }"));
+        assert!(!will_bash_accept_buffer("echo a && { echo b;"));
+        assert!(will_bash_accept_buffer("echo a && { echo b; }"));
     }
 
     // TODO test ones that will be syntax errors but complete commands

--- a/src/grammar/dparser.rs
+++ b/src/grammar/dparser.rs
@@ -254,6 +254,26 @@ impl DParser {
         )
     }
 
+    fn is_new_command_nesting(kind: &TokenKind) -> bool {
+        matches!(
+            kind,
+            TokenKind::CmdSubst
+                | TokenKind::Backtick
+                | TokenKind::LParen
+                | TokenKind::ProcessSubstIn
+                | TokenKind::ProcessSubstOut
+                | TokenKind::If
+                | TokenKind::Case
+                | TokenKind::For
+                | TokenKind::While
+                | TokenKind::Until
+                | TokenKind::ArithSubst
+                | TokenKind::ArithCommand
+                | TokenKind::ParamExpansion
+                | TokenKind::DoubleLBracket
+        )
+    }
+
     fn is_builtin_like_reserved_word(kind: &TokenKind) -> bool {
         matches!(
             kind,
@@ -564,10 +584,12 @@ impl DParser {
                         self.current_command_range = Some(idx..=idx);
                     } else if self.current_command_range.is_none() {
                         self.current_command_range = Some(idx..=idx);
+                    } else if let Some(range) = &mut self.current_command_range {
+                        *range = *range.start()..=idx;
                     }
                     nestings.push((idx, token.kind.clone()));
-                    command_start_stack.push(self.current_command_range.clone());
-                    if !is_lbracket_command {
+                    if Self::is_new_command_nesting(&token.kind) {
+                        command_start_stack.push(self.current_command_range.clone());
                         self.current_command_range = None; // set for next word after this
                     }
                 }
@@ -592,7 +614,7 @@ impl DParser {
                 | TokenKind::Fi
                     if Self::nested_closing_satisfied(&token, nestings.last().map(|(_, k)| k)) =>
                 {
-                    let (opening_idx, _kind) = nestings.pop().unwrap();
+                    let (opening_idx, opening_kind) = nestings.pop().unwrap();
                     let depth = nestings.len();
                     self.tokens[idx].annotations.closing = Some(ClosingAnnotation {
                         opening_idx,
@@ -627,6 +649,7 @@ impl DParser {
                         && !cursor_part_way_through_token
                         && current_command_range_contains_cursor
                         && is_nesting_before_or_at_cursor
+                        && Self::is_new_command_nesting(&opening_kind)
                     {
                         // cursor_part_way_through_token is used to handle multi closing character tokens like )) and ]]
                         // echo $((10 * 2█))      -> cursor context is: 10 * 2
@@ -635,11 +658,15 @@ impl DParser {
                         break;
                     }
 
-                    if let Some(prev_command_range) = command_start_stack.pop() {
-                        self.current_command_range = prev_command_range;
-                        if let Some(range) = &mut self.current_command_range {
-                            *range = *range.start()..=idx;
+                    if Self::is_new_command_nesting(&opening_kind) {
+                        if let Some(prev_command_range) = command_start_stack.pop() {
+                            self.current_command_range = prev_command_range;
+                            if let Some(range) = &mut self.current_command_range {
+                                *range = *range.start()..=idx;
+                            }
                         }
+                    } else if let Some(range) = &mut self.current_command_range {
+                        *range = *range.start()..=idx;
                     }
 
                     // If the restored range begins with an env-var token (e.g. the `FOO` in
@@ -940,7 +967,16 @@ impl DParser {
                         }
                     }
                 }
-                TokenKind::LBracket | TokenKind::LBrace | TokenKind::ExtGlob(_) => {
+                TokenKind::ExtGlob(_) => {
+                    let end = match &annotated.annotations.opening {
+                        Some(OpeningState::Matched(closing_idx)) => (*closing_idx + 1).min(n),
+                        _ => n,
+                    };
+                    for flag in &mut is_glob_flags[i..end] {
+                        *flag = true;
+                    }
+                }
+                TokenKind::LBracket | TokenKind::LBrace => {
                     if let Some(OpeningState::Matched(closing_idx)) = &annotated.annotations.opening
                     {
                         let mut is_glob_brace = false;
@@ -2771,5 +2807,37 @@ mod test_keyword_bracket_color {
             assert_ne!(t.annotations.command_word, Some("bar".to_string()));
             assert_ne!(t.annotations.command_word, Some("baz2".to_string()));
         }
+    }
+
+    #[test]
+    fn test_extglob_preserves_enclosing_command_range_at_cursor() {
+        let input = "ls !(foo|*bar)";
+        let bar_pos = input.find("*bar").unwrap();
+        let mut parser = DParser::from(input);
+        parser.walk_to_cursor(bar_pos);
+        let cmd_tokens = parser.get_current_command_tokens();
+
+        // Command tokens should include `ls`, not just `foo|*bar`
+        assert_eq!(cmd_tokens[0].token.value, "ls");
+        assert_eq!(
+            cmd_tokens[0].annotations.command_word,
+            Some("ls".to_string())
+        );
+    }
+
+    #[test]
+    fn test_nested_extglob_preserves_enclosing_command_range_at_cursor() {
+        let input = "echo ./target/@(foo|bar)";
+        let bar_pos = input.find("bar)").unwrap();
+        let mut parser = DParser::from(input);
+        parser.walk_to_cursor(bar_pos);
+        let cmd_tokens = parser.get_current_command_tokens();
+
+        // Command tokens should include `echo`
+        assert_eq!(cmd_tokens[0].token.value, "echo");
+        assert_eq!(
+            cmd_tokens[0].annotations.command_word,
+            Some("echo".to_string())
+        );
     }
 }

--- a/src/grammar/dparser.rs
+++ b/src/grammar/dparser.rs
@@ -958,20 +958,8 @@ impl DParser {
 
             match &annotated.token.kind {
                 TokenKind::Word(val) => {
-                    let mut escaped = false;
-                    for c in val.chars() {
-                        if escaped {
-                            escaped = false;
-                            continue;
-                        }
-                        if c == '\\' {
-                            escaped = true;
-                            continue;
-                        }
-                        if c == '*' || c == '?' {
-                            is_glob_flags[i] = true;
-                            break;
-                        }
+                    if Self::has_unescaped_wildcard(val) {
+                        is_glob_flags[i] = true;
                     }
                 }
                 TokenKind::ExtGlob(_) => {
@@ -1019,6 +1007,30 @@ impl DParser {
                 token.annotations.is_glob = true;
             }
         }
+    }
+
+    /// Returns the byte offset of the first unescaped `*` or `?` in `s`, if any.
+    pub fn first_unescaped_wildcard(s: &str) -> Option<usize> {
+        let mut escaped = false;
+        for (offset, c) in s.char_indices() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if c == '\\' {
+                escaped = true;
+                continue;
+            }
+            if c == '*' || c == '?' {
+                return Some(offset);
+            }
+        }
+        None
+    }
+
+    /// Returns `true` if `s` contains an unescaped wildcard (`*` or `?`).
+    pub fn has_unescaped_wildcard(s: &str) -> bool {
+        Self::first_unescaped_wildcard(s).is_some()
     }
 
     pub fn needs_more_input(&self) -> bool {

--- a/src/grammar/dparser.rs
+++ b/src/grammar/dparser.rs
@@ -64,6 +64,8 @@ pub struct Annotations {
     /// Nesting depth for opening and closing delimiter tokens, used for rainbow bracket
     /// colouring.  `0` is the outermost level.  `None` for non-delimiter tokens.
     pub bracket_depth: Option<usize>,
+    /// Whether this token is part of a glob expression.
+    pub is_glob: bool,
 }
 
 impl Annotations {
@@ -729,11 +731,25 @@ impl DParser {
                     }
                 }
 
+                TokenKind::Pipe => {
+                    let is_inside_extglob = nestings
+                        .last()
+                        .is_some_and(|(_, kind)| matches!(kind, TokenKind::ExtGlob(_)));
+                    if is_inside_extglob {
+                        if let Some(range) = &mut self.current_command_range {
+                            *range = *range.start()..=idx;
+                        }
+                    } else {
+                        if stop_parsing_at_command_boundary && !in_nesting_after_cursor {
+                            break;
+                        }
+                        self.current_command_range = None;
+                    }
+                }
                 // These keywords and operators introduce a new command; reset the command
                 // context so the first word after them receives the command_word annotation.
                 TokenKind::And
                 | TokenKind::Or
-                | TokenKind::Pipe
                 | TokenKind::Semicolon
                 | TokenKind::Background
                 | TokenKind::DoubleSemicolon
@@ -890,6 +906,75 @@ impl DParser {
 
         for (opening_idx, closing_idx) in updates {
             self.tokens[opening_idx].annotations.opening = Some(OpeningState::Matched(closing_idx));
+        }
+
+        self.annotate_globs();
+    }
+
+    fn annotate_globs(&mut self) {
+        let n = self.tokens.len();
+        let mut is_glob_flags = vec![false; n];
+
+        for (i, annotated) in self.tokens.iter().enumerate() {
+            if annotated.annotations.is_inside_single_quotes
+                || annotated.annotations.is_inside_double_quotes
+            {
+                continue;
+            }
+
+            match &annotated.token.kind {
+                TokenKind::Word(val) => {
+                    let mut escaped = false;
+                    for c in val.chars() {
+                        if escaped {
+                            escaped = false;
+                            continue;
+                        }
+                        if c == '\\' {
+                            escaped = true;
+                            continue;
+                        }
+                        if c == '*' || c == '?' {
+                            is_glob_flags[i] = true;
+                            break;
+                        }
+                    }
+                }
+                TokenKind::LBracket | TokenKind::LBrace | TokenKind::ExtGlob(_) => {
+                    if let Some(OpeningState::Matched(closing_idx)) = &annotated.annotations.opening
+                    {
+                        let mut is_glob_brace = false;
+                        if annotated.token.kind == TokenKind::LBrace {
+                            // check if the brace contains ',' or '..'
+                            for k in (i + 1)..*closing_idx {
+                                if let Some(token) = self.tokens.get(k) {
+                                    let val = &token.token.value;
+                                    if val.contains(',') || val.contains("..") {
+                                        is_glob_brace = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        } else {
+                            is_glob_brace = true;
+                        }
+
+                        if is_glob_brace {
+                            let end = (*closing_idx + 1).min(n);
+                            for flag in &mut is_glob_flags[i..end] {
+                                *flag = true;
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        for (token, is_glob) in self.tokens.iter_mut().zip(is_glob_flags) {
+            if is_glob {
+                token.annotations.is_glob = true;
+            }
         }
     }
 
@@ -2638,6 +2723,53 @@ mod test_keyword_bracket_color {
             ) {
                 assert_eq!(token.annotations.bracket_depth, None);
             }
+        }
+    }
+
+    #[test]
+    fn test_glob_annotations_wildcards_and_braces() {
+        let mut parser = DParser::from("echo *.txt ./foo/{a,b} bar[0-9]");
+        parser.walk_to_end();
+        let tokens = parser.tokens();
+
+        // echo
+        assert_eq!(tokens[0].annotations.is_glob, false);
+        // *.txt
+        assert_eq!(tokens[2].annotations.is_glob, true);
+        // ./foo/
+        assert_eq!(tokens[4].annotations.is_glob, false);
+        // {
+        assert_eq!(tokens[5].annotations.is_glob, true);
+        // a,b
+        assert_eq!(tokens[6].annotations.is_glob, true);
+        // }
+        assert_eq!(tokens[7].annotations.is_glob, true);
+        // bar
+        assert_eq!(tokens[9].annotations.is_glob, false);
+        // [
+        assert_eq!(tokens[10].annotations.is_glob, true);
+        // 0-9
+        assert_eq!(tokens[11].annotations.is_glob, true);
+        // ]
+        assert_eq!(tokens[12].annotations.is_glob, true);
+    }
+
+    #[test]
+    fn test_glob_annotations_nested_extglobs() {
+        let mut parser = DParser::from("ls @(foo|bar|!(baz1|baz2))");
+        parser.walk_to_end();
+        let tokens = parser.tokens();
+
+        // ls
+        assert_eq!(tokens[0].annotations.is_glob, false);
+        assert_eq!(tokens[0].annotations.command_word, Some("ls".to_string()));
+
+        // All tokens inside @(...) should be marked is_glob = true
+        for t in &tokens[2..] {
+            assert_eq!(t.annotations.is_glob, true);
+            // '|' inside extglob should not create spurious command_word annotations
+            assert_ne!(t.annotations.command_word, Some("bar".to_string()));
+            assert_ne!(t.annotations.command_word, Some("baz2".to_string()));
         }
     }
 }

--- a/src/grammar/dparser.rs
+++ b/src/grammar/dparser.rs
@@ -576,9 +576,12 @@ impl DParser {
                         self.tokens[idx].annotations.bracket_depth = Some(depth);
                     }
 
+                    let is_command_position = self.current_command_range.is_none();
                     let is_lbracket_command =
-                        token.kind == TokenKind::LBracket && self.current_command_range.is_none();
-                    if is_lbracket_command {
+                        token.kind == TokenKind::LBracket && is_command_position;
+                    let is_lbrace_command = token.kind == TokenKind::LBrace && is_command_position;
+
+                    if is_lbracket_command || is_lbrace_command {
                         self.tokens[idx].annotations.command_word =
                             Some(self.tokens[idx].token.value.clone());
                         self.current_command_range = Some(idx..=idx);
@@ -588,7 +591,7 @@ impl DParser {
                         *range = *range.start()..=idx;
                     }
                     nestings.push((idx, token.kind.clone()));
-                    if Self::is_new_command_nesting(&token.kind) {
+                    if Self::is_new_command_nesting(&token.kind) || is_lbrace_command {
                         command_start_stack.push(self.current_command_range.clone());
                         self.current_command_range = None; // set for next word after this
                     }
@@ -645,11 +648,15 @@ impl DParser {
 
                     let is_nesting_before_or_at_cursor =
                         cursor_token_idx.is_none_or(|c_idx| opening_idx <= c_idx);
+                    let is_scope_isolating_nesting = Self::is_new_command_nesting(&opening_kind)
+                        || (opening_kind == TokenKind::LBrace
+                            && self.tokens[opening_idx].annotations.command_word.is_some());
+
                     if stop_parsing_at_command_boundary
                         && !cursor_part_way_through_token
                         && current_command_range_contains_cursor
                         && is_nesting_before_or_at_cursor
-                        && Self::is_new_command_nesting(&opening_kind)
+                        && is_scope_isolating_nesting
                     {
                         // cursor_part_way_through_token is used to handle multi closing character tokens like )) and ]]
                         // echo $((10 * 2█))      -> cursor context is: 10 * 2
@@ -658,7 +665,7 @@ impl DParser {
                         break;
                     }
 
-                    if Self::is_new_command_nesting(&opening_kind) {
+                    if is_scope_isolating_nesting {
                         if let Some(prev_command_range) = command_start_stack.pop() {
                             self.current_command_range = prev_command_range;
                             if let Some(range) = &mut self.current_command_range {
@@ -1016,8 +1023,17 @@ impl DParser {
 
     pub fn needs_more_input(&self) -> bool {
         self.tokens.iter().any(|t| {
-            t.annotations.opening == Some(OpeningState::Unmatched)
-                && t.token.kind != TokenKind::LBracket
+            if t.annotations.opening != Some(OpeningState::Unmatched) {
+                return false;
+            }
+            if t.token.kind == TokenKind::LBracket {
+                return false;
+            }
+            if t.token.kind == TokenKind::LBrace && t.annotations.command_word.is_none() {
+                // Argument-level brace (e.g. `echo {`, `echo ./foo/{`) does not require closing `}` in bash
+                return false;
+            }
+            true
         })
     }
 


### PR DESCRIPTION
This emits { and } as individual tokens instead of merging them as part of a word so that auto close works.
This centralizes the globbing pattern parsing logic.