### PR TITLE
ignore new bash-completion _comp_complete_minimal fallback

### DIFF
--- a/src/shell/bash/funcs.rs
+++ b/src/shell/bash/funcs.rs
@@ -493,7 +493,9 @@ pub fn useful_compspec_ran(command_word: &str) -> bool {
                 command_word,
                 funcname_str
             );
-            if funcname_str == "_minimal" || funcname_str == "_completion_loader"
+            if funcname_str == "_minimal"
+                || funcname_str == "_comp_complete_minimal"
+                || funcname_str == "_completion_loader"
             // || funcname_str == "_longopt"
             {
                 return false;


### PR DESCRIPTION
In the latest bash-completion version 2.18.0

Around line 3386 in bash completion:
```
    # Minimal completion to use as fallback in _comp_complete_load.
    # TODO:API: rename per conventions
    _comp_complete_minimal()
    {
        local cur prev words cword comp_args
        _comp_initialize -- "$@" || return
        compopt -o bashdefault -o default
    }
```

The fallback `_minimal` was changed to `_comp_complete_minimal`, this causes flycomp to not pop up. This pr should fix that.

Before:
<img width="1236" height="477" alt="2026-09-01_11-09-1788234721" src="https://github.com/user-attachments/assets/7802afbf-6a12-4f0c-a880-29ba0dbce756" />

After:
<img width="1642" height="229" alt="2026-09-01_11-09-1788234707" src="https://github.com/user-attachments/assets/97b13169-410e-4f3c-9500-fb7ab5fadcd2" />
