### PR TITLE
make inline history metadata optional

### DIFF
--- a/src/app/ui.rs
+++ b/src/app/ui.rs
@@ -862,17 +862,20 @@ impl App<'_> {
                     ));
 
                     if is_last {
-                        let mut extra_info_text = format!(" #idx={}", sug.index);
-                        if let Some(ts) = sug.timestamp {
-                            let time_ago_str = ts.format_timeago_5chars();
-                            extra_info_text.push_str(&format!(" {}", time_ago_str.trim_start()));
-                        }
+                        if crate::settings().show_inline_history_metadata {
+                            let mut extra_info_text = format!(" #idx={}", sug.index);
+                            if let Some(ts) = sug.timestamp {
+                                let time_ago_str = ts.format_timeago_5chars();
+                                extra_info_text
+                                    .push_str(&format!(" {}", time_ago_str.trim_start()));
+                            }
 
-                        content.write_tagged_span_dont_overwrite(&TaggedSpan::new(
-                            Span::from(extra_info_text)
-                                .style(crate::settings().colour_palette.inline_suggestion()),
-                            Tag::HistorySuggestion,
-                        ));
+                            content.write_tagged_span_dont_overwrite(&TaggedSpan::new(
+                                Span::from(extra_info_text)
+                                    .style(crate::settings().colour_palette.inline_suggestion()),
+                                Tag::HistorySuggestion,
+                            ));
+                        }
 
                         if crate::settings().run_tutorial {
                             content.write_tagged_span_dont_overwrite(&TaggedSpan::new(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -568,6 +568,9 @@ enum Commands {
         /// Show inline history suggestions.
         #[arg(long = "show-inline-history", default_missing_value = "true", num_args = 0..=1)]
         show_inline_history: Option<bool>,
+        /// Show metadata (index and timestamp) for inline history suggestions.
+        #[arg(long = "show-inline-history-metadata", default_missing_value = "true", num_args = 0..=1)]
+        show_inline_history_metadata: Option<bool>,
         /// Whether mouse clicks and drags on the command buffer change the
         /// cursor position and selection. Default is `true`. When `false`,
         /// mouse interaction with the buffer does not change the selection.
@@ -1484,6 +1487,7 @@ pub(crate) fn call(words: *const bash_symbols::WordList) -> c_int {
                 Some(Commands::Editor {
                     auto_close_chars,
                     show_inline_history,
+                    show_inline_history_metadata,
                     select_with_mouse,
                 }) => {
                     if let Some(enabled) = auto_close_chars {
@@ -1493,6 +1497,10 @@ pub(crate) fn call(words: *const bash_symbols::WordList) -> c_int {
                     if let Some(enabled) = show_inline_history {
                         log::info!("Inline history suggestions set to {}", enabled);
                         settings.show_inline_history = enabled;
+                    }
+                    if let Some(enabled) = show_inline_history_metadata {
+                        log::info!("Inline history metadata set to {}", enabled);
+                        settings.show_inline_history_metadata = enabled;
                     }
                     if let Some(enabled) = select_with_mouse {
                         log::info!("Select with mouse set to {}", enabled);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -294,6 +294,8 @@ pub struct Settings {
     pub show_animations: bool,
     /// Whether to show inline history suggestions.
     pub show_inline_history: bool,
+    /// Whether to show metadata (index and timestamp) for inline history suggestions.
+    pub show_inline_history_metadata: bool,
     /// Whether to auto-start tab completion suggestions as you type.
     pub auto_suggest: bool,
     /// Whether to show last modification timestamps for Git references (branches, tags, stashes).
@@ -401,6 +403,7 @@ impl Default for Settings {
             fuzzy_mode: FuzzyMode::default(),
             num_suggestion_rows: 12,
             show_inline_history: true,
+            show_inline_history_metadata: true,
             auto_close_chars: true,
             select_with_mouse: true,
             cursor_config: CursorConfig::default(),


### PR DESCRIPTION
The pr allows user to turn off inline history metadata (index and timestamp)

<img width="1920" height="1080" alt="2026-09-01_08-09-1788224014" src="https://github.com/user-attachments/assets/5bb1acb8-dd42-408a-90e4-e3f12228b249" />

Closes #964